### PR TITLE
Cleanup

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,7 +10,7 @@
     <CopyRetryCount>2</CopyRetryCount>
     <CopyRetryDelayMilliseconds>500</CopyRetryDelayMilliseconds>
 
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>11</LangVersion>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <DebugType>portable</DebugType>
     <WarningsAsErrors>CS0108,CS0109,CS0114,CS0162,CS0251,CS0659,CS0660,CS1717,CS1718</WarningsAsErrors>

--- a/src/CSharpFastPFOR.Benchmarks/CSharpFastPFOR.Benchmarks.csproj
+++ b/src/CSharpFastPFOR.Benchmarks/CSharpFastPFOR.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/CSharpFastPFOR.Tests/CSharpFastPFOR.Tests.csproj
+++ b/src/CSharpFastPFOR.Tests/CSharpFastPFOR.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/CSharpFastPFOR/BinaryPacking.cs
+++ b/src/CSharpFastPFOR/BinaryPacking.cs
@@ -37,7 +37,7 @@
 
 namespace Genbox.CSharpFastPFOR;
 
-public class BinaryPacking : IntegerCODEC, SkippableIntegerCODEC
+public sealed class BinaryPacking : IntegerCODEC, SkippableIntegerCODEC
 {
     private const int BLOCK_SIZE = 32;
 

--- a/src/CSharpFastPFOR/BinaryPacking.cs
+++ b/src/CSharpFastPFOR/BinaryPacking.cs
@@ -35,120 +35,119 @@
  * @author Daniel Lemire
  */
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class BinaryPacking : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class BinaryPacking : IntegerCODEC, SkippableIntegerCODEC
+    private const int BLOCK_SIZE = 32;
+
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
     {
-        private const int BLOCK_SIZE = 32;
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
-
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            int tmpoutpos = outpos.get();
-            int s = inpos.get();
-            for (; s + BLOCK_SIZE * 4 - 1 < inpos.get() + inlength; s += BLOCK_SIZE * 4)
-            {
-
-                int mbits1 = Util.maxbits(@in, s, BLOCK_SIZE);
-
-                int mbits2 = Util.maxbits(@in, s + BLOCK_SIZE, BLOCK_SIZE);
-
-                int mbits3 = Util.maxbits(@in, s + 2 * BLOCK_SIZE, BLOCK_SIZE);
-
-                int mbits4 = Util.maxbits(@in, s + 3 * BLOCK_SIZE, BLOCK_SIZE);
-                @out[tmpoutpos++] = (mbits1 << 24) | (mbits2 << 16)
-                                    | (mbits3 << 8) | (mbits4);
-                BitPacking.fastpackwithoutmask(@in, s, @out, tmpoutpos,
-                    mbits1);
-                tmpoutpos += mbits1;
-                BitPacking.fastpackwithoutmask(@in, s + BLOCK_SIZE, @out,
-                    tmpoutpos, mbits2);
-                tmpoutpos += mbits2;
-                BitPacking.fastpackwithoutmask(@in, s + 2 * BLOCK_SIZE, @out,
-                    tmpoutpos, mbits3);
-                tmpoutpos += mbits3;
-                BitPacking.fastpackwithoutmask(@in, s + 3 * BLOCK_SIZE, @out,
-                    tmpoutpos, mbits4);
-                tmpoutpos += mbits4;
-            }
-            for (; s < inpos.get() + inlength; s += BLOCK_SIZE)
-            {
-
-                int mbits = Util.maxbits(@in, s, BLOCK_SIZE);
-                @out[tmpoutpos++] = mbits;
-                BitPacking.fastpackwithoutmask(@in, s, @out, tmpoutpos,
-                    mbits);
-                tmpoutpos += mbits;
-
-            }
-            inpos.add(inlength);
-            outpos.set(tmpoutpos);
-        }
-
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
-        }
-
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num)
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        int tmpoutpos = outpos.get();
+        int s = inpos.get();
+        for (; s + BLOCK_SIZE * 4 - 1 < inpos.get() + inlength; s += BLOCK_SIZE * 4)
         {
 
-            int outlength = Util.greatestMultiple(num, BLOCK_SIZE);
-            int tmpinpos = inpos.get();
-            int s = outpos.get();
-            for (; s + BLOCK_SIZE * 4 - 1 < outpos.get() + outlength; s += BLOCK_SIZE * 4)
-            {
+            int mbits1 = Util.maxbits(@in, s, BLOCK_SIZE);
 
-                int mbits1 = (int)((uint)@in[tmpinpos] >> 24);
+            int mbits2 = Util.maxbits(@in, s + BLOCK_SIZE, BLOCK_SIZE);
 
-                int mbits2 = (int)((uint)@in[tmpinpos] >> 16) & 0xFF;
+            int mbits3 = Util.maxbits(@in, s + 2 * BLOCK_SIZE, BLOCK_SIZE);
 
-                int mbits3 = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
-
-                int mbits4 = (int)((uint)@in[tmpinpos]) & 0xFF;
-                ++tmpinpos;
-                BitPacking.fastunpack(@in, tmpinpos, @out, s, mbits1);
-                tmpinpos += mbits1;
-                BitPacking
-                    .fastunpack(@in, tmpinpos, @out, s + BLOCK_SIZE, mbits2);
-                tmpinpos += mbits2;
-                BitPacking.fastunpack(@in, tmpinpos, @out, s + 2 * BLOCK_SIZE,
-                    mbits3);
-                tmpinpos += mbits3;
-                BitPacking.fastunpack(@in, tmpinpos, @out, s + 3 * BLOCK_SIZE,
-                    mbits4);
-                tmpinpos += mbits4;
-            }
-            for (; s < outpos.get() + outlength; s += BLOCK_SIZE)
-            {
-
-                int mbits = @in[tmpinpos];
-                ++tmpinpos;
-                BitPacking.fastunpack(@in, tmpinpos, @out, s, mbits);
-                tmpinpos += mbits;
-            }
-            outpos.add(outlength);
-            inpos.set(tmpinpos);
+            int mbits4 = Util.maxbits(@in, s + 3 * BLOCK_SIZE, BLOCK_SIZE);
+            @out[tmpoutpos++] = (mbits1 << 24) | (mbits2 << 16)
+                                | (mbits3 << 8) | (mbits4);
+            BitPacking.fastpackwithoutmask(@in, s, @out, tmpoutpos,
+                mbits1);
+            tmpoutpos += mbits1;
+            BitPacking.fastpackwithoutmask(@in, s + BLOCK_SIZE, @out,
+                tmpoutpos, mbits2);
+            tmpoutpos += mbits2;
+            BitPacking.fastpackwithoutmask(@in, s + 2 * BLOCK_SIZE, @out,
+                tmpoutpos, mbits3);
+            tmpoutpos += mbits3;
+            BitPacking.fastpackwithoutmask(@in, s + 3 * BLOCK_SIZE, @out,
+                tmpoutpos, mbits4);
+            tmpoutpos += mbits4;
         }
-
-        public override string ToString()
+        for (; s < inpos.get() + inlength; s += BLOCK_SIZE)
         {
-            return nameof(BinaryPacking);
+
+            int mbits = Util.maxbits(@in, s, BLOCK_SIZE);
+            @out[tmpoutpos++] = mbits;
+            BitPacking.fastpackwithoutmask(@in, s, @out, tmpoutpos,
+                mbits);
+            tmpoutpos += mbits;
+
         }
+        inpos.add(inlength);
+        outpos.set(tmpoutpos);
+    }
+
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
+    }
+
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num)
+    {
+
+        int outlength = Util.greatestMultiple(num, BLOCK_SIZE);
+        int tmpinpos = inpos.get();
+        int s = outpos.get();
+        for (; s + BLOCK_SIZE * 4 - 1 < outpos.get() + outlength; s += BLOCK_SIZE * 4)
+        {
+
+            int mbits1 = (int)((uint)@in[tmpinpos] >> 24);
+
+            int mbits2 = (int)((uint)@in[tmpinpos] >> 16) & 0xFF;
+
+            int mbits3 = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
+
+            int mbits4 = (int)((uint)@in[tmpinpos]) & 0xFF;
+            ++tmpinpos;
+            BitPacking.fastunpack(@in, tmpinpos, @out, s, mbits1);
+            tmpinpos += mbits1;
+            BitPacking
+                .fastunpack(@in, tmpinpos, @out, s + BLOCK_SIZE, mbits2);
+            tmpinpos += mbits2;
+            BitPacking.fastunpack(@in, tmpinpos, @out, s + 2 * BLOCK_SIZE,
+                mbits3);
+            tmpinpos += mbits3;
+            BitPacking.fastunpack(@in, tmpinpos, @out, s + 3 * BLOCK_SIZE,
+                mbits4);
+            tmpinpos += mbits4;
+        }
+        for (; s < outpos.get() + outlength; s += BLOCK_SIZE)
+        {
+
+            int mbits = @in[tmpinpos];
+            ++tmpinpos;
+            BitPacking.fastunpack(@in, tmpinpos, @out, s, mbits);
+            tmpinpos += mbits;
+        }
+        outpos.add(outlength);
+        inpos.set(tmpinpos);
+    }
+
+    public override string ToString()
+    {
+        return nameof(BinaryPacking);
     }
 }

--- a/src/CSharpFastPFOR/BitPacking.cs
+++ b/src/CSharpFastPFOR/BitPacking.cs
@@ -23,4655 +23,4654 @@
 using System;
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class BitPacking
 {
-    public class BitPacking
+
+    /**
+     * Pack 32 integers
+     * 
+     * @param in
+     *                source array
+     * @param inpos
+     *                position in source array
+     * @param out
+     *                output array
+     * @param outpos
+     *                position in output array
+     * @param bit
+     *                number of bits to use per integer
+     */
+    public static void fastpack(int[] @in, int inpos, int[] @out, int outpos, int bit)
     {
-
-        /**
-         * Pack 32 integers
-         * 
-         * @param in
-         *                source array
-         * @param inpos
-         *                position in source array
-         * @param out
-         *                output array
-         * @param outpos
-         *                position in output array
-         * @param bit
-         *                number of bits to use per integer
-         */
-        public static void fastpack(int[] @in, int inpos, int[] @out, int outpos, int bit)
-        {
-            switch (bit)
-            {
-                case 0:
-                    fastpack0(@in, inpos, @out, outpos);
-                    break;
-                case 1:
-                    fastpack1(@in, inpos, @out, outpos);
-                    break;
-                case 2:
-                    fastpack2(@in, inpos, @out, outpos);
-                    break;
-                case 3:
-                    fastpack3(@in, inpos, @out, outpos);
-                    break;
-                case 4:
-                    fastpack4(@in, inpos, @out, outpos);
-                    break;
-                case 5:
-                    fastpack5(@in, inpos, @out, outpos);
-                    break;
-                case 6:
-                    fastpack6(@in, inpos, @out, outpos);
-                    break;
-                case 7:
-                    fastpack7(@in, inpos, @out, outpos);
-                    break;
-                case 8:
-                    fastpack8(@in, inpos, @out, outpos);
-                    break;
-                case 9:
-                    fastpack9(@in, inpos, @out, outpos);
-                    break;
-                case 10:
-                    fastpack10(@in, inpos, @out, outpos);
-                    break;
-                case 11:
-                    fastpack11(@in, inpos, @out, outpos);
-                    break;
-                case 12:
-                    fastpack12(@in, inpos, @out, outpos);
-                    break;
-                case 13:
-                    fastpack13(@in, inpos, @out, outpos);
-                    break;
-                case 14:
-                    fastpack14(@in, inpos, @out, outpos);
-                    break;
-                case 15:
-                    fastpack15(@in, inpos, @out, outpos);
-                    break;
-                case 16:
-                    fastpack16(@in, inpos, @out, outpos);
-                    break;
-                case 17:
-                    fastpack17(@in, inpos, @out, outpos);
-                    break;
-                case 18:
-                    fastpack18(@in, inpos, @out, outpos);
-                    break;
-                case 19:
-                    fastpack19(@in, inpos, @out, outpos);
-                    break;
-                case 20:
-                    fastpack20(@in, inpos, @out, outpos);
-                    break;
-                case 21:
-                    fastpack21(@in, inpos, @out, outpos);
-                    break;
-                case 22:
-                    fastpack22(@in, inpos, @out, outpos);
-                    break;
-                case 23:
-                    fastpack23(@in, inpos, @out, outpos);
-                    break;
-                case 24:
-                    fastpack24(@in, inpos, @out, outpos);
-                    break;
-                case 25:
-                    fastpack25(@in, inpos, @out, outpos);
-                    break;
-                case 26:
-                    fastpack26(@in, inpos, @out, outpos);
-                    break;
-                case 27:
-                    fastpack27(@in, inpos, @out, outpos);
-                    break;
-                case 28:
-                    fastpack28(@in, inpos, @out, outpos);
-                    break;
-                case 29:
-                    fastpack29(@in, inpos, @out, outpos);
-                    break;
-                case 30:
-                    fastpack30(@in, inpos, @out, outpos);
-                    break;
-                case 31:
-                    fastpack31(@in, inpos, @out, outpos);
-                    break;
-                case 32:
-                    fastpack32(@in, inpos, @out, outpos);
-                    break;
-                default:
-                    throw new ArgumentException("Unsupported bit width.");
-            }
-        }
-
-        protected static void fastpack0(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            // nothing
-        }
-
-        protected static void fastpack1(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 1)
-                               | ((@in[1 + inpos] & 1) << 1)
-                               | ((@in[2 + inpos] & 1) << 2)
-                               | ((@in[3 + inpos] & 1) << 3)
-                               | ((@in[4 + inpos] & 1) << 4)
-                               | ((@in[5 + inpos] & 1) << 5)
-                               | ((@in[6 + inpos] & 1) << 6)
-                               | ((@in[7 + inpos] & 1) << 7)
-                               | ((@in[8 + inpos] & 1) << 8)
-                               | ((@in[9 + inpos] & 1) << 9)
-                               | ((@in[10 + inpos] & 1) << 10)
-                               | ((@in[11 + inpos] & 1) << 11)
-                               | ((@in[12 + inpos] & 1) << 12)
-                               | ((@in[13 + inpos] & 1) << 13)
-                               | ((@in[14 + inpos] & 1) << 14)
-                               | ((@in[15 + inpos] & 1) << 15)
-                               | ((@in[16 + inpos] & 1) << 16)
-                               | ((@in[17 + inpos] & 1) << 17)
-                               | ((@in[18 + inpos] & 1) << 18)
-                               | ((@in[19 + inpos] & 1) << 19)
-                               | ((@in[20 + inpos] & 1) << 20)
-                               | ((@in[21 + inpos] & 1) << 21)
-                               | ((@in[22 + inpos] & 1) << 22)
-                               | ((@in[23 + inpos] & 1) << 23)
-                               | ((@in[24 + inpos] & 1) << 24)
-                               | ((@in[25 + inpos] & 1) << 25)
-                               | ((@in[26 + inpos] & 1) << 26)
-                               | ((@in[27 + inpos] & 1) << 27)
-                               | ((@in[28 + inpos] & 1) << 28)
-                               | ((@in[29 + inpos] & 1) << 29)
-                               | ((@in[30 + inpos] & 1) << 30)
-                               | ((@in[31 + inpos]) << 31);
-        }
-
-        protected static void fastpack10(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 1023)
-                               | ((@in[1 + inpos] & 1023) << 10)
-                               | ((@in[2 + inpos] & 1023) << 20)
-                               | ((@in[3 + inpos]) << 30);
-            @out[1 + outpos] = (int)(((uint)@in[3 + inpos] & 1023) >> (10 - 8))
-                               | ((@in[4 + inpos] & 1023) << 8)
-                               | ((@in[5 + inpos] & 1023) << 18)
-                               | ((@in[6 + inpos]) << 28);
-            @out[2 + outpos] = (int)(((uint)@in[6 + inpos] & 1023) >> (10 - 6))
-                               | ((@in[7 + inpos] & 1023) << 6)
-                               | ((@in[8 + inpos] & 1023) << 16)
-                               | ((@in[9 + inpos]) << 26);
-            @out[3 + outpos] = (int)(((uint)@in[9 + inpos] & 1023) >> (10 - 4))
-                               | ((@in[10 + inpos] & 1023) << 4)
-                               | ((@in[11 + inpos] & 1023) << 14)
-                               | ((@in[12 + inpos]) << 24);
-            @out[4 + outpos] = (int)(((uint)@in[12 + inpos] & 1023) >> (10 - 2))
-                               | ((@in[13 + inpos] & 1023) << 2)
-                               | ((@in[14 + inpos] & 1023) << 12)
-                               | ((@in[15 + inpos]) << 22);
-            @out[5 + outpos] = (@in[16 + inpos] & 1023)
-                               | ((@in[17 + inpos] & 1023) << 10)
-                               | ((@in[18 + inpos] & 1023) << 20)
-                               | ((@in[19 + inpos]) << 30);
-            @out[6 + outpos] = (int)(((uint)@in[19 + inpos] & 1023) >> (10 - 8))
-                               | ((@in[20 + inpos] & 1023) << 8)
-                               | ((@in[21 + inpos] & 1023) << 18)
-                               | ((@in[22 + inpos]) << 28);
-            @out[7 + outpos] = (int)(((uint)@in[22 + inpos] & 1023) >> (10 - 6))
-                               | ((@in[23 + inpos] & 1023) << 6)
-                               | ((@in[24 + inpos] & 1023) << 16)
-                               | ((@in[25 + inpos]) << 26);
-            @out[8 + outpos] = (int)(((uint)@in[25 + inpos] & 1023) >> (10 - 4))
-                               | ((@in[26 + inpos] & 1023) << 4)
-                               | ((@in[27 + inpos] & 1023) << 14)
-                               | ((@in[28 + inpos]) << 24);
-            @out[9 + outpos] = (int)(((uint)@in[28 + inpos] & 1023) >> (10 - 2))
-                               | ((@in[29 + inpos] & 1023) << 2)
-                               | ((@in[30 + inpos] & 1023) << 12)
-                               | ((@in[31 + inpos]) << 22);
-        }
-
-        protected static void fastpack11(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 2047)
-                               | ((@in[1 + inpos] & 2047) << 11)
-                               | ((@in[2 + inpos]) << 22);
-            @out[1 + outpos] = (int)(((uint)@in[2 + inpos] & 2047) >> (11 - 1))
-                               | ((@in[3 + inpos] & 2047) << 1)
-                               | ((@in[4 + inpos] & 2047) << 12)
-                               | ((@in[5 + inpos]) << 23);
-            @out[2 + outpos] = (int)(((uint)@in[5 + inpos] & 2047) >> (11 - 2))
-                               | ((@in[6 + inpos] & 2047) << 2)
-                               | ((@in[7 + inpos] & 2047) << 13)
-                               | ((@in[8 + inpos]) << 24);
-            @out[3 + outpos] = (int)(((uint)@in[8 + inpos] & 2047) >> (11 - 3))
-                               | ((@in[9 + inpos] & 2047) << 3)
-                               | ((@in[10 + inpos] & 2047) << 14)
-                               | ((@in[11 + inpos]) << 25);
-            @out[4 + outpos] = (int)(((uint)@in[11 + inpos] & 2047) >> (11 - 4))
-                               | ((@in[12 + inpos] & 2047) << 4)
-                               | ((@in[13 + inpos] & 2047) << 15)
-                               | ((@in[14 + inpos]) << 26);
-            @out[5 + outpos] = (int)(((uint)@in[14 + inpos] & 2047) >> (11 - 5))
-                               | ((@in[15 + inpos] & 2047) << 5)
-                               | ((@in[16 + inpos] & 2047) << 16)
-                               | ((@in[17 + inpos]) << 27);
-            @out[6 + outpos] = (int)(((uint)@in[17 + inpos] & 2047) >> (11 - 6))
-                               | ((@in[18 + inpos] & 2047) << 6)
-                               | ((@in[19 + inpos] & 2047) << 17)
-                               | ((@in[20 + inpos]) << 28);
-            @out[7 + outpos] = (int)(((uint)@in[20 + inpos] & 2047) >> (11 - 7))
-                               | ((@in[21 + inpos] & 2047) << 7)
-                               | ((@in[22 + inpos] & 2047) << 18)
-                               | ((@in[23 + inpos]) << 29);
-            @out[8 + outpos] = (int)(((uint)@in[23 + inpos] & 2047) >> (11 - 8))
-                               | ((@in[24 + inpos] & 2047) << 8)
-                               | ((@in[25 + inpos] & 2047) << 19)
-                               | ((@in[26 + inpos]) << 30);
-            @out[9 + outpos] = (int)(((uint)@in[26 + inpos] & 2047) >> (11 - 9))
-                               | ((@in[27 + inpos] & 2047) << 9)
-                               | ((@in[28 + inpos] & 2047) << 20)
-                               | ((@in[29 + inpos]) << 31);
-            @out[10 + outpos] = (int)(((uint)@in[29 + inpos] & 2047) >> (11 - 10))
-                                | ((@in[30 + inpos] & 2047) << 10)
-                                | ((@in[31 + inpos]) << 21);
-        }
-
-        protected static void fastpack12(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 4095)
-                               | ((@in[1 + inpos] & 4095) << 12)
-                               | ((@in[2 + inpos]) << 24);
-            @out[1 + outpos] = (int)(((uint)@in[2 + inpos] & 4095) >> (12 - 4))
-                               | ((@in[3 + inpos] & 4095) << 4)
-                               | ((@in[4 + inpos] & 4095) << 16)
-                               | ((@in[5 + inpos]) << 28);
-            @out[2 + outpos] = (int)(((uint)@in[5 + inpos] & 4095) >> (12 - 8))
-                               | ((@in[6 + inpos] & 4095) << 8)
-                               | ((@in[7 + inpos]) << 20);
-            @out[3 + outpos] = (@in[8 + inpos] & 4095)
-                               | ((@in[9 + inpos] & 4095) << 12)
-                               | ((@in[10 + inpos]) << 24);
-            @out[4 + outpos] = (int)(((uint)@in[10 + inpos] & 4095) >> (12 - 4))
-                               | ((@in[11 + inpos] & 4095) << 4)
-                               | ((@in[12 + inpos] & 4095) << 16)
-                               | ((@in[13 + inpos]) << 28);
-            @out[5 + outpos] = (int)(((uint)@in[13 + inpos] & 4095) >> (12 - 8))
-                               | ((@in[14 + inpos] & 4095) << 8)
-                               | ((@in[15 + inpos]) << 20);
-            @out[6 + outpos] = (@in[16 + inpos] & 4095)
-                               | ((@in[17 + inpos] & 4095) << 12)
-                               | ((@in[18 + inpos]) << 24);
-            @out[7 + outpos] = (int)(((uint)@in[18 + inpos] & 4095) >> (12 - 4))
-                               | ((@in[19 + inpos] & 4095) << 4)
-                               | ((@in[20 + inpos] & 4095) << 16)
-                               | ((@in[21 + inpos]) << 28);
-            @out[8 + outpos] = (int)(((uint)@in[21 + inpos] & 4095) >> (12 - 8))
-                               | ((@in[22 + inpos] & 4095) << 8)
-                               | ((@in[23 + inpos]) << 20);
-            @out[9 + outpos] = (@in[24 + inpos] & 4095)
-                               | ((@in[25 + inpos] & 4095) << 12)
-                               | ((@in[26 + inpos]) << 24);
-            @out[10 + outpos] = (int)(((uint)@in[26 + inpos] & 4095) >> (12 - 4))
-                                | ((@in[27 + inpos] & 4095) << 4)
-                                | ((@in[28 + inpos] & 4095) << 16)
-                                | ((@in[29 + inpos]) << 28);
-            @out[11 + outpos] = (int)(((uint)@in[29 + inpos] & 4095) >> (12 - 8))
-                                | ((@in[30 + inpos] & 4095) << 8)
-                                | ((@in[31 + inpos]) << 20);
-        }
-
-        protected static void fastpack13(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 8191)
-                               | ((@in[1 + inpos] & 8191) << 13)
-                               | ((@in[2 + inpos]) << 26);
-            @out[1 + outpos] = (int)(((uint)@in[2 + inpos] & 8191) >> (13 - 7))
-                               | ((@in[3 + inpos] & 8191) << 7)
-                               | ((@in[4 + inpos]) << 20);
-            @out[2 + outpos] = (int)(((uint)@in[4 + inpos] & 8191) >> (13 - 1))
-                               | ((@in[5 + inpos] & 8191) << 1)
-                               | ((@in[6 + inpos] & 8191) << 14)
-                               | ((@in[7 + inpos]) << 27);
-            @out[3 + outpos] = (int)(((uint)@in[7 + inpos] & 8191) >> (13 - 8))
-                               | ((@in[8 + inpos] & 8191) << 8)
-                               | ((@in[9 + inpos]) << 21);
-            @out[4 + outpos] = (int)(((uint)@in[9 + inpos] & 8191) >> (13 - 2))
-                               | ((@in[10 + inpos] & 8191) << 2)
-                               | ((@in[11 + inpos] & 8191) << 15)
-                               | ((@in[12 + inpos]) << 28);
-            @out[5 + outpos] = (int)(((uint)@in[12 + inpos] & 8191) >> (13 - 9))
-                               | ((@in[13 + inpos] & 8191) << 9)
-                               | ((@in[14 + inpos]) << 22);
-            @out[6 + outpos] = (int)(((uint)@in[14 + inpos] & 8191) >> (13 - 3))
-                               | ((@in[15 + inpos] & 8191) << 3)
-                               | ((@in[16 + inpos] & 8191) << 16)
-                               | ((@in[17 + inpos]) << 29);
-            @out[7 + outpos] = (int)(((uint)@in[17 + inpos] & 8191) >> (13 - 10))
-                               | ((@in[18 + inpos] & 8191) << 10)
-                               | ((@in[19 + inpos]) << 23);
-            @out[8 + outpos] = (int)(((uint)@in[19 + inpos] & 8191) >> (13 - 4))
-                               | ((@in[20 + inpos] & 8191) << 4)
-                               | ((@in[21 + inpos] & 8191) << 17)
-                               | ((@in[22 + inpos]) << 30);
-            @out[9 + outpos] = (int)(((uint)@in[22 + inpos] & 8191) >> (13 - 11))
-                               | ((@in[23 + inpos] & 8191) << 11)
-                               | ((@in[24 + inpos]) << 24);
-            @out[10 + outpos] = (int)(((uint)@in[24 + inpos] & 8191) >> (13 - 5))
-                                | ((@in[25 + inpos] & 8191) << 5)
-                                | ((@in[26 + inpos] & 8191) << 18)
-                                | ((@in[27 + inpos]) << 31);
-            @out[11 + outpos] = (int)(((uint)@in[27 + inpos] & 8191) >> (13 - 12))
-                                | ((@in[28 + inpos] & 8191) << 12)
-                                | ((@in[29 + inpos]) << 25);
-            @out[12 + outpos] = (int)(((uint)@in[29 + inpos] & 8191) >> (13 - 6))
-                                | ((@in[30 + inpos] & 8191) << 6)
-                                | ((@in[31 + inpos]) << 19);
-        }
-
-        protected static void fastpack14(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 16383)
-                               | ((@in[1 + inpos] & 16383) << 14)
-                               | ((@in[2 + inpos]) << 28);
-            @out[1 + outpos] = (int)(((uint)@in[2 + inpos] & 16383) >> (14 - 10))
-                               | ((@in[3 + inpos] & 16383) << 10)
-                               | ((@in[4 + inpos]) << 24);
-            @out[2 + outpos] = (int)(((uint)@in[4 + inpos] & 16383) >> (14 - 6))
-                               | ((@in[5 + inpos] & 16383) << 6)
-                               | ((@in[6 + inpos]) << 20);
-            @out[3 + outpos] = (int)(((uint)@in[6 + inpos] & 16383) >> (14 - 2))
-                               | ((@in[7 + inpos] & 16383) << 2)
-                               | ((@in[8 + inpos] & 16383) << 16)
-                               | ((@in[9 + inpos]) << 30);
-            @out[4 + outpos] = (int)(((uint)@in[9 + inpos] & 16383) >> (14 - 12))
-                               | ((@in[10 + inpos] & 16383) << 12)
-                               | ((@in[11 + inpos]) << 26);
-            @out[5 + outpos] = (int)(((uint)@in[11 + inpos] & 16383) >> (14 - 8))
-                               | ((@in[12 + inpos] & 16383) << 8)
-                               | ((@in[13 + inpos]) << 22);
-            @out[6 + outpos] = (int)(((uint)@in[13 + inpos] & 16383) >> (14 - 4))
-                               | ((@in[14 + inpos] & 16383) << 4)
-                               | ((@in[15 + inpos]) << 18);
-            @out[7 + outpos] = (@in[16 + inpos] & 16383)
-                               | ((@in[17 + inpos] & 16383) << 14)
-                               | ((@in[18 + inpos]) << 28);
-            @out[8 + outpos] = (int)(((uint)@in[18 + inpos] & 16383) >> (14 - 10))
-                               | ((@in[19 + inpos] & 16383) << 10)
-                               | ((@in[20 + inpos]) << 24);
-            @out[9 + outpos] = (int)(((uint)@in[20 + inpos] & 16383) >> (14 - 6))
-                               | ((@in[21 + inpos] & 16383) << 6)
-                               | ((@in[22 + inpos]) << 20);
-            @out[10 + outpos] = (int)(((uint)@in[22 + inpos] & 16383) >> (14 - 2))
-                                | ((@in[23 + inpos] & 16383) << 2)
-                                | ((@in[24 + inpos] & 16383) << 16)
-                                | ((@in[25 + inpos]) << 30);
-            @out[11 + outpos] = (int)(((uint)@in[25 + inpos] & 16383) >> (14 - 12))
-                                | ((@in[26 + inpos] & 16383) << 12)
-                                | ((@in[27 + inpos]) << 26);
-            @out[12 + outpos] = (int)(((uint)@in[27 + inpos] & 16383) >> (14 - 8))
-                                | ((@in[28 + inpos] & 16383) << 8)
-                                | ((@in[29 + inpos]) << 22);
-            @out[13 + outpos] = (int)(((uint)@in[29 + inpos] & 16383) >> (14 - 4))
-                                | ((@in[30 + inpos] & 16383) << 4)
-                                | ((@in[31 + inpos]) << 18);
-        }
-
-        protected static void fastpack15(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 32767)
-                               | ((@in[1 + inpos] & 32767) << 15)
-                               | ((@in[2 + inpos]) << 30);
-            @out[1 + outpos] = (int)(((uint)@in[2 + inpos] & 32767) >> (15 - 13))
-                               | ((@in[3 + inpos] & 32767) << 13)
-                               | ((@in[4 + inpos]) << 28);
-            @out[2 + outpos] = (int)(((uint)@in[4 + inpos] & 32767) >> (15 - 11))
-                               | ((@in[5 + inpos] & 32767) << 11)
-                               | ((@in[6 + inpos]) << 26);
-            @out[3 + outpos] = (int)(((uint)@in[6 + inpos] & 32767) >> (15 - 9))
-                               | ((@in[7 + inpos] & 32767) << 9)
-                               | ((@in[8 + inpos]) << 24);
-            @out[4 + outpos] = (int)(((uint)@in[8 + inpos] & 32767) >> (15 - 7))
-                               | ((@in[9 + inpos] & 32767) << 7)
-                               | ((@in[10 + inpos]) << 22);
-            @out[5 + outpos] = (int)(((uint)@in[10 + inpos] & 32767) >> (15 - 5))
-                               | ((@in[11 + inpos] & 32767) << 5)
-                               | ((@in[12 + inpos]) << 20);
-            @out[6 + outpos] = (int)(((uint)@in[12 + inpos] & 32767) >> (15 - 3))
-                               | ((@in[13 + inpos] & 32767) << 3)
-                               | ((@in[14 + inpos]) << 18);
-            @out[7 + outpos] = (int)(((uint)@in[14 + inpos] & 32767) >> (15 - 1))
-                               | ((@in[15 + inpos] & 32767) << 1)
-                               | ((@in[16 + inpos] & 32767) << 16)
-                               | ((@in[17 + inpos]) << 31);
-            @out[8 + outpos] = (int)(((uint)@in[17 + inpos] & 32767) >> (15 - 14))
-                               | ((@in[18 + inpos] & 32767) << 14)
-                               | ((@in[19 + inpos]) << 29);
-            @out[9 + outpos] = (int)(((uint)@in[19 + inpos] & 32767) >> (15 - 12))
-                               | ((@in[20 + inpos] & 32767) << 12)
-                               | ((@in[21 + inpos]) << 27);
-            @out[10 + outpos] = (int)(((uint)@in[21 + inpos] & 32767) >> (15 - 10))
-                                | ((@in[22 + inpos] & 32767) << 10)
-                                | ((@in[23 + inpos]) << 25);
-            @out[11 + outpos] = (int)(((uint)@in[23 + inpos] & 32767) >> (15 - 8))
-                                | ((@in[24 + inpos] & 32767) << 8)
-                                | ((@in[25 + inpos]) << 23);
-            @out[12 + outpos] = (int)(((uint)@in[25 + inpos] & 32767) >> (15 - 6))
-                                | ((@in[26 + inpos] & 32767) << 6)
-                                | ((@in[27 + inpos]) << 21);
-            @out[13 + outpos] = (int)(((uint)@in[27 + inpos] & 32767) >> (15 - 4))
-                                | ((@in[28 + inpos] & 32767) << 4)
-                                | ((@in[29 + inpos]) << 19);
-            @out[14 + outpos] = (int)(((uint)@in[29 + inpos] & 32767) >> (15 - 2))
-                                | ((@in[30 + inpos] & 32767) << 2)
-                                | ((@in[31 + inpos]) << 17);
-        }
-
-        protected static void fastpack16(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 65535)
-                               | ((@in[1 + inpos]) << 16);
-            @out[1 + outpos] = (@in[2 + inpos] & 65535)
-                               | ((@in[3 + inpos]) << 16);
-            @out[2 + outpos] = (@in[4 + inpos] & 65535)
-                               | ((@in[5 + inpos]) << 16);
-            @out[3 + outpos] = (@in[6 + inpos] & 65535)
-                               | ((@in[7 + inpos]) << 16);
-            @out[4 + outpos] = (@in[8 + inpos] & 65535)
-                               | ((@in[9 + inpos]) << 16);
-            @out[5 + outpos] = (@in[10 + inpos] & 65535)
-                               | ((@in[11 + inpos]) << 16);
-            @out[6 + outpos] = (@in[12 + inpos] & 65535)
-                               | ((@in[13 + inpos]) << 16);
-            @out[7 + outpos] = (@in[14 + inpos] & 65535)
-                               | ((@in[15 + inpos]) << 16);
-            @out[8 + outpos] = (@in[16 + inpos] & 65535)
-                               | ((@in[17 + inpos]) << 16);
-            @out[9 + outpos] = (@in[18 + inpos] & 65535)
-                               | ((@in[19 + inpos]) << 16);
-            @out[10 + outpos] = (@in[20 + inpos] & 65535)
-                                | ((@in[21 + inpos]) << 16);
-            @out[11 + outpos] = (@in[22 + inpos] & 65535)
-                                | ((@in[23 + inpos]) << 16);
-            @out[12 + outpos] = (@in[24 + inpos] & 65535)
-                                | ((@in[25 + inpos]) << 16);
-            @out[13 + outpos] = (@in[26 + inpos] & 65535)
-                                | ((@in[27 + inpos]) << 16);
-            @out[14 + outpos] = (@in[28 + inpos] & 65535)
-                                | ((@in[29 + inpos]) << 16);
-            @out[15 + outpos] = (@in[30 + inpos] & 65535)
-                                | ((@in[31 + inpos]) << 16);
-        }
-
-        protected static void fastpack17(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 131071)
-                               | ((@in[1 + inpos]) << 17);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 131071) >> (17 - 2))
-                               | ((@in[2 + inpos] & 131071) << 2)
-                               | ((@in[3 + inpos]) << 19);
-            @out[2 + outpos] = (int)(((uint)@in[3 + inpos] & 131071) >> (17 - 4))
-                               | ((@in[4 + inpos] & 131071) << 4)
-                               | ((@in[5 + inpos]) << 21);
-            @out[3 + outpos] = (int)(((uint)@in[5 + inpos] & 131071) >> (17 - 6))
-                               | ((@in[6 + inpos] & 131071) << 6)
-                               | ((@in[7 + inpos]) << 23);
-            @out[4 + outpos] = (int)(((uint)@in[7 + inpos] & 131071) >> (17 - 8))
-                               | ((@in[8 + inpos] & 131071) << 8)
-                               | ((@in[9 + inpos]) << 25);
-            @out[5 + outpos] = (int)(((uint)@in[9 + inpos] & 131071) >> (17 - 10))
-                               | ((@in[10 + inpos] & 131071) << 10)
-                               | ((@in[11 + inpos]) << 27);
-            @out[6 + outpos] = (int)(((uint)@in[11 + inpos] & 131071) >> (17 - 12))
-                               | ((@in[12 + inpos] & 131071) << 12)
-                               | ((@in[13 + inpos]) << 29);
-            @out[7 + outpos] = (int)(((uint)@in[13 + inpos] & 131071) >> (17 - 14))
-                               | ((@in[14 + inpos] & 131071) << 14)
-                               | ((@in[15 + inpos]) << 31);
-            @out[8 + outpos] = (int)(((uint)@in[15 + inpos] & 131071) >> (17 - 16))
-                               | ((@in[16 + inpos]) << 16);
-            @out[9 + outpos] = (int)(((uint)@in[16 + inpos] & 131071) >> (17 - 1))
-                               | ((@in[17 + inpos] & 131071) << 1)
-                               | ((@in[18 + inpos]) << 18);
-            @out[10 + outpos] = (int)(((uint)@in[18 + inpos] & 131071) >> (17 - 3))
-                                | ((@in[19 + inpos] & 131071) << 3)
-                                | ((@in[20 + inpos]) << 20);
-            @out[11 + outpos] = (int)(((uint)@in[20 + inpos] & 131071) >> (17 - 5))
-                                | ((@in[21 + inpos] & 131071) << 5)
-                                | ((@in[22 + inpos]) << 22);
-            @out[12 + outpos] = (int)(((uint)@in[22 + inpos] & 131071) >> (17 - 7))
-                                | ((@in[23 + inpos] & 131071) << 7)
-                                | ((@in[24 + inpos]) << 24);
-            @out[13 + outpos] = (int)(((uint)@in[24 + inpos] & 131071) >> (17 - 9))
-                                | ((@in[25 + inpos] & 131071) << 9)
-                                | ((@in[26 + inpos]) << 26);
-            @out[14 + outpos] = (int)(((uint)@in[26 + inpos] & 131071) >> (17 - 11))
-                                | ((@in[27 + inpos] & 131071) << 11)
-                                | ((@in[28 + inpos]) << 28);
-            @out[15 + outpos] = (int)(((uint)@in[28 + inpos] & 131071) >> (17 - 13))
-                                | ((@in[29 + inpos] & 131071) << 13)
-                                | ((@in[30 + inpos]) << 30);
-            @out[16 + outpos] = (int)(((uint)@in[30 + inpos] & 131071) >> (17 - 15))
-                                | ((@in[31 + inpos]) << 15);
-        }
-
-        protected static void fastpack18(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 262143)
-                               | ((@in[1 + inpos]) << 18);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 262143) >> (18 - 4))
-                               | ((@in[2 + inpos] & 262143) << 4)
-                               | ((@in[3 + inpos]) << 22);
-            @out[2 + outpos] = (int)(((uint)@in[3 + inpos] & 262143) >> (18 - 8))
-                               | ((@in[4 + inpos] & 262143) << 8)
-                               | ((@in[5 + inpos]) << 26);
-            @out[3 + outpos] = (int)(((uint)@in[5 + inpos] & 262143) >> (18 - 12))
-                               | ((@in[6 + inpos] & 262143) << 12)
-                               | ((@in[7 + inpos]) << 30);
-            @out[4 + outpos] = (int)(((uint)@in[7 + inpos] & 262143) >> (18 - 16))
-                               | ((@in[8 + inpos]) << 16);
-            @out[5 + outpos] = (int)(((uint)@in[8 + inpos] & 262143) >> (18 - 2))
-                               | ((@in[9 + inpos] & 262143) << 2)
-                               | ((@in[10 + inpos]) << 20);
-            @out[6 + outpos] = (int)(((uint)@in[10 + inpos] & 262143) >> (18 - 6))
-                               | ((@in[11 + inpos] & 262143) << 6)
-                               | ((@in[12 + inpos]) << 24);
-            @out[7 + outpos] = (int)(((uint)@in[12 + inpos] & 262143) >> (18 - 10))
-                               | ((@in[13 + inpos] & 262143) << 10)
-                               | ((@in[14 + inpos]) << 28);
-            @out[8 + outpos] = (int)(((uint)@in[14 + inpos] & 262143) >> (18 - 14))
-                               | ((@in[15 + inpos]) << 14);
-            @out[9 + outpos] = (@in[16 + inpos] & 262143)
-                               | ((@in[17 + inpos]) << 18);
-            @out[10 + outpos] = (int)(((uint)@in[17 + inpos] & 262143) >> (18 - 4))
-                                | ((@in[18 + inpos] & 262143) << 4)
-                                | ((@in[19 + inpos]) << 22);
-            @out[11 + outpos] = (int)(((uint)@in[19 + inpos] & 262143) >> (18 - 8))
-                                | ((@in[20 + inpos] & 262143) << 8)
-                                | ((@in[21 + inpos]) << 26);
-            @out[12 + outpos] = (int)(((uint)@in[21 + inpos] & 262143) >> (18 - 12))
-                                | ((@in[22 + inpos] & 262143) << 12)
-                                | ((@in[23 + inpos]) << 30);
-            @out[13 + outpos] = (int)(((uint)@in[23 + inpos] & 262143) >> (18 - 16))
-                                | ((@in[24 + inpos]) << 16);
-            @out[14 + outpos] = (int)(((uint)@in[24 + inpos] & 262143) >> (18 - 2))
-                                | ((@in[25 + inpos] & 262143) << 2)
-                                | ((@in[26 + inpos]) << 20);
-            @out[15 + outpos] = (int)(((uint)@in[26 + inpos] & 262143) >> (18 - 6))
-                                | ((@in[27 + inpos] & 262143) << 6)
-                                | ((@in[28 + inpos]) << 24);
-            @out[16 + outpos] = (int)(((uint)@in[28 + inpos] & 262143) >> (18 - 10))
-                                | ((@in[29 + inpos] & 262143) << 10)
-                                | ((@in[30 + inpos]) << 28);
-            @out[17 + outpos] = (int)(((uint)@in[30 + inpos] & 262143) >> (18 - 14))
-                                | ((@in[31 + inpos]) << 14);
-        }
-
-        protected static void fastpack19(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 524287)
-                               | ((@in[1 + inpos]) << 19);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 524287) >> (19 - 6))
-                               | ((@in[2 + inpos] & 524287) << 6)
-                               | ((@in[3 + inpos]) << 25);
-            @out[2 + outpos] = (int)(((uint)@in[3 + inpos] & 524287) >> (19 - 12))
-                               | ((@in[4 + inpos] & 524287) << 12)
-                               | ((@in[5 + inpos]) << 31);
-            @out[3 + outpos] = (int)(((uint)@in[5 + inpos] & 524287) >> (19 - 18))
-                               | ((@in[6 + inpos]) << 18);
-            @out[4 + outpos] = (int)(((uint)@in[6 + inpos] & 524287) >> (19 - 5))
-                               | ((@in[7 + inpos] & 524287) << 5)
-                               | ((@in[8 + inpos]) << 24);
-            @out[5 + outpos] = (int)(((uint)@in[8 + inpos] & 524287) >> (19 - 11))
-                               | ((@in[9 + inpos] & 524287) << 11)
-                               | ((@in[10 + inpos]) << 30);
-            @out[6 + outpos] = (int)(((uint)@in[10 + inpos] & 524287) >> (19 - 17))
-                               | ((@in[11 + inpos]) << 17);
-            @out[7 + outpos] = (int)(((uint)@in[11 + inpos] & 524287) >> (19 - 4))
-                               | ((@in[12 + inpos] & 524287) << 4)
-                               | ((@in[13 + inpos]) << 23);
-            @out[8 + outpos] = (int)(((uint)@in[13 + inpos] & 524287) >> (19 - 10))
-                               | ((@in[14 + inpos] & 524287) << 10)
-                               | ((@in[15 + inpos]) << 29);
-            @out[9 + outpos] = (int)(((uint)@in[15 + inpos] & 524287) >> (19 - 16))
-                               | ((@in[16 + inpos]) << 16);
-            @out[10 + outpos] = (int)(((uint)@in[16 + inpos] & 524287) >> (19 - 3))
-                                | ((@in[17 + inpos] & 524287) << 3)
-                                | ((@in[18 + inpos]) << 22);
-            @out[11 + outpos] = (int)(((uint)@in[18 + inpos] & 524287) >> (19 - 9))
-                                | ((@in[19 + inpos] & 524287) << 9)
-                                | ((@in[20 + inpos]) << 28);
-            @out[12 + outpos] = (int)(((uint)@in[20 + inpos] & 524287) >> (19 - 15))
-                                | ((@in[21 + inpos]) << 15);
-            @out[13 + outpos] = (int)(((uint)@in[21 + inpos] & 524287) >> (19 - 2))
-                                | ((@in[22 + inpos] & 524287) << 2)
-                                | ((@in[23 + inpos]) << 21);
-            @out[14 + outpos] = (int)(((uint)@in[23 + inpos] & 524287) >> (19 - 8))
-                                | ((@in[24 + inpos] & 524287) << 8)
-                                | ((@in[25 + inpos]) << 27);
-            @out[15 + outpos] = (int)(((uint)@in[25 + inpos] & 524287) >> (19 - 14))
-                                | ((@in[26 + inpos]) << 14);
-            @out[16 + outpos] = (int)(((uint)@in[26 + inpos] & 524287) >> (19 - 1))
-                                | ((@in[27 + inpos] & 524287) << 1)
-                                | ((@in[28 + inpos]) << 20);
-            @out[17 + outpos] = (int)(((uint)@in[28 + inpos] & 524287) >> (19 - 7))
-                                | ((@in[29 + inpos] & 524287) << 7)
-                                | ((@in[30 + inpos]) << 26);
-            @out[18 + outpos] = (int)(((uint)@in[30 + inpos] & 524287) >> (19 - 13))
-                                | ((@in[31 + inpos]) << 13);
-        }
-
-        protected static void fastpack2(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 3)
-                               | ((@in[1 + inpos] & 3) << 2)
-                               | ((@in[2 + inpos] & 3) << 4)
-                               | ((@in[3 + inpos] & 3) << 6)
-                               | ((@in[4 + inpos] & 3) << 8)
-                               | ((@in[5 + inpos] & 3) << 10)
-                               | ((@in[6 + inpos] & 3) << 12)
-                               | ((@in[7 + inpos] & 3) << 14)
-                               | ((@in[8 + inpos] & 3) << 16)
-                               | ((@in[9 + inpos] & 3) << 18)
-                               | ((@in[10 + inpos] & 3) << 20)
-                               | ((@in[11 + inpos] & 3) << 22)
-                               | ((@in[12 + inpos] & 3) << 24)
-                               | ((@in[13 + inpos] & 3) << 26)
-                               | ((@in[14 + inpos] & 3) << 28)
-                               | ((@in[15 + inpos]) << 30);
-            @out[1 + outpos] = (@in[16 + inpos] & 3)
-                               | ((@in[17 + inpos] & 3) << 2)
-                               | ((@in[18 + inpos] & 3) << 4)
-                               | ((@in[19 + inpos] & 3) << 6)
-                               | ((@in[20 + inpos] & 3) << 8)
-                               | ((@in[21 + inpos] & 3) << 10)
-                               | ((@in[22 + inpos] & 3) << 12)
-                               | ((@in[23 + inpos] & 3) << 14)
-                               | ((@in[24 + inpos] & 3) << 16)
-                               | ((@in[25 + inpos] & 3) << 18)
-                               | ((@in[26 + inpos] & 3) << 20)
-                               | ((@in[27 + inpos] & 3) << 22)
-                               | ((@in[28 + inpos] & 3) << 24)
-                               | ((@in[29 + inpos] & 3) << 26)
-                               | ((@in[30 + inpos] & 3) << 28)
-                               | ((@in[31 + inpos]) << 30);
-        }
-
-        protected static void fastpack20(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 1048575)
-                               | ((@in[1 + inpos]) << 20);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 1048575) >> (20 - 8))
-                               | ((@in[2 + inpos] & 1048575) << 8)
-                               | ((@in[3 + inpos]) << 28);
-            @out[2 + outpos] = (int)(((uint)@in[3 + inpos] & 1048575) >> (20 - 16))
-                               | ((@in[4 + inpos]) << 16);
-            @out[3 + outpos] = (int)(((uint)@in[4 + inpos] & 1048575) >> (20 - 4))
-                               | ((@in[5 + inpos] & 1048575) << 4)
-                               | ((@in[6 + inpos]) << 24);
-            @out[4 + outpos] = (int)(((uint)@in[6 + inpos] & 1048575) >> (20 - 12))
-                               | ((@in[7 + inpos]) << 12);
-            @out[5 + outpos] = (@in[8 + inpos] & 1048575)
-                               | ((@in[9 + inpos]) << 20);
-            @out[6 + outpos] = (int)(((uint)@in[9 + inpos] & 1048575) >> (20 - 8))
-                               | ((@in[10 + inpos] & 1048575) << 8)
-                               | ((@in[11 + inpos]) << 28);
-            @out[7 + outpos] = (int)(((uint)@in[11 + inpos] & 1048575) >> (20 - 16))
-                               | ((@in[12 + inpos]) << 16);
-            @out[8 + outpos] = (int)(((uint)@in[12 + inpos] & 1048575) >> (20 - 4))
-                               | ((@in[13 + inpos] & 1048575) << 4)
-                               | ((@in[14 + inpos]) << 24);
-            @out[9 + outpos] = (int)(((uint)@in[14 + inpos] & 1048575) >> (20 - 12))
-                               | ((@in[15 + inpos]) << 12);
-            @out[10 + outpos] = (@in[16 + inpos] & 1048575)
-                                | ((@in[17 + inpos]) << 20);
-            @out[11 + outpos] = (int)(((uint)@in[17 + inpos] & 1048575) >> (20 - 8))
-                                | ((@in[18 + inpos] & 1048575) << 8)
-                                | ((@in[19 + inpos]) << 28);
-            @out[12 + outpos] = (int)(((uint)@in[19 + inpos] & 1048575) >> (20 - 16))
-                                | ((@in[20 + inpos]) << 16);
-            @out[13 + outpos] = (int)(((uint)@in[20 + inpos] & 1048575) >> (20 - 4))
-                                | ((@in[21 + inpos] & 1048575) << 4)
-                                | ((@in[22 + inpos]) << 24);
-            @out[14 + outpos] = (int)(((uint)@in[22 + inpos] & 1048575) >> (20 - 12))
-                                | ((@in[23 + inpos]) << 12);
-            @out[15 + outpos] = (@in[24 + inpos] & 1048575)
-                                | ((@in[25 + inpos]) << 20);
-            @out[16 + outpos] = (int)(((uint)@in[25 + inpos] & 1048575) >> (20 - 8))
-                                | ((@in[26 + inpos] & 1048575) << 8)
-                                | ((@in[27 + inpos]) << 28);
-            @out[17 + outpos] = (int)(((uint)@in[27 + inpos] & 1048575) >> (20 - 16))
-                                | ((@in[28 + inpos]) << 16);
-            @out[18 + outpos] = (int)(((uint)@in[28 + inpos] & 1048575) >> (20 - 4))
-                                | ((@in[29 + inpos] & 1048575) << 4)
-                                | ((@in[30 + inpos]) << 24);
-            @out[19 + outpos] = (int)(((uint)@in[30 + inpos] & 1048575) >> (20 - 12))
-                                | ((@in[31 + inpos]) << 12);
-        }
-
-        protected static void fastpack21(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 2097151)
-                               | ((@in[1 + inpos]) << 21);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 2097151) >> (21 - 10))
-                               | ((@in[2 + inpos] & 2097151) << 10)
-                               | ((@in[3 + inpos]) << 31);
-            @out[2 + outpos] = (int)(((uint)@in[3 + inpos] & 2097151) >> (21 - 20))
-                               | ((@in[4 + inpos]) << 20);
-            @out[3 + outpos] = (int)(((uint)@in[4 + inpos] & 2097151) >> (21 - 9))
-                               | ((@in[5 + inpos] & 2097151) << 9)
-                               | ((@in[6 + inpos]) << 30);
-            @out[4 + outpos] = (int)(((uint)@in[6 + inpos] & 2097151) >> (21 - 19))
-                               | ((@in[7 + inpos]) << 19);
-            @out[5 + outpos] = (int)(((uint)@in[7 + inpos] & 2097151) >> (21 - 8))
-                               | ((@in[8 + inpos] & 2097151) << 8)
-                               | ((@in[9 + inpos]) << 29);
-            @out[6 + outpos] = (int)(((uint)@in[9 + inpos] & 2097151) >> (21 - 18))
-                               | ((@in[10 + inpos]) << 18);
-            @out[7 + outpos] = (int)(((uint)@in[10 + inpos] & 2097151) >> (21 - 7))
-                               | ((@in[11 + inpos] & 2097151) << 7)
-                               | ((@in[12 + inpos]) << 28);
-            @out[8 + outpos] = (int)(((uint)@in[12 + inpos] & 2097151) >> (21 - 17))
-                               | ((@in[13 + inpos]) << 17);
-            @out[9 + outpos] = (int)(((uint)@in[13 + inpos] & 2097151) >> (21 - 6))
-                               | ((@in[14 + inpos] & 2097151) << 6)
-                               | ((@in[15 + inpos]) << 27);
-            @out[10 + outpos] = (int)(((uint)@in[15 + inpos] & 2097151) >> (21 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[11 + outpos] = (int)(((uint)@in[16 + inpos] & 2097151) >> (21 - 5))
-                                | ((@in[17 + inpos] & 2097151) << 5)
-                                | ((@in[18 + inpos]) << 26);
-            @out[12 + outpos] = (int)(((uint)@in[18 + inpos] & 2097151) >> (21 - 15))
-                                | ((@in[19 + inpos]) << 15);
-            @out[13 + outpos] = (int)(((uint)@in[19 + inpos] & 2097151) >> (21 - 4))
-                                | ((@in[20 + inpos] & 2097151) << 4)
-                                | ((@in[21 + inpos]) << 25);
-            @out[14 + outpos] = (int)(((uint)@in[21 + inpos] & 2097151) >> (21 - 14))
-                                | ((@in[22 + inpos]) << 14);
-            @out[15 + outpos] = (int)(((uint)@in[22 + inpos] & 2097151) >> (21 - 3))
-                                | ((@in[23 + inpos] & 2097151) << 3)
-                                | ((@in[24 + inpos]) << 24);
-            @out[16 + outpos] = (int)(((uint)@in[24 + inpos] & 2097151) >> (21 - 13))
-                                | ((@in[25 + inpos]) << 13);
-            @out[17 + outpos] = (int)(((uint)@in[25 + inpos] & 2097151) >> (21 - 2))
-                                | ((@in[26 + inpos] & 2097151) << 2)
-                                | ((@in[27 + inpos]) << 23);
-            @out[18 + outpos] = (int)(((uint)@in[27 + inpos] & 2097151) >> (21 - 12))
-                                | ((@in[28 + inpos]) << 12);
-            @out[19 + outpos] = (int)(((uint)@in[28 + inpos] & 2097151) >> (21 - 1))
-                                | ((@in[29 + inpos] & 2097151) << 1)
-                                | ((@in[30 + inpos]) << 22);
-            @out[20 + outpos] = (int)(((uint)@in[30 + inpos] & 2097151) >> (21 - 11))
-                                | ((@in[31 + inpos]) << 11);
-        }
-
-        protected static void fastpack22(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 4194303)
-                               | ((@in[1 + inpos]) << 22);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 4194303) >> (22 - 12))
-                               | ((@in[2 + inpos]) << 12);
-            @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 4194303) >> (22 - 2))
-                               | ((@in[3 + inpos] & 4194303) << 2)
-                               | ((@in[4 + inpos]) << 24);
-            @out[3 + outpos] = (int)(((uint)@in[4 + inpos] & 4194303) >> (22 - 14))
-                               | ((@in[5 + inpos]) << 14);
-            @out[4 + outpos] = (int)(((uint)@in[5 + inpos] & 4194303) >> (22 - 4))
-                               | ((@in[6 + inpos] & 4194303) << 4)
-                               | ((@in[7 + inpos]) << 26);
-            @out[5 + outpos] = (int)(((uint)@in[7 + inpos] & 4194303) >> (22 - 16))
-                               | ((@in[8 + inpos]) << 16);
-            @out[6 + outpos] = (int)(((uint)@in[8 + inpos] & 4194303) >> (22 - 6))
-                               | ((@in[9 + inpos] & 4194303) << 6)
-                               | ((@in[10 + inpos]) << 28);
-            @out[7 + outpos] = (int)(((uint)@in[10 + inpos] & 4194303) >> (22 - 18))
-                               | ((@in[11 + inpos]) << 18);
-            @out[8 + outpos] = (int)(((uint)@in[11 + inpos] & 4194303) >> (22 - 8))
-                               | ((@in[12 + inpos] & 4194303) << 8)
-                               | ((@in[13 + inpos]) << 30);
-            @out[9 + outpos] = (int)(((uint)@in[13 + inpos] & 4194303) >> (22 - 20))
-                               | ((@in[14 + inpos]) << 20);
-            @out[10 + outpos] = (int)(((uint)@in[14 + inpos] & 4194303) >> (22 - 10))
-                                | ((@in[15 + inpos]) << 10);
-            @out[11 + outpos] = (@in[16 + inpos] & 4194303)
-                                | ((@in[17 + inpos]) << 22);
-            @out[12 + outpos] = (int)(((uint)@in[17 + inpos] & 4194303) >> (22 - 12))
-                                | ((@in[18 + inpos]) << 12);
-            @out[13 + outpos] = (int)(((uint)@in[18 + inpos] & 4194303) >> (22 - 2))
-                                | ((@in[19 + inpos] & 4194303) << 2)
-                                | ((@in[20 + inpos]) << 24);
-            @out[14 + outpos] = (int)(((uint)@in[20 + inpos] & 4194303) >> (22 - 14))
-                                | ((@in[21 + inpos]) << 14);
-            @out[15 + outpos] = (int)(((uint)@in[21 + inpos] & 4194303) >> (22 - 4))
-                                | ((@in[22 + inpos] & 4194303) << 4)
-                                | ((@in[23 + inpos]) << 26);
-            @out[16 + outpos] = (int)(((uint)@in[23 + inpos] & 4194303) >> (22 - 16))
-                                | ((@in[24 + inpos]) << 16);
-            @out[17 + outpos] = (int)(((uint)@in[24 + inpos] & 4194303) >> (22 - 6))
-                                | ((@in[25 + inpos] & 4194303) << 6)
-                                | ((@in[26 + inpos]) << 28);
-            @out[18 + outpos] = (int)(((uint)@in[26 + inpos] & 4194303) >> (22 - 18))
-                                | ((@in[27 + inpos]) << 18);
-            @out[19 + outpos] = (int)(((uint)@in[27 + inpos] & 4194303) >> (22 - 8))
-                                | ((@in[28 + inpos] & 4194303) << 8)
-                                | ((@in[29 + inpos]) << 30);
-            @out[20 + outpos] = (int)(((uint)@in[29 + inpos] & 4194303) >> (22 - 20))
-                                | ((@in[30 + inpos]) << 20);
-            @out[21 + outpos] = (int)(((uint)@in[30 + inpos] & 4194303) >> (22 - 10))
-                                | ((@in[31 + inpos]) << 10);
-        }
-
-        protected static void fastpack23(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 8388607)
-                               | ((@in[1 + inpos]) << 23);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 8388607) >> (23 - 14))
-                               | ((@in[2 + inpos]) << 14);
-            @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 8388607) >> (23 - 5))
-                               | ((@in[3 + inpos] & 8388607) << 5)
-                               | ((@in[4 + inpos]) << 28);
-            @out[3 + outpos] = (int)(((uint)@in[4 + inpos] & 8388607) >> (23 - 19))
-                               | ((@in[5 + inpos]) << 19);
-            @out[4 + outpos] = (int)(((uint)@in[5 + inpos] & 8388607) >> (23 - 10))
-                               | ((@in[6 + inpos]) << 10);
-            @out[5 + outpos] = (int)(((uint)@in[6 + inpos] & 8388607) >> (23 - 1))
-                               | ((@in[7 + inpos] & 8388607) << 1)
-                               | ((@in[8 + inpos]) << 24);
-            @out[6 + outpos] = (int)(((uint)@in[8 + inpos] & 8388607) >> (23 - 15))
-                               | ((@in[9 + inpos]) << 15);
-            @out[7 + outpos] = (int)(((uint)@in[9 + inpos] & 8388607) >> (23 - 6))
-                               | ((@in[10 + inpos] & 8388607) << 6)
-                               | ((@in[11 + inpos]) << 29);
-            @out[8 + outpos] = (int)(((uint)@in[11 + inpos] & 8388607) >> (23 - 20))
-                               | ((@in[12 + inpos]) << 20);
-            @out[9 + outpos] = (int)(((uint)@in[12 + inpos] & 8388607) >> (23 - 11))
-                               | ((@in[13 + inpos]) << 11);
-            @out[10 + outpos] = (int)(((uint)@in[13 + inpos] & 8388607) >> (23 - 2))
-                                | ((@in[14 + inpos] & 8388607) << 2)
-                                | ((@in[15 + inpos]) << 25);
-            @out[11 + outpos] = (int)(((uint)@in[15 + inpos] & 8388607) >> (23 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[12 + outpos] = (int)(((uint)@in[16 + inpos] & 8388607) >> (23 - 7))
-                                | ((@in[17 + inpos] & 8388607) << 7)
-                                | ((@in[18 + inpos]) << 30);
-            @out[13 + outpos] = (int)(((uint)@in[18 + inpos] & 8388607) >> (23 - 21))
-                                | ((@in[19 + inpos]) << 21);
-            @out[14 + outpos] = (int)(((uint)@in[19 + inpos] & 8388607) >> (23 - 12))
-                                | ((@in[20 + inpos]) << 12);
-            @out[15 + outpos] = (int)(((uint)@in[20 + inpos] & 8388607) >> (23 - 3))
-                                | ((@in[21 + inpos] & 8388607) << 3)
-                                | ((@in[22 + inpos]) << 26);
-            @out[16 + outpos] = (int)(((uint)@in[22 + inpos] & 8388607) >> (23 - 17))
-                                | ((@in[23 + inpos]) << 17);
-            @out[17 + outpos] = (int)(((uint)@in[23 + inpos] & 8388607) >> (23 - 8))
-                                | ((@in[24 + inpos] & 8388607) << 8)
-                                | ((@in[25 + inpos]) << 31);
-            @out[18 + outpos] = (int)(((uint)@in[25 + inpos] & 8388607) >> (23 - 22))
-                                | ((@in[26 + inpos]) << 22);
-            @out[19 + outpos] = (int)(((uint)@in[26 + inpos] & 8388607) >> (23 - 13))
-                                | ((@in[27 + inpos]) << 13);
-            @out[20 + outpos] = (int)(((uint)@in[27 + inpos] & 8388607) >> (23 - 4))
-                                | ((@in[28 + inpos] & 8388607) << 4)
-                                | ((@in[29 + inpos]) << 27);
-            @out[21 + outpos] = (int)(((uint)@in[29 + inpos] & 8388607) >> (23 - 18))
-                                | ((@in[30 + inpos]) << 18);
-            @out[22 + outpos] = (int)(((uint)@in[30 + inpos] & 8388607) >> (23 - 9))
-                                | ((@in[31 + inpos]) << 9);
-        }
-
-        protected static void fastpack24(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 16777215)
-                               | ((@in[1 + inpos]) << 24);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 16777215) >> (24 - 16))
-                               | ((@in[2 + inpos]) << 16);
-            @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 16777215) >> (24 - 8))
-                               | ((@in[3 + inpos]) << 8);
-            @out[3 + outpos] = (@in[4 + inpos] & 16777215)
-                               | ((@in[5 + inpos]) << 24);
-            @out[4 + outpos] = (int)(((uint)@in[5 + inpos] & 16777215) >> (24 - 16))
-                               | ((@in[6 + inpos]) << 16);
-            @out[5 + outpos] = (int)(((uint)@in[6 + inpos] & 16777215) >> (24 - 8))
-                               | ((@in[7 + inpos]) << 8);
-            @out[6 + outpos] = (@in[8 + inpos] & 16777215)
-                               | ((@in[9 + inpos]) << 24);
-            @out[7 + outpos] = (int)(((uint)@in[9 + inpos] & 16777215) >> (24 - 16))
-                               | ((@in[10 + inpos]) << 16);
-            @out[8 + outpos] = (int)(((uint)@in[10 + inpos] & 16777215) >> (24 - 8))
-                               | ((@in[11 + inpos]) << 8);
-            @out[9 + outpos] = (@in[12 + inpos] & 16777215)
-                               | ((@in[13 + inpos]) << 24);
-            @out[10 + outpos] = (int)(((uint)@in[13 + inpos] & 16777215) >> (24 - 16))
-                                | ((@in[14 + inpos]) << 16);
-            @out[11 + outpos] = (int)(((uint)@in[14 + inpos] & 16777215) >> (24 - 8))
-                                | ((@in[15 + inpos]) << 8);
-            @out[12 + outpos] = (@in[16 + inpos] & 16777215)
-                                | ((@in[17 + inpos]) << 24);
-            @out[13 + outpos] = (int)(((uint)@in[17 + inpos] & 16777215) >> (24 - 16))
-                                | ((@in[18 + inpos]) << 16);
-            @out[14 + outpos] = (int)(((uint)@in[18 + inpos] & 16777215) >> (24 - 8))
-                                | ((@in[19 + inpos]) << 8);
-            @out[15 + outpos] = (@in[20 + inpos] & 16777215)
-                                | ((@in[21 + inpos]) << 24);
-            @out[16 + outpos] = (int)(((uint)@in[21 + inpos] & 16777215) >> (24 - 16))
-                                | ((@in[22 + inpos]) << 16);
-            @out[17 + outpos] = (int)(((uint)@in[22 + inpos] & 16777215) >> (24 - 8))
-                                | ((@in[23 + inpos]) << 8);
-            @out[18 + outpos] = (@in[24 + inpos] & 16777215)
-                                | ((@in[25 + inpos]) << 24);
-            @out[19 + outpos] = (int)(((uint)@in[25 + inpos] & 16777215) >> (24 - 16))
-                                | ((@in[26 + inpos]) << 16);
-            @out[20 + outpos] = (int)(((uint)@in[26 + inpos] & 16777215) >> (24 - 8))
-                                | ((@in[27 + inpos]) << 8);
-            @out[21 + outpos] = (@in[28 + inpos] & 16777215)
-                                | ((@in[29 + inpos]) << 24);
-            @out[22 + outpos] = (int)(((uint)@in[29 + inpos] & 16777215) >> (24 - 16))
-                                | ((@in[30 + inpos]) << 16);
-            @out[23 + outpos] = (int)(((uint)@in[30 + inpos] & 16777215) >> (24 - 8))
-                                | ((@in[31 + inpos]) << 8);
-        }
-
-        protected static void fastpack25(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 33554431)
-                               | ((@in[1 + inpos]) << 25);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 33554431) >> (25 - 18))
-                               | ((@in[2 + inpos]) << 18);
-            @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 33554431) >> (25 - 11))
-                               | ((@in[3 + inpos]) << 11);
-            @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 33554431) >> (25 - 4))
-                               | ((@in[4 + inpos] & 33554431) << 4)
-                               | ((@in[5 + inpos]) << 29);
-            @out[4 + outpos] = (int)(((uint)@in[5 + inpos] & 33554431) >> (25 - 22))
-                               | ((@in[6 + inpos]) << 22);
-            @out[5 + outpos] = (int)(((uint)@in[6 + inpos] & 33554431) >> (25 - 15))
-                               | ((@in[7 + inpos]) << 15);
-            @out[6 + outpos] = (int)(((uint)@in[7 + inpos] & 33554431) >> (25 - 8))
-                               | ((@in[8 + inpos]) << 8);
-            @out[7 + outpos] = (int)(((uint)@in[8 + inpos] & 33554431) >> (25 - 1))
-                               | ((@in[9 + inpos] & 33554431) << 1)
-                               | ((@in[10 + inpos]) << 26);
-            @out[8 + outpos] = (int)(((uint)@in[10 + inpos] & 33554431) >> (25 - 19))
-                               | ((@in[11 + inpos]) << 19);
-            @out[9 + outpos] = (int)(((uint)@in[11 + inpos] & 33554431) >> (25 - 12))
-                               | ((@in[12 + inpos]) << 12);
-            @out[10 + outpos] = (int)(((uint)@in[12 + inpos] & 33554431) >> (25 - 5))
-                                | ((@in[13 + inpos] & 33554431) << 5)
-                                | ((@in[14 + inpos]) << 30);
-            @out[11 + outpos] = (int)(((uint)@in[14 + inpos] & 33554431) >> (25 - 23))
-                                | ((@in[15 + inpos]) << 23);
-            @out[12 + outpos] = (int)(((uint)@in[15 + inpos] & 33554431) >> (25 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[13 + outpos] = (int)(((uint)@in[16 + inpos] & 33554431) >> (25 - 9))
-                                | ((@in[17 + inpos]) << 9);
-            @out[14 + outpos] = (int)(((uint)@in[17 + inpos] & 33554431) >> (25 - 2))
-                                | ((@in[18 + inpos] & 33554431) << 2)
-                                | ((@in[19 + inpos]) << 27);
-            @out[15 + outpos] = (int)(((uint)@in[19 + inpos] & 33554431) >> (25 - 20))
-                                | ((@in[20 + inpos]) << 20);
-            @out[16 + outpos] = (int)(((uint)@in[20 + inpos] & 33554431) >> (25 - 13))
-                                | ((@in[21 + inpos]) << 13);
-            @out[17 + outpos] = (int)(((uint)@in[21 + inpos] & 33554431) >> (25 - 6))
-                                | ((@in[22 + inpos] & 33554431) << 6)
-                                | ((@in[23 + inpos]) << 31);
-            @out[18 + outpos] = (int)(((uint)@in[23 + inpos] & 33554431) >> (25 - 24))
-                                | ((@in[24 + inpos]) << 24);
-            @out[19 + outpos] = (int)(((uint)@in[24 + inpos] & 33554431) >> (25 - 17))
-                                | ((@in[25 + inpos]) << 17);
-            @out[20 + outpos] = (int)(((uint)@in[25 + inpos] & 33554431) >> (25 - 10))
-                                | ((@in[26 + inpos]) << 10);
-            @out[21 + outpos] = (int)(((uint)@in[26 + inpos] & 33554431) >> (25 - 3))
-                                | ((@in[27 + inpos] & 33554431) << 3)
-                                | ((@in[28 + inpos]) << 28);
-            @out[22 + outpos] = (int)(((uint)@in[28 + inpos] & 33554431) >> (25 - 21))
-                                | ((@in[29 + inpos]) << 21);
-            @out[23 + outpos] = (int)(((uint)@in[29 + inpos] & 33554431) >> (25 - 14))
-                                | ((@in[30 + inpos]) << 14);
-            @out[24 + outpos] = (int)(((uint)@in[30 + inpos] & 33554431) >> (25 - 7))
-                                | ((@in[31 + inpos]) << 7);
-        }
-
-        protected static void fastpack26(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 67108863)
-                               | ((@in[1 + inpos]) << 26);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 67108863) >> (26 - 20))
-                               | ((@in[2 + inpos]) << 20);
-            @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 67108863) >> (26 - 14))
-                               | ((@in[3 + inpos]) << 14);
-            @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 67108863) >> (26 - 8))
-                               | ((@in[4 + inpos]) << 8);
-            @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 67108863) >> (26 - 2))
-                               | ((@in[5 + inpos] & 67108863) << 2)
-                               | ((@in[6 + inpos]) << 28);
-            @out[5 + outpos] = (int)(((uint)@in[6 + inpos] & 67108863) >> (26 - 22))
-                               | ((@in[7 + inpos]) << 22);
-            @out[6 + outpos] = (int)(((uint)@in[7 + inpos] & 67108863) >> (26 - 16))
-                               | ((@in[8 + inpos]) << 16);
-            @out[7 + outpos] = (int)(((uint)@in[8 + inpos] & 67108863) >> (26 - 10))
-                               | ((@in[9 + inpos]) << 10);
-            @out[8 + outpos] = (int)(((uint)@in[9 + inpos] & 67108863) >> (26 - 4))
-                               | ((@in[10 + inpos] & 67108863) << 4)
-                               | ((@in[11 + inpos]) << 30);
-            @out[9 + outpos] = (int)(((uint)@in[11 + inpos] & 67108863) >> (26 - 24))
-                               | ((@in[12 + inpos]) << 24);
-            @out[10 + outpos] = (int)(((uint)@in[12 + inpos] & 67108863) >> (26 - 18))
-                                | ((@in[13 + inpos]) << 18);
-            @out[11 + outpos] = (int)(((uint)@in[13 + inpos] & 67108863) >> (26 - 12))
-                                | ((@in[14 + inpos]) << 12);
-            @out[12 + outpos] = (int)(((uint)@in[14 + inpos] & 67108863) >> (26 - 6))
-                                | ((@in[15 + inpos]) << 6);
-            @out[13 + outpos] = (@in[16 + inpos] & 67108863)
-                                | ((@in[17 + inpos]) << 26);
-            @out[14 + outpos] = (int)(((uint)@in[17 + inpos] & 67108863) >> (26 - 20))
-                                | ((@in[18 + inpos]) << 20);
-            @out[15 + outpos] = (int)(((uint)@in[18 + inpos] & 67108863) >> (26 - 14))
-                                | ((@in[19 + inpos]) << 14);
-            @out[16 + outpos] = (int)(((uint)@in[19 + inpos] & 67108863) >> (26 - 8))
-                                | ((@in[20 + inpos]) << 8);
-            @out[17 + outpos] = (int)(((uint)@in[20 + inpos] & 67108863) >> (26 - 2))
-                                | ((@in[21 + inpos] & 67108863) << 2)
-                                | ((@in[22 + inpos]) << 28);
-            @out[18 + outpos] = (int)(((uint)@in[22 + inpos] & 67108863) >> (26 - 22))
-                                | ((@in[23 + inpos]) << 22);
-            @out[19 + outpos] = (int)(((uint)@in[23 + inpos] & 67108863) >> (26 - 16))
-                                | ((@in[24 + inpos]) << 16);
-            @out[20 + outpos] = (int)(((uint)@in[24 + inpos] & 67108863) >> (26 - 10))
-                                | ((@in[25 + inpos]) << 10);
-            @out[21 + outpos] = (int)(((uint)@in[25 + inpos] & 67108863) >> (26 - 4))
-                                | ((@in[26 + inpos] & 67108863) << 4)
-                                | ((@in[27 + inpos]) << 30);
-            @out[22 + outpos] = (int)(((uint)@in[27 + inpos] & 67108863) >> (26 - 24))
-                                | ((@in[28 + inpos]) << 24);
-            @out[23 + outpos] = (int)(((uint)@in[28 + inpos] & 67108863) >> (26 - 18))
-                                | ((@in[29 + inpos]) << 18);
-            @out[24 + outpos] = (int)(((uint)@in[29 + inpos] & 67108863) >> (26 - 12))
-                                | ((@in[30 + inpos]) << 12);
-            @out[25 + outpos] = (int)(((uint)@in[30 + inpos] & 67108863) >> (26 - 6))
-                                | ((@in[31 + inpos]) << 6);
-        }
-
-        protected static void fastpack27(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 134217727)
-                               | ((@in[1 + inpos]) << 27);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 134217727) >> (27 - 22))
-                               | ((@in[2 + inpos]) << 22);
-            @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 134217727) >> (27 - 17))
-                               | ((@in[3 + inpos]) << 17);
-            @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 134217727) >> (27 - 12))
-                               | ((@in[4 + inpos]) << 12);
-            @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 134217727) >> (27 - 7))
-                               | ((@in[5 + inpos]) << 7);
-            @out[5 + outpos] = (int)(((uint)@in[5 + inpos] & 134217727) >> (27 - 2))
-                               | ((@in[6 + inpos] & 134217727) << 2)
-                               | ((@in[7 + inpos]) << 29);
-            @out[6 + outpos] = (int)(((uint)@in[7 + inpos] & 134217727) >> (27 - 24))
-                               | ((@in[8 + inpos]) << 24);
-            @out[7 + outpos] = (int)(((uint)@in[8 + inpos] & 134217727) >> (27 - 19))
-                               | ((@in[9 + inpos]) << 19);
-            @out[8 + outpos] = (int)(((uint)@in[9 + inpos] & 134217727) >> (27 - 14))
-                               | ((@in[10 + inpos]) << 14);
-            @out[9 + outpos] = (int)(((uint)@in[10 + inpos] & 134217727) >> (27 - 9))
-                               | ((@in[11 + inpos]) << 9);
-            @out[10 + outpos] = (int)(((uint)@in[11 + inpos] & 134217727) >> (27 - 4))
-                                | ((@in[12 + inpos] & 134217727) << 4)
-                                | ((@in[13 + inpos]) << 31);
-            @out[11 + outpos] = (int)(((uint)@in[13 + inpos] & 134217727) >> (27 - 26))
-                                | ((@in[14 + inpos]) << 26);
-            @out[12 + outpos] = (int)(((uint)@in[14 + inpos] & 134217727) >> (27 - 21))
-                                | ((@in[15 + inpos]) << 21);
-            @out[13 + outpos] = (int)(((uint)@in[15 + inpos] & 134217727) >> (27 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[14 + outpos] = (int)(((uint)@in[16 + inpos] & 134217727) >> (27 - 11))
-                                | ((@in[17 + inpos]) << 11);
-            @out[15 + outpos] = (int)(((uint)@in[17 + inpos] & 134217727) >> (27 - 6))
-                                | ((@in[18 + inpos]) << 6);
-            @out[16 + outpos] = (int)(((uint)@in[18 + inpos] & 134217727) >> (27 - 1))
-                                | ((@in[19 + inpos] & 134217727) << 1)
-                                | ((@in[20 + inpos]) << 28);
-            @out[17 + outpos] = (int)(((uint)@in[20 + inpos] & 134217727) >> (27 - 23))
-                                | ((@in[21 + inpos]) << 23);
-            @out[18 + outpos] = (int)(((uint)@in[21 + inpos] & 134217727) >> (27 - 18))
-                                | ((@in[22 + inpos]) << 18);
-            @out[19 + outpos] = (int)(((uint)@in[22 + inpos] & 134217727) >> (27 - 13))
-                                | ((@in[23 + inpos]) << 13);
-            @out[20 + outpos] = (int)(((uint)@in[23 + inpos] & 134217727) >> (27 - 8))
-                                | ((@in[24 + inpos]) << 8);
-            @out[21 + outpos] = (int)(((uint)@in[24 + inpos] & 134217727) >> (27 - 3))
-                                | ((@in[25 + inpos] & 134217727) << 3)
-                                | ((@in[26 + inpos]) << 30);
-            @out[22 + outpos] = (int)(((uint)@in[26 + inpos] & 134217727) >> (27 - 25))
-                                | ((@in[27 + inpos]) << 25);
-            @out[23 + outpos] = (int)(((uint)@in[27 + inpos] & 134217727) >> (27 - 20))
-                                | ((@in[28 + inpos]) << 20);
-            @out[24 + outpos] = (int)(((uint)@in[28 + inpos] & 134217727) >> (27 - 15))
-                                | ((@in[29 + inpos]) << 15);
-            @out[25 + outpos] = (int)(((uint)@in[29 + inpos] & 134217727) >> (27 - 10))
-                                | ((@in[30 + inpos]) << 10);
-            @out[26 + outpos] = (int)(((uint)@in[30 + inpos] & 134217727) >> (27 - 5))
-                                | ((@in[31 + inpos]) << 5);
-        }
-
-        protected static void fastpack28(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 268435455)
-                               | ((@in[1 + inpos]) << 28);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 268435455) >> (28 - 24))
-                               | ((@in[2 + inpos]) << 24);
-            @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 268435455) >> (28 - 20))
-                               | ((@in[3 + inpos]) << 20);
-            @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 268435455) >> (28 - 16))
-                               | ((@in[4 + inpos]) << 16);
-            @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 268435455) >> (28 - 12))
-                               | ((@in[5 + inpos]) << 12);
-            @out[5 + outpos] = (int)(((uint)@in[5 + inpos] & 268435455) >> (28 - 8))
-                               | ((@in[6 + inpos]) << 8);
-            @out[6 + outpos] = (int)(((uint)@in[6 + inpos] & 268435455) >> (28 - 4))
-                               | ((@in[7 + inpos]) << 4);
-            @out[7 + outpos] = (@in[8 + inpos] & 268435455)
-                               | ((@in[9 + inpos]) << 28);
-            @out[8 + outpos] = (int)(((uint)@in[9 + inpos] & 268435455) >> (28 - 24))
-                               | ((@in[10 + inpos]) << 24);
-            @out[9 + outpos] = (int)(((uint)@in[10 + inpos] & 268435455) >> (28 - 20))
-                               | ((@in[11 + inpos]) << 20);
-            @out[10 + outpos] = (int)(((uint)@in[11 + inpos] & 268435455) >> (28 - 16))
-                                | ((@in[12 + inpos]) << 16);
-            @out[11 + outpos] = (int)(((uint)@in[12 + inpos] & 268435455) >> (28 - 12))
-                                | ((@in[13 + inpos]) << 12);
-            @out[12 + outpos] = (int)(((uint)@in[13 + inpos] & 268435455) >> (28 - 8))
-                                | ((@in[14 + inpos]) << 8);
-            @out[13 + outpos] = (int)(((uint)@in[14 + inpos] & 268435455) >> (28 - 4))
-                                | ((@in[15 + inpos]) << 4);
-            @out[14 + outpos] = (@in[16 + inpos] & 268435455)
-                                | ((@in[17 + inpos]) << 28);
-            @out[15 + outpos] = (int)(((uint)@in[17 + inpos] & 268435455) >> (28 - 24))
-                                | ((@in[18 + inpos]) << 24);
-            @out[16 + outpos] = (int)(((uint)@in[18 + inpos] & 268435455) >> (28 - 20))
-                                | ((@in[19 + inpos]) << 20);
-            @out[17 + outpos] = (int)(((uint)@in[19 + inpos] & 268435455) >> (28 - 16))
-                                | ((@in[20 + inpos]) << 16);
-            @out[18 + outpos] = (int)(((uint)@in[20 + inpos] & 268435455) >> (28 - 12))
-                                | ((@in[21 + inpos]) << 12);
-            @out[19 + outpos] = (int)(((uint)@in[21 + inpos] & 268435455) >> (28 - 8))
-                                | ((@in[22 + inpos]) << 8);
-            @out[20 + outpos] = (int)(((uint)@in[22 + inpos] & 268435455) >> (28 - 4))
-                                | ((@in[23 + inpos]) << 4);
-            @out[21 + outpos] = (@in[24 + inpos] & 268435455)
-                                | ((@in[25 + inpos]) << 28);
-            @out[22 + outpos] = (int)(((uint)@in[25 + inpos] & 268435455) >> (28 - 24))
-                                | ((@in[26 + inpos]) << 24);
-            @out[23 + outpos] = (int)(((uint)@in[26 + inpos] & 268435455) >> (28 - 20))
-                                | ((@in[27 + inpos]) << 20);
-            @out[24 + outpos] = (int)(((uint)@in[27 + inpos] & 268435455) >> (28 - 16))
-                                | ((@in[28 + inpos]) << 16);
-            @out[25 + outpos] = (int)(((uint)@in[28 + inpos] & 268435455) >> (28 - 12))
-                                | ((@in[29 + inpos]) << 12);
-            @out[26 + outpos] = (int)(((uint)@in[29 + inpos] & 268435455) >> (28 - 8))
-                                | ((@in[30 + inpos]) << 8);
-            @out[27 + outpos] = (int)(((uint)@in[30 + inpos] & 268435455) >> (28 - 4))
-                                | ((@in[31 + inpos]) << 4);
-        }
-
-        protected static void fastpack29(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 536870911)
-                               | ((@in[1 + inpos]) << 29);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 536870911) >> (29 - 26))
-                               | ((@in[2 + inpos]) << 26);
-            @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 536870911) >> (29 - 23))
-                               | ((@in[3 + inpos]) << 23);
-            @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 536870911) >> (29 - 20))
-                               | ((@in[4 + inpos]) << 20);
-            @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 536870911) >> (29 - 17))
-                               | ((@in[5 + inpos]) << 17);
-            @out[5 + outpos] = (int)(((uint)@in[5 + inpos] & 536870911) >> (29 - 14))
-                               | ((@in[6 + inpos]) << 14);
-            @out[6 + outpos] = (int)(((uint)@in[6 + inpos] & 536870911) >> (29 - 11))
-                               | ((@in[7 + inpos]) << 11);
-            @out[7 + outpos] = (int)(((uint)@in[7 + inpos] & 536870911) >> (29 - 8))
-                               | ((@in[8 + inpos]) << 8);
-            @out[8 + outpos] = (int)(((uint)@in[8 + inpos] & 536870911) >> (29 - 5))
-                               | ((@in[9 + inpos]) << 5);
-            @out[9 + outpos] = (int)(((uint)@in[9 + inpos] & 536870911) >> (29 - 2))
-                               | ((@in[10 + inpos] & 536870911) << 2)
-                               | ((@in[11 + inpos]) << 31);
-            @out[10 + outpos] = (int)(((uint)@in[11 + inpos] & 536870911) >> (29 - 28))
-                                | ((@in[12 + inpos]) << 28);
-            @out[11 + outpos] = (int)(((uint)@in[12 + inpos] & 536870911) >> (29 - 25))
-                                | ((@in[13 + inpos]) << 25);
-            @out[12 + outpos] = (int)(((uint)@in[13 + inpos] & 536870911) >> (29 - 22))
-                                | ((@in[14 + inpos]) << 22);
-            @out[13 + outpos] = (int)(((uint)@in[14 + inpos] & 536870911) >> (29 - 19))
-                                | ((@in[15 + inpos]) << 19);
-            @out[14 + outpos] = (int)(((uint)@in[15 + inpos] & 536870911) >> (29 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[15 + outpos] = (int)(((uint)@in[16 + inpos] & 536870911) >> (29 - 13))
-                                | ((@in[17 + inpos]) << 13);
-            @out[16 + outpos] = (int)(((uint)@in[17 + inpos] & 536870911) >> (29 - 10))
-                                | ((@in[18 + inpos]) << 10);
-            @out[17 + outpos] = (int)(((uint)@in[18 + inpos] & 536870911) >> (29 - 7))
-                                | ((@in[19 + inpos]) << 7);
-            @out[18 + outpos] = (int)(((uint)@in[19 + inpos] & 536870911) >> (29 - 4))
-                                | ((@in[20 + inpos]) << 4);
-            @out[19 + outpos] = (int)(((uint)@in[20 + inpos] & 536870911) >> (29 - 1))
-                                | ((@in[21 + inpos] & 536870911) << 1)
-                                | ((@in[22 + inpos]) << 30);
-            @out[20 + outpos] = (int)(((uint)@in[22 + inpos] & 536870911) >> (29 - 27))
-                                | ((@in[23 + inpos]) << 27);
-            @out[21 + outpos] = (int)(((uint)@in[23 + inpos] & 536870911) >> (29 - 24))
-                                | ((@in[24 + inpos]) << 24);
-            @out[22 + outpos] = (int)(((uint)@in[24 + inpos] & 536870911) >> (29 - 21))
-                                | ((@in[25 + inpos]) << 21);
-            @out[23 + outpos] = (int)(((uint)@in[25 + inpos] & 536870911) >> (29 - 18))
-                                | ((@in[26 + inpos]) << 18);
-            @out[24 + outpos] = (int)(((uint)@in[26 + inpos] & 536870911) >> (29 - 15))
-                                | ((@in[27 + inpos]) << 15);
-            @out[25 + outpos] = (int)(((uint)@in[27 + inpos] & 536870911) >> (29 - 12))
-                                | ((@in[28 + inpos]) << 12);
-            @out[26 + outpos] = (int)(((uint)@in[28 + inpos] & 536870911) >> (29 - 9))
-                                | ((@in[29 + inpos]) << 9);
-            @out[27 + outpos] = (int)(((uint)@in[29 + inpos] & 536870911) >> (29 - 6))
-                                | ((@in[30 + inpos]) << 6);
-            @out[28 + outpos] = (int)(((uint)@in[30 + inpos] & 536870911) >> (29 - 3))
-                                | ((@in[31 + inpos]) << 3);
-        }
-
-        protected static void fastpack3(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 7)
-                               | ((@in[1 + inpos] & 7) << 3)
-                               | ((@in[2 + inpos] & 7) << 6)
-                               | ((@in[3 + inpos] & 7) << 9)
-                               | ((@in[4 + inpos] & 7) << 12)
-                               | ((@in[5 + inpos] & 7) << 15)
-                               | ((@in[6 + inpos] & 7) << 18)
-                               | ((@in[7 + inpos] & 7) << 21)
-                               | ((@in[8 + inpos] & 7) << 24)
-                               | ((@in[9 + inpos] & 7) << 27)
-                               | ((@in[10 + inpos]) << 30);
-            @out[1 + outpos] = (int)(((uint)@in[10 + inpos] & 7) >> (3 - 1))
-                               | ((@in[11 + inpos] & 7) << 1)
-                               | ((@in[12 + inpos] & 7) << 4)
-                               | ((@in[13 + inpos] & 7) << 7)
-                               | ((@in[14 + inpos] & 7) << 10)
-                               | ((@in[15 + inpos] & 7) << 13)
-                               | ((@in[16 + inpos] & 7) << 16)
-                               | ((@in[17 + inpos] & 7) << 19)
-                               | ((@in[18 + inpos] & 7) << 22)
-                               | ((@in[19 + inpos] & 7) << 25)
-                               | ((@in[20 + inpos] & 7) << 28)
-                               | ((@in[21 + inpos]) << 31);
-            @out[2 + outpos] = (int)(((uint)@in[21 + inpos] & 7) >> (3 - 2))
-                               | ((@in[22 + inpos] & 7) << 2)
-                               | ((@in[23 + inpos] & 7) << 5)
-                               | ((@in[24 + inpos] & 7) << 8)
-                               | ((@in[25 + inpos] & 7) << 11)
-                               | ((@in[26 + inpos] & 7) << 14)
-                               | ((@in[27 + inpos] & 7) << 17)
-                               | ((@in[28 + inpos] & 7) << 20)
-                               | ((@in[29 + inpos] & 7) << 23)
-                               | ((@in[30 + inpos] & 7) << 26)
-                               | ((@in[31 + inpos]) << 29);
-        }
-
-        protected static void fastpack30(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 1073741823)
-                               | ((@in[1 + inpos]) << 30);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 1073741823) >> (30 - 28))
-                               | ((@in[2 + inpos]) << 28);
-            @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 1073741823) >> (30 - 26))
-                               | ((@in[3 + inpos]) << 26);
-            @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 1073741823) >> (30 - 24))
-                               | ((@in[4 + inpos]) << 24);
-            @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 1073741823) >> (30 - 22))
-                               | ((@in[5 + inpos]) << 22);
-            @out[5 + outpos] = (int)(((uint)@in[5 + inpos] & 1073741823) >> (30 - 20))
-                               | ((@in[6 + inpos]) << 20);
-            @out[6 + outpos] = (int)(((uint)@in[6 + inpos] & 1073741823) >> (30 - 18))
-                               | ((@in[7 + inpos]) << 18);
-            @out[7 + outpos] = (int)(((uint)@in[7 + inpos] & 1073741823) >> (30 - 16))
-                               | ((@in[8 + inpos]) << 16);
-            @out[8 + outpos] = (int)(((uint)@in[8 + inpos] & 1073741823) >> (30 - 14))
-                               | ((@in[9 + inpos]) << 14);
-            @out[9 + outpos] = (int)(((uint)@in[9 + inpos] & 1073741823) >> (30 - 12))
-                               | ((@in[10 + inpos]) << 12);
-            @out[10 + outpos] = (int)(((uint)@in[10 + inpos] & 1073741823) >> (30 - 10))
-                                | ((@in[11 + inpos]) << 10);
-            @out[11 + outpos] = (int)(((uint)@in[11 + inpos] & 1073741823) >> (30 - 8))
-                                | ((@in[12 + inpos]) << 8);
-            @out[12 + outpos] = (int)(((uint)@in[12 + inpos] & 1073741823) >> (30 - 6))
-                                | ((@in[13 + inpos]) << 6);
-            @out[13 + outpos] = (int)(((uint)@in[13 + inpos] & 1073741823) >> (30 - 4))
-                                | ((@in[14 + inpos]) << 4);
-            @out[14 + outpos] = (int)(((uint)@in[14 + inpos] & 1073741823) >> (30 - 2))
-                                | ((@in[15 + inpos]) << 2);
-            @out[15 + outpos] = (@in[16 + inpos] & 1073741823)
-                                | ((@in[17 + inpos]) << 30);
-            @out[16 + outpos] = (int)(((uint)@in[17 + inpos] & 1073741823) >> (30 - 28))
-                                | ((@in[18 + inpos]) << 28);
-            @out[17 + outpos] = (int)(((uint)@in[18 + inpos] & 1073741823) >> (30 - 26))
-                                | ((@in[19 + inpos]) << 26);
-            @out[18 + outpos] = (int)(((uint)@in[19 + inpos] & 1073741823) >> (30 - 24))
-                                | ((@in[20 + inpos]) << 24);
-            @out[19 + outpos] = (int)(((uint)@in[20 + inpos] & 1073741823) >> (30 - 22))
-                                | ((@in[21 + inpos]) << 22);
-            @out[20 + outpos] = (int)(((uint)@in[21 + inpos] & 1073741823) >> (30 - 20))
-                                | ((@in[22 + inpos]) << 20);
-            @out[21 + outpos] = (int)(((uint)@in[22 + inpos] & 1073741823) >> (30 - 18))
-                                | ((@in[23 + inpos]) << 18);
-            @out[22 + outpos] = (int)(((uint)@in[23 + inpos] & 1073741823) >> (30 - 16))
-                                | ((@in[24 + inpos]) << 16);
-            @out[23 + outpos] = (int)(((uint)@in[24 + inpos] & 1073741823) >> (30 - 14))
-                                | ((@in[25 + inpos]) << 14);
-            @out[24 + outpos] = (int)(((uint)@in[25 + inpos] & 1073741823) >> (30 - 12))
-                                | ((@in[26 + inpos]) << 12);
-            @out[25 + outpos] = (int)(((uint)@in[26 + inpos] & 1073741823) >> (30 - 10))
-                                | ((@in[27 + inpos]) << 10);
-            @out[26 + outpos] = (int)(((uint)@in[27 + inpos] & 1073741823) >> (30 - 8))
-                                | ((@in[28 + inpos]) << 8);
-            @out[27 + outpos] = (int)(((uint)@in[28 + inpos] & 1073741823) >> (30 - 6))
-                                | ((@in[29 + inpos]) << 6);
-            @out[28 + outpos] = (int)(((uint)@in[29 + inpos] & 1073741823) >> (30 - 4))
-                                | ((@in[30 + inpos]) << 4);
-            @out[29 + outpos] = (int)(((uint)@in[30 + inpos] & 1073741823) >> (30 - 2))
-                                | ((@in[31 + inpos]) << 2);
-        }
-
-        protected static void fastpack31(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 2147483647)
-                               | ((@in[1 + inpos]) << 31);
-            @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 2147483647) >> (31 - 30))
-                               | ((@in[2 + inpos]) << 30);
-            @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 2147483647) >> (31 - 29))
-                               | ((@in[3 + inpos]) << 29);
-            @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 2147483647) >> (31 - 28))
-                               | ((@in[4 + inpos]) << 28);
-            @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 2147483647) >> (31 - 27))
-                               | ((@in[5 + inpos]) << 27);
-            @out[5 + outpos] = (int)(((uint)@in[5 + inpos] & 2147483647) >> (31 - 26))
-                               | ((@in[6 + inpos]) << 26);
-            @out[6 + outpos] = (int)(((uint)@in[6 + inpos] & 2147483647) >> (31 - 25))
-                               | ((@in[7 + inpos]) << 25);
-            @out[7 + outpos] = (int)(((uint)@in[7 + inpos] & 2147483647) >> (31 - 24))
-                               | ((@in[8 + inpos]) << 24);
-            @out[8 + outpos] = (int)(((uint)@in[8 + inpos] & 2147483647) >> (31 - 23))
-                               | ((@in[9 + inpos]) << 23);
-            @out[9 + outpos] = (int)(((uint)@in[9 + inpos] & 2147483647) >> (31 - 22))
-                               | ((@in[10 + inpos]) << 22);
-            @out[10 + outpos] = (int)(((uint)@in[10 + inpos] & 2147483647) >> (31 - 21))
-                                | ((@in[11 + inpos]) << 21);
-            @out[11 + outpos] = (int)(((uint)@in[11 + inpos] & 2147483647) >> (31 - 20))
-                                | ((@in[12 + inpos]) << 20);
-            @out[12 + outpos] = (int)(((uint)@in[12 + inpos] & 2147483647) >> (31 - 19))
-                                | ((@in[13 + inpos]) << 19);
-            @out[13 + outpos] = (int)(((uint)@in[13 + inpos] & 2147483647) >> (31 - 18))
-                                | ((@in[14 + inpos]) << 18);
-            @out[14 + outpos] = (int)(((uint)@in[14 + inpos] & 2147483647) >> (31 - 17))
-                                | ((@in[15 + inpos]) << 17);
-            @out[15 + outpos] = (int)(((uint)@in[15 + inpos] & 2147483647) >> (31 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[16 + outpos] = (int)(((uint)@in[16 + inpos] & 2147483647) >> (31 - 15))
-                                | ((@in[17 + inpos]) << 15);
-            @out[17 + outpos] = (int)(((uint)@in[17 + inpos] & 2147483647) >> (31 - 14))
-                                | ((@in[18 + inpos]) << 14);
-            @out[18 + outpos] = (int)(((uint)@in[18 + inpos] & 2147483647) >> (31 - 13))
-                                | ((@in[19 + inpos]) << 13);
-            @out[19 + outpos] = (int)(((uint)@in[19 + inpos] & 2147483647) >> (31 - 12))
-                                | ((@in[20 + inpos]) << 12);
-            @out[20 + outpos] = (int)(((uint)@in[20 + inpos] & 2147483647) >> (31 - 11))
-                                | ((@in[21 + inpos]) << 11);
-            @out[21 + outpos] = (int)(((uint)@in[21 + inpos] & 2147483647) >> (31 - 10))
-                                | ((@in[22 + inpos]) << 10);
-            @out[22 + outpos] = (int)(((uint)@in[22 + inpos] & 2147483647) >> (31 - 9))
-                                | ((@in[23 + inpos]) << 9);
-            @out[23 + outpos] = (int)(((uint)@in[23 + inpos] & 2147483647) >> (31 - 8))
-                                | ((@in[24 + inpos]) << 8);
-            @out[24 + outpos] = (int)(((uint)@in[24 + inpos] & 2147483647) >> (31 - 7))
-                                | ((@in[25 + inpos]) << 7);
-            @out[25 + outpos] = (int)(((uint)@in[25 + inpos] & 2147483647) >> (31 - 6))
-                                | ((@in[26 + inpos]) << 6);
-            @out[26 + outpos] = (int)(((uint)@in[26 + inpos] & 2147483647) >> (31 - 5))
-                                | ((@in[27 + inpos]) << 5);
-            @out[27 + outpos] = (int)(((uint)@in[27 + inpos] & 2147483647) >> (31 - 4))
-                                | ((@in[28 + inpos]) << 4);
-            @out[28 + outpos] = (int)(((uint)@in[28 + inpos] & 2147483647) >> (31 - 3))
-                                | ((@in[29 + inpos]) << 3);
-            @out[29 + outpos] = (int)(((uint)@in[29 + inpos] & 2147483647) >> (31 - 2))
-                                | ((@in[30 + inpos]) << 2);
-            @out[30 + outpos] = (int)(((uint)@in[30 + inpos] & 2147483647) >> (31 - 1))
-                                | ((@in[31 + inpos]) << 1);
-        }
-
-        protected static void fastpack32(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            Array.Copy(@in, inpos, @out, outpos, 32);
-        }
-
-        protected static void fastpack4(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 15)
-                               | ((@in[1 + inpos] & 15) << 4)
-                               | ((@in[2 + inpos] & 15) << 8)
-                               | ((@in[3 + inpos] & 15) << 12)
-                               | ((@in[4 + inpos] & 15) << 16)
-                               | ((@in[5 + inpos] & 15) << 20)
-                               | ((@in[6 + inpos] & 15) << 24)
-                               | ((@in[7 + inpos]) << 28);
-            @out[1 + outpos] = (@in[8 + inpos] & 15)
-                               | ((@in[9 + inpos] & 15) << 4)
-                               | ((@in[10 + inpos] & 15) << 8)
-                               | ((@in[11 + inpos] & 15) << 12)
-                               | ((@in[12 + inpos] & 15) << 16)
-                               | ((@in[13 + inpos] & 15) << 20)
-                               | ((@in[14 + inpos] & 15) << 24)
-                               | ((@in[15 + inpos]) << 28);
-            @out[2 + outpos] = (@in[16 + inpos] & 15)
-                               | ((@in[17 + inpos] & 15) << 4)
-                               | ((@in[18 + inpos] & 15) << 8)
-                               | ((@in[19 + inpos] & 15) << 12)
-                               | ((@in[20 + inpos] & 15) << 16)
-                               | ((@in[21 + inpos] & 15) << 20)
-                               | ((@in[22 + inpos] & 15) << 24)
-                               | ((@in[23 + inpos]) << 28);
-            @out[3 + outpos] = (@in[24 + inpos] & 15)
-                               | ((@in[25 + inpos] & 15) << 4)
-                               | ((@in[26 + inpos] & 15) << 8)
-                               | ((@in[27 + inpos] & 15) << 12)
-                               | ((@in[28 + inpos] & 15) << 16)
-                               | ((@in[29 + inpos] & 15) << 20)
-                               | ((@in[30 + inpos] & 15) << 24)
-                               | ((@in[31 + inpos]) << 28);
-        }
-
-        protected static void fastpack5(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 31)
-                               | ((@in[1 + inpos] & 31) << 5)
-                               | ((@in[2 + inpos] & 31) << 10)
-                               | ((@in[3 + inpos] & 31) << 15)
-                               | ((@in[4 + inpos] & 31) << 20)
-                               | ((@in[5 + inpos] & 31) << 25)
-                               | ((@in[6 + inpos]) << 30);
-            @out[1 + outpos] = (int)(((uint)@in[6 + inpos] & 31) >> (5 - 3))
-                               | ((@in[7 + inpos] & 31) << 3)
-                               | ((@in[8 + inpos] & 31) << 8)
-                               | ((@in[9 + inpos] & 31) << 13)
-                               | ((@in[10 + inpos] & 31) << 18)
-                               | ((@in[11 + inpos] & 31) << 23)
-                               | ((@in[12 + inpos]) << 28);
-            @out[2 + outpos] = (int)(((uint)@in[12 + inpos] & 31) >> (5 - 1))
-                               | ((@in[13 + inpos] & 31) << 1)
-                               | ((@in[14 + inpos] & 31) << 6)
-                               | ((@in[15 + inpos] & 31) << 11)
-                               | ((@in[16 + inpos] & 31) << 16)
-                               | ((@in[17 + inpos] & 31) << 21)
-                               | ((@in[18 + inpos] & 31) << 26)
-                               | ((@in[19 + inpos]) << 31);
-            @out[3 + outpos] = (int)(((uint)@in[19 + inpos] & 31) >> (5 - 4))
-                               | ((@in[20 + inpos] & 31) << 4)
-                               | ((@in[21 + inpos] & 31) << 9)
-                               | ((@in[22 + inpos] & 31) << 14)
-                               | ((@in[23 + inpos] & 31) << 19)
-                               | ((@in[24 + inpos] & 31) << 24)
-                               | ((@in[25 + inpos]) << 29);
-            @out[4 + outpos] = (int)(((uint)@in[25 + inpos] & 31) >> (5 - 2))
-                               | ((@in[26 + inpos] & 31) << 2)
-                               | ((@in[27 + inpos] & 31) << 7)
-                               | ((@in[28 + inpos] & 31) << 12)
-                               | ((@in[29 + inpos] & 31) << 17)
-                               | ((@in[30 + inpos] & 31) << 22)
-                               | ((@in[31 + inpos]) << 27);
-        }
-
-        protected static void fastpack6(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 63)
-                               | ((@in[1 + inpos] & 63) << 6)
-                               | ((@in[2 + inpos] & 63) << 12)
-                               | ((@in[3 + inpos] & 63) << 18)
-                               | ((@in[4 + inpos] & 63) << 24)
-                               | ((@in[5 + inpos]) << 30);
-            @out[1 + outpos] = (int)(((uint)@in[5 + inpos] & 63) >> (6 - 4))
-                               | ((@in[6 + inpos] & 63) << 4)
-                               | ((@in[7 + inpos] & 63) << 10)
-                               | ((@in[8 + inpos] & 63) << 16)
-                               | ((@in[9 + inpos] & 63) << 22)
-                               | ((@in[10 + inpos]) << 28);
-            @out[2 + outpos] = (int)(((uint)@in[10 + inpos] & 63) >> (6 - 2))
-                               | ((@in[11 + inpos] & 63) << 2)
-                               | ((@in[12 + inpos] & 63) << 8)
-                               | ((@in[13 + inpos] & 63) << 14)
-                               | ((@in[14 + inpos] & 63) << 20)
-                               | ((@in[15 + inpos]) << 26);
-            @out[3 + outpos] = (@in[16 + inpos] & 63)
-                               | ((@in[17 + inpos] & 63) << 6)
-                               | ((@in[18 + inpos] & 63) << 12)
-                               | ((@in[19 + inpos] & 63) << 18)
-                               | ((@in[20 + inpos] & 63) << 24)
-                               | ((@in[21 + inpos]) << 30);
-            @out[4 + outpos] = (int)(((uint)@in[21 + inpos] & 63) >> (6 - 4))
-                               | ((@in[22 + inpos] & 63) << 4)
-                               | ((@in[23 + inpos] & 63) << 10)
-                               | ((@in[24 + inpos] & 63) << 16)
-                               | ((@in[25 + inpos] & 63) << 22)
-                               | ((@in[26 + inpos]) << 28);
-            @out[5 + outpos] = (int)(((uint)@in[26 + inpos] & 63) >> (6 - 2))
-                               | ((@in[27 + inpos] & 63) << 2)
-                               | ((@in[28 + inpos] & 63) << 8)
-                               | ((@in[29 + inpos] & 63) << 14)
-                               | ((@in[30 + inpos] & 63) << 20)
-                               | ((@in[31 + inpos]) << 26);
-        }
-
-        protected static void fastpack7(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 127)
-                               | ((@in[1 + inpos] & 127) << 7)
-                               | ((@in[2 + inpos] & 127) << 14)
-                               | ((@in[3 + inpos] & 127) << 21)
-                               | ((@in[4 + inpos]) << 28);
-            @out[1 + outpos] = (int)(((uint)@in[4 + inpos] & 127) >> (7 - 3))
-                               | ((@in[5 + inpos] & 127) << 3)
-                               | ((@in[6 + inpos] & 127) << 10)
-                               | ((@in[7 + inpos] & 127) << 17)
-                               | ((@in[8 + inpos] & 127) << 24)
-                               | ((@in[9 + inpos]) << 31);
-            @out[2 + outpos] = (int)(((uint)@in[9 + inpos] & 127) >> (7 - 6))
-                               | ((@in[10 + inpos] & 127) << 6)
-                               | ((@in[11 + inpos] & 127) << 13)
-                               | ((@in[12 + inpos] & 127) << 20)
-                               | ((@in[13 + inpos]) << 27);
-            @out[3 + outpos] = (int)(((uint)@in[13 + inpos] & 127) >> (7 - 2))
-                               | ((@in[14 + inpos] & 127) << 2)
-                               | ((@in[15 + inpos] & 127) << 9)
-                               | ((@in[16 + inpos] & 127) << 16)
-                               | ((@in[17 + inpos] & 127) << 23)
-                               | ((@in[18 + inpos]) << 30);
-            @out[4 + outpos] = (int)(((uint)@in[18 + inpos] & 127) >> (7 - 5))
-                               | ((@in[19 + inpos] & 127) << 5)
-                               | ((@in[20 + inpos] & 127) << 12)
-                               | ((@in[21 + inpos] & 127) << 19)
-                               | ((@in[22 + inpos]) << 26);
-            @out[5 + outpos] = (int)(((uint)@in[22 + inpos] & 127) >> (7 - 1))
-                               | ((@in[23 + inpos] & 127) << 1)
-                               | ((@in[24 + inpos] & 127) << 8)
-                               | ((@in[25 + inpos] & 127) << 15)
-                               | ((@in[26 + inpos] & 127) << 22)
-                               | ((@in[27 + inpos]) << 29);
-            @out[6 + outpos] = (int)(((uint)@in[27 + inpos] & 127) >> (7 - 4))
-                               | ((@in[28 + inpos] & 127) << 4)
-                               | ((@in[29 + inpos] & 127) << 11)
-                               | ((@in[30 + inpos] & 127) << 18)
-                               | ((@in[31 + inpos]) << 25);
-        }
-
-        protected static void fastpack8(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 255)
-                               | ((@in[1 + inpos] & 255) << 8)
-                               | ((@in[2 + inpos] & 255) << 16)
-                               | ((@in[3 + inpos]) << 24);
-            @out[1 + outpos] = (@in[4 + inpos] & 255)
-                               | ((@in[5 + inpos] & 255) << 8)
-                               | ((@in[6 + inpos] & 255) << 16)
-                               | ((@in[7 + inpos]) << 24);
-            @out[2 + outpos] = (@in[8 + inpos] & 255)
-                               | ((@in[9 + inpos] & 255) << 8)
-                               | ((@in[10 + inpos] & 255) << 16)
-                               | ((@in[11 + inpos]) << 24);
-            @out[3 + outpos] = (@in[12 + inpos] & 255)
-                               | ((@in[13 + inpos] & 255) << 8)
-                               | ((@in[14 + inpos] & 255) << 16)
-                               | ((@in[15 + inpos]) << 24);
-            @out[4 + outpos] = (@in[16 + inpos] & 255)
-                               | ((@in[17 + inpos] & 255) << 8)
-                               | ((@in[18 + inpos] & 255) << 16)
-                               | ((@in[19 + inpos]) << 24);
-            @out[5 + outpos] = (@in[20 + inpos] & 255)
-                               | ((@in[21 + inpos] & 255) << 8)
-                               | ((@in[22 + inpos] & 255) << 16)
-                               | ((@in[23 + inpos]) << 24);
-            @out[6 + outpos] = (@in[24 + inpos] & 255)
-                               | ((@in[25 + inpos] & 255) << 8)
-                               | ((@in[26 + inpos] & 255) << 16)
-                               | ((@in[27 + inpos]) << 24);
-            @out[7 + outpos] = (@in[28 + inpos] & 255)
-                               | ((@in[29 + inpos] & 255) << 8)
-                               | ((@in[30 + inpos] & 255) << 16)
-                               | ((@in[31 + inpos]) << 24);
-        }
-
-        protected static void fastpack9(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] & 511)
-                               | ((@in[1 + inpos] & 511) << 9)
-                               | ((@in[2 + inpos] & 511) << 18)
-                               | ((@in[3 + inpos]) << 27);
-            @out[1 + outpos] = (int)(((uint)@in[3 + inpos] & 511) >> (9 - 4))
-                               | ((@in[4 + inpos] & 511) << 4)
-                               | ((@in[5 + inpos] & 511) << 13)
-                               | ((@in[6 + inpos] & 511) << 22)
-                               | ((@in[7 + inpos]) << 31);
-            @out[2 + outpos] = (int)(((uint)@in[7 + inpos] & 511) >> (9 - 8))
-                               | ((@in[8 + inpos] & 511) << 8)
-                               | ((@in[9 + inpos] & 511) << 17)
-                               | ((@in[10 + inpos]) << 26);
-            @out[3 + outpos] = (int)(((uint)@in[10 + inpos] & 511) >> (9 - 3))
-                               | ((@in[11 + inpos] & 511) << 3)
-                               | ((@in[12 + inpos] & 511) << 12)
-                               | ((@in[13 + inpos] & 511) << 21)
-                               | ((@in[14 + inpos]) << 30);
-            @out[4 + outpos] = (int)(((uint)@in[14 + inpos] & 511) >> (9 - 7))
-                               | ((@in[15 + inpos] & 511) << 7)
-                               | ((@in[16 + inpos] & 511) << 16)
-                               | ((@in[17 + inpos]) << 25);
-            @out[5 + outpos] = (int)(((uint)@in[17 + inpos] & 511) >> (9 - 2))
-                               | ((@in[18 + inpos] & 511) << 2)
-                               | ((@in[19 + inpos] & 511) << 11)
-                               | ((@in[20 + inpos] & 511) << 20)
-                               | ((@in[21 + inpos]) << 29);
-            @out[6 + outpos] = (int)(((uint)@in[21 + inpos] & 511) >> (9 - 6))
-                               | ((@in[22 + inpos] & 511) << 6)
-                               | ((@in[23 + inpos] & 511) << 15)
-                               | ((@in[24 + inpos]) << 24);
-            @out[7 + outpos] = (int)(((uint)@in[24 + inpos] & 511) >> (9 - 1))
-                               | ((@in[25 + inpos] & 511) << 1)
-                               | ((@in[26 + inpos] & 511) << 10)
-                               | ((@in[27 + inpos] & 511) << 19)
-                               | ((@in[28 + inpos]) << 28);
-            @out[8 + outpos] = (int)(((uint)@in[28 + inpos] & 511) >> (9 - 5))
-                               | ((@in[29 + inpos] & 511) << 5)
-                               | ((@in[30 + inpos] & 511) << 14)
-                               | ((@in[31 + inpos]) << 23);
-        }
-
-        /**
-         * Unpack 32 integers
-         * 
-         * @param in
-         *                source array
-         * @param inpos
-         *                position in source array
-         * @param out
-         *                output array
-         * @param outpos
-         *                position in output array
-         * @param bit
-         *                number of bits to use per integer
-         */
-        public static void fastpackwithoutmask(int[] @in, int inpos, int[] @out, int outpos, int bit)
-        {
-            switch (bit)
-            {
-                case 0:
-                    fastpackwithoutmask0(@in, inpos, @out, outpos);
-                    break;
-                case 1:
-                    fastpackwithoutmask1(@in, inpos, @out, outpos);
-                    break;
-                case 2:
-                    fastpackwithoutmask2(@in, inpos, @out, outpos);
-                    break;
-                case 3:
-                    fastpackwithoutmask3(@in, inpos, @out, outpos);
-                    break;
-                case 4:
-                    fastpackwithoutmask4(@in, inpos, @out, outpos);
-                    break;
-                case 5:
-                    fastpackwithoutmask5(@in, inpos, @out, outpos);
-                    break;
-                case 6:
-                    fastpackwithoutmask6(@in, inpos, @out, outpos);
-                    break;
-                case 7:
-                    fastpackwithoutmask7(@in, inpos, @out, outpos);
-                    break;
-                case 8:
-                    fastpackwithoutmask8(@in, inpos, @out, outpos);
-                    break;
-                case 9:
-                    fastpackwithoutmask9(@in, inpos, @out, outpos);
-                    break;
-                case 10:
-                    fastpackwithoutmask10(@in, inpos, @out, outpos);
-                    break;
-                case 11:
-                    fastpackwithoutmask11(@in, inpos, @out, outpos);
-                    break;
-                case 12:
-                    fastpackwithoutmask12(@in, inpos, @out, outpos);
-                    break;
-                case 13:
-                    fastpackwithoutmask13(@in, inpos, @out, outpos);
-                    break;
-                case 14:
-                    fastpackwithoutmask14(@in, inpos, @out, outpos);
-                    break;
-                case 15:
-                    fastpackwithoutmask15(@in, inpos, @out, outpos);
-                    break;
-                case 16:
-                    fastpackwithoutmask16(@in, inpos, @out, outpos);
-                    break;
-                case 17:
-                    fastpackwithoutmask17(@in, inpos, @out, outpos);
-                    break;
-                case 18:
-                    fastpackwithoutmask18(@in, inpos, @out, outpos);
-                    break;
-                case 19:
-                    fastpackwithoutmask19(@in, inpos, @out, outpos);
-                    break;
-                case 20:
-                    fastpackwithoutmask20(@in, inpos, @out, outpos);
-                    break;
-                case 21:
-                    fastpackwithoutmask21(@in, inpos, @out, outpos);
-                    break;
-                case 22:
-                    fastpackwithoutmask22(@in, inpos, @out, outpos);
-                    break;
-                case 23:
-                    fastpackwithoutmask23(@in, inpos, @out, outpos);
-                    break;
-                case 24:
-                    fastpackwithoutmask24(@in, inpos, @out, outpos);
-                    break;
-                case 25:
-                    fastpackwithoutmask25(@in, inpos, @out, outpos);
-                    break;
-                case 26:
-                    fastpackwithoutmask26(@in, inpos, @out, outpos);
-                    break;
-                case 27:
-                    fastpackwithoutmask27(@in, inpos, @out, outpos);
-                    break;
-                case 28:
-                    fastpackwithoutmask28(@in, inpos, @out, outpos);
-                    break;
-                case 29:
-                    fastpackwithoutmask29(@in, inpos, @out, outpos);
-                    break;
-                case 30:
-                    fastpackwithoutmask30(@in, inpos, @out, outpos);
-                    break;
-                case 31:
-                    fastpackwithoutmask31(@in, inpos, @out, outpos);
-                    break;
-                case 32:
-                    fastpackwithoutmask32(@in, inpos, @out, outpos);
-                    break;
-                default:
-                    throw new ArgumentException(
-                        "Unsupported bit width.");
-            }
-        }
-
-        protected static void fastpackwithoutmask0(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            // nothing
-        }
-
-        protected static void fastpackwithoutmask1(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 1)
-                               | ((@in[2 + inpos]) << 2) | ((@in[3 + inpos]) << 3)
-                               | ((@in[4 + inpos]) << 4) | ((@in[5 + inpos]) << 5)
-                               | ((@in[6 + inpos]) << 6) | ((@in[7 + inpos]) << 7)
-                               | ((@in[8 + inpos]) << 8) | ((@in[9 + inpos]) << 9)
-                               | ((@in[10 + inpos]) << 10) | ((@in[11 + inpos]) << 11)
-                               | ((@in[12 + inpos]) << 12) | ((@in[13 + inpos]) << 13)
-                               | ((@in[14 + inpos]) << 14) | ((@in[15 + inpos]) << 15)
-                               | ((@in[16 + inpos]) << 16) | ((@in[17 + inpos]) << 17)
-                               | ((@in[18 + inpos]) << 18) | ((@in[19 + inpos]) << 19)
-                               | ((@in[20 + inpos]) << 20) | ((@in[21 + inpos]) << 21)
-                               | ((@in[22 + inpos]) << 22) | ((@in[23 + inpos]) << 23)
-                               | ((@in[24 + inpos]) << 24) | ((@in[25 + inpos]) << 25)
-                               | ((@in[26 + inpos]) << 26) | ((@in[27 + inpos]) << 27)
-                               | ((@in[28 + inpos]) << 28) | ((@in[29 + inpos]) << 29)
-                               | ((@in[30 + inpos]) << 30) | ((@in[31 + inpos]) << 31);
-        }
-
-        protected static void fastpackwithoutmask10(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 10)
-                               | ((@in[2 + inpos]) << 20) | ((@in[3 + inpos]) << 30);
-            @out[1 + outpos] = (int)((uint)(@in[3 + inpos]) >> (10 - 8))
-                               | ((@in[4 + inpos]) << 8) | ((@in[5 + inpos]) << 18)
-                               | ((@in[6 + inpos]) << 28);
-            @out[2 + outpos] = (int)((uint)(@in[6 + inpos]) >> (10 - 6))
-                               | ((@in[7 + inpos]) << 6) | ((@in[8 + inpos]) << 16)
-                               | ((@in[9 + inpos]) << 26);
-            @out[3 + outpos] = (int)((uint)(@in[9 + inpos]) >> (10 - 4))
-                               | ((@in[10 + inpos]) << 4) | ((@in[11 + inpos]) << 14)
-                               | ((@in[12 + inpos]) << 24);
-            @out[4 + outpos] = (int)((uint)(@in[12 + inpos]) >> (10 - 2))
-                               | ((@in[13 + inpos]) << 2) | ((@in[14 + inpos]) << 12)
-                               | ((@in[15 + inpos]) << 22);
-            @out[5 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 10)
-                               | ((@in[18 + inpos]) << 20) | ((@in[19 + inpos]) << 30);
-            @out[6 + outpos] = (int)((uint)(@in[19 + inpos]) >> (10 - 8))
-                               | ((@in[20 + inpos]) << 8) | ((@in[21 + inpos]) << 18)
-                               | ((@in[22 + inpos]) << 28);
-            @out[7 + outpos] = (int)((uint)(@in[22 + inpos]) >> (10 - 6))
-                               | ((@in[23 + inpos]) << 6) | ((@in[24 + inpos]) << 16)
-                               | ((@in[25 + inpos]) << 26);
-            @out[8 + outpos] = (int)((uint)(@in[25 + inpos]) >> (10 - 4))
-                               | ((@in[26 + inpos]) << 4) | ((@in[27 + inpos]) << 14)
-                               | ((@in[28 + inpos]) << 24);
-            @out[9 + outpos] = (int)((uint)(@in[28 + inpos]) >> (10 - 2))
-                               | ((@in[29 + inpos]) << 2) | ((@in[30 + inpos]) << 12)
-                               | ((@in[31 + inpos]) << 22);
-        }
-
-        protected static void fastpackwithoutmask11(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 11)
-                               | ((@in[2 + inpos]) << 22);
-            @out[1 + outpos] = (int)((uint)(@in[2 + inpos]) >> (11 - 1))
-                               | ((@in[3 + inpos]) << 1) | ((@in[4 + inpos]) << 12)
-                               | ((@in[5 + inpos]) << 23);
-            @out[2 + outpos] = (int)((uint)(@in[5 + inpos]) >> (11 - 2))
-                               | ((@in[6 + inpos]) << 2) | ((@in[7 + inpos]) << 13)
-                               | ((@in[8 + inpos]) << 24);
-            @out[3 + outpos] = (int)((uint)(@in[8 + inpos]) >> (11 - 3))
-                               | ((@in[9 + inpos]) << 3) | ((@in[10 + inpos]) << 14)
-                               | ((@in[11 + inpos]) << 25);
-            @out[4 + outpos] = (int)((uint)(@in[11 + inpos]) >> (11 - 4))
-                               | ((@in[12 + inpos]) << 4) | ((@in[13 + inpos]) << 15)
-                               | ((@in[14 + inpos]) << 26);
-            @out[5 + outpos] = (int)((uint)(@in[14 + inpos]) >> (11 - 5))
-                               | ((@in[15 + inpos]) << 5) | ((@in[16 + inpos]) << 16)
-                               | ((@in[17 + inpos]) << 27);
-            @out[6 + outpos] = (int)((uint)(@in[17 + inpos]) >> (11 - 6))
-                               | ((@in[18 + inpos]) << 6) | ((@in[19 + inpos]) << 17)
-                               | ((@in[20 + inpos]) << 28);
-            @out[7 + outpos] = (int)((uint)(@in[20 + inpos]) >> (11 - 7))
-                               | ((@in[21 + inpos]) << 7) | ((@in[22 + inpos]) << 18)
-                               | ((@in[23 + inpos]) << 29);
-            @out[8 + outpos] = (int)((uint)(@in[23 + inpos]) >> (11 - 8))
-                               | ((@in[24 + inpos]) << 8) | ((@in[25 + inpos]) << 19)
-                               | ((@in[26 + inpos]) << 30);
-            @out[9 + outpos] = (int)((uint)(@in[26 + inpos]) >> (11 - 9))
-                               | ((@in[27 + inpos]) << 9) | ((@in[28 + inpos]) << 20)
-                               | ((@in[29 + inpos]) << 31);
-            @out[10 + outpos] = (int)((uint)(@in[29 + inpos]) >> (11 - 10))
-                                | ((@in[30 + inpos]) << 10) | ((@in[31 + inpos]) << 21);
-        }
-
-        protected static void fastpackwithoutmask12(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 12)
-                               | ((@in[2 + inpos]) << 24);
-            @out[1 + outpos] = (int)((uint)(@in[2 + inpos]) >> (12 - 4))
-                               | ((@in[3 + inpos]) << 4) | ((@in[4 + inpos]) << 16)
-                               | ((@in[5 + inpos]) << 28);
-            @out[2 + outpos] = (int)((uint)(@in[5 + inpos]) >> (12 - 8))
-                               | ((@in[6 + inpos]) << 8) | ((@in[7 + inpos]) << 20);
-            @out[3 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 12)
-                               | ((@in[10 + inpos]) << 24);
-            @out[4 + outpos] = (int)((uint)(@in[10 + inpos]) >> (12 - 4))
-                               | ((@in[11 + inpos]) << 4) | ((@in[12 + inpos]) << 16)
-                               | ((@in[13 + inpos]) << 28);
-            @out[5 + outpos] = (int)((uint)(@in[13 + inpos]) >> (12 - 8))
-                               | ((@in[14 + inpos]) << 8) | ((@in[15 + inpos]) << 20);
-            @out[6 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 12)
-                               | ((@in[18 + inpos]) << 24);
-            @out[7 + outpos] = (int)((uint)(@in[18 + inpos]) >> (12 - 4))
-                               | ((@in[19 + inpos]) << 4) | ((@in[20 + inpos]) << 16)
-                               | ((@in[21 + inpos]) << 28);
-            @out[8 + outpos] = (int)((uint)(@in[21 + inpos]) >> (12 - 8))
-                               | ((@in[22 + inpos]) << 8) | ((@in[23 + inpos]) << 20);
-            @out[9 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 12)
-                               | ((@in[26 + inpos]) << 24);
-            @out[10 + outpos] = (int)((uint)(@in[26 + inpos]) >> (12 - 4))
-                                | ((@in[27 + inpos]) << 4) | ((@in[28 + inpos]) << 16)
-                                | ((@in[29 + inpos]) << 28);
-            @out[11 + outpos] = (int)((uint)(@in[29 + inpos]) >> (12 - 8))
-                                | ((@in[30 + inpos]) << 8) | ((@in[31 + inpos]) << 20);
-        }
-
-        protected static void fastpackwithoutmask13(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 13)
-                               | ((@in[2 + inpos]) << 26);
-            @out[1 + outpos] = (int)((uint)(@in[2 + inpos]) >> (13 - 7))
-                               | ((@in[3 + inpos]) << 7) | ((@in[4 + inpos]) << 20);
-            @out[2 + outpos] = (int)((uint)(@in[4 + inpos]) >> (13 - 1))
-                               | ((@in[5 + inpos]) << 1) | ((@in[6 + inpos]) << 14)
-                               | ((@in[7 + inpos]) << 27);
-            @out[3 + outpos] = (int)((uint)(@in[7 + inpos]) >> (13 - 8))
-                               | ((@in[8 + inpos]) << 8) | ((@in[9 + inpos]) << 21);
-            @out[4 + outpos] = (int)((uint)(@in[9 + inpos]) >> (13 - 2))
-                               | ((@in[10 + inpos]) << 2) | ((@in[11 + inpos]) << 15)
-                               | ((@in[12 + inpos]) << 28);
-            @out[5 + outpos] = (int)((uint)(@in[12 + inpos]) >> (13 - 9))
-                               | ((@in[13 + inpos]) << 9) | ((@in[14 + inpos]) << 22);
-            @out[6 + outpos] = (int)((uint)(@in[14 + inpos]) >> (13 - 3))
-                               | ((@in[15 + inpos]) << 3) | ((@in[16 + inpos]) << 16)
-                               | ((@in[17 + inpos]) << 29);
-            @out[7 + outpos] = (int)((uint)(@in[17 + inpos]) >> (13 - 10))
-                               | ((@in[18 + inpos]) << 10) | ((@in[19 + inpos]) << 23);
-            @out[8 + outpos] = (int)((uint)(@in[19 + inpos]) >> (13 - 4))
-                               | ((@in[20 + inpos]) << 4) | ((@in[21 + inpos]) << 17)
-                               | ((@in[22 + inpos]) << 30);
-            @out[9 + outpos] = (int)((uint)(@in[22 + inpos]) >> (13 - 11))
-                               | ((@in[23 + inpos]) << 11) | ((@in[24 + inpos]) << 24);
-            @out[10 + outpos] = (int)((uint)(@in[24 + inpos]) >> (13 - 5))
-                                | ((@in[25 + inpos]) << 5) | ((@in[26 + inpos]) << 18)
-                                | ((@in[27 + inpos]) << 31);
-            @out[11 + outpos] = (int)((uint)(@in[27 + inpos]) >> (13 - 12))
-                                | ((@in[28 + inpos]) << 12) | ((@in[29 + inpos]) << 25);
-            @out[12 + outpos] = (int)((uint)(@in[29 + inpos]) >> (13 - 6))
-                                | ((@in[30 + inpos]) << 6) | ((@in[31 + inpos]) << 19);
-        }
-
-        protected static void fastpackwithoutmask14(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 14)
-                               | ((@in[2 + inpos]) << 28);
-            @out[1 + outpos] = (int)((uint)(@in[2 + inpos]) >> (14 - 10))
-                               | ((@in[3 + inpos]) << 10) | ((@in[4 + inpos]) << 24);
-            @out[2 + outpos] = (int)((uint)(@in[4 + inpos]) >> (14 - 6))
-                               | ((@in[5 + inpos]) << 6) | ((@in[6 + inpos]) << 20);
-            @out[3 + outpos] = (int)((uint)(@in[6 + inpos]) >> (14 - 2))
-                               | ((@in[7 + inpos]) << 2) | ((@in[8 + inpos]) << 16)
-                               | ((@in[9 + inpos]) << 30);
-            @out[4 + outpos] = (int)((uint)(@in[9 + inpos]) >> (14 - 12))
-                               | ((@in[10 + inpos]) << 12) | ((@in[11 + inpos]) << 26);
-            @out[5 + outpos] = (int)((uint)(@in[11 + inpos]) >> (14 - 8))
-                               | ((@in[12 + inpos]) << 8) | ((@in[13 + inpos]) << 22);
-            @out[6 + outpos] = (int)((uint)(@in[13 + inpos]) >> (14 - 4))
-                               | ((@in[14 + inpos]) << 4) | ((@in[15 + inpos]) << 18);
-            @out[7 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 14)
-                               | ((@in[18 + inpos]) << 28);
-            @out[8 + outpos] = (int)((uint)(@in[18 + inpos]) >> (14 - 10))
-                               | ((@in[19 + inpos]) << 10) | ((@in[20 + inpos]) << 24);
-            @out[9 + outpos] = (int)((uint)(@in[20 + inpos]) >> (14 - 6))
-                               | ((@in[21 + inpos]) << 6) | ((@in[22 + inpos]) << 20);
-            @out[10 + outpos] = (int)((uint)(@in[22 + inpos]) >> (14 - 2))
-                                | ((@in[23 + inpos]) << 2) | ((@in[24 + inpos]) << 16)
-                                | ((@in[25 + inpos]) << 30);
-            @out[11 + outpos] = (int)((uint)(@in[25 + inpos]) >> (14 - 12))
-                                | ((@in[26 + inpos]) << 12) | ((@in[27 + inpos]) << 26);
-            @out[12 + outpos] = (int)((uint)(@in[27 + inpos]) >> (14 - 8))
-                                | ((@in[28 + inpos]) << 8) | ((@in[29 + inpos]) << 22);
-            @out[13 + outpos] = (int)((uint)(@in[29 + inpos]) >> (14 - 4))
-                                | ((@in[30 + inpos]) << 4) | ((@in[31 + inpos]) << 18);
-        }
-
-        protected static void fastpackwithoutmask15(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 15)
-                               | ((@in[2 + inpos]) << 30);
-            @out[1 + outpos] = (int)((uint)(@in[2 + inpos]) >> (15 - 13))
-                               | ((@in[3 + inpos]) << 13) | ((@in[4 + inpos]) << 28);
-            @out[2 + outpos] = (int)((uint)(@in[4 + inpos]) >> (15 - 11))
-                               | ((@in[5 + inpos]) << 11) | ((@in[6 + inpos]) << 26);
-            @out[3 + outpos] = (int)((uint)(@in[6 + inpos]) >> (15 - 9))
-                               | ((@in[7 + inpos]) << 9) | ((@in[8 + inpos]) << 24);
-            @out[4 + outpos] = (int)((uint)(@in[8 + inpos]) >> (15 - 7))
-                               | ((@in[9 + inpos]) << 7) | ((@in[10 + inpos]) << 22);
-            @out[5 + outpos] = (int)((uint)(@in[10 + inpos]) >> (15 - 5))
-                               | ((@in[11 + inpos]) << 5) | ((@in[12 + inpos]) << 20);
-            @out[6 + outpos] = (int)((uint)(@in[12 + inpos]) >> (15 - 3))
-                               | ((@in[13 + inpos]) << 3) | ((@in[14 + inpos]) << 18);
-            @out[7 + outpos] = (int)((uint)(@in[14 + inpos]) >> (15 - 1))
-                               | ((@in[15 + inpos]) << 1) | ((@in[16 + inpos]) << 16)
-                               | ((@in[17 + inpos]) << 31);
-            @out[8 + outpos] = (int)((uint)(@in[17 + inpos]) >> (15 - 14))
-                               | ((@in[18 + inpos]) << 14) | ((@in[19 + inpos]) << 29);
-            @out[9 + outpos] = (int)((uint)(@in[19 + inpos]) >> (15 - 12))
-                               | ((@in[20 + inpos]) << 12) | ((@in[21 + inpos]) << 27);
-            @out[10 + outpos] = (int)((uint)(@in[21 + inpos]) >> (15 - 10))
-                                | ((@in[22 + inpos]) << 10) | ((@in[23 + inpos]) << 25);
-            @out[11 + outpos] = (int)((uint)(@in[23 + inpos]) >> (15 - 8))
-                                | ((@in[24 + inpos]) << 8) | ((@in[25 + inpos]) << 23);
-            @out[12 + outpos] = (int)((uint)(@in[25 + inpos]) >> (15 - 6))
-                                | ((@in[26 + inpos]) << 6) | ((@in[27 + inpos]) << 21);
-            @out[13 + outpos] = (int)((uint)(@in[27 + inpos]) >> (15 - 4))
-                                | ((@in[28 + inpos]) << 4) | ((@in[29 + inpos]) << 19);
-            @out[14 + outpos] = (int)((uint)(@in[29 + inpos]) >> (15 - 2))
-                                | ((@in[30 + inpos]) << 2) | ((@in[31 + inpos]) << 17);
-        }
-
-        protected static void fastpackwithoutmask16(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 16);
-            @out[1 + outpos] = @in[2 + inpos] | ((@in[3 + inpos]) << 16);
-            @out[2 + outpos] = @in[4 + inpos] | ((@in[5 + inpos]) << 16);
-            @out[3 + outpos] = @in[6 + inpos] | ((@in[7 + inpos]) << 16);
-            @out[4 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 16);
-            @out[5 + outpos] = @in[10 + inpos] | ((@in[11 + inpos]) << 16);
-            @out[6 + outpos] = @in[12 + inpos] | ((@in[13 + inpos]) << 16);
-            @out[7 + outpos] = @in[14 + inpos] | ((@in[15 + inpos]) << 16);
-            @out[8 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 16);
-            @out[9 + outpos] = @in[18 + inpos] | ((@in[19 + inpos]) << 16);
-            @out[10 + outpos] = @in[20 + inpos] | ((@in[21 + inpos]) << 16);
-            @out[11 + outpos] = @in[22 + inpos] | ((@in[23 + inpos]) << 16);
-            @out[12 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 16);
-            @out[13 + outpos] = @in[26 + inpos] | ((@in[27 + inpos]) << 16);
-            @out[14 + outpos] = @in[28 + inpos] | ((@in[29 + inpos]) << 16);
-            @out[15 + outpos] = @in[30 + inpos] | ((@in[31 + inpos]) << 16);
-        }
-
-        protected static void fastpackwithoutmask17(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 17);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (17 - 2))
-                               | ((@in[2 + inpos]) << 2) | ((@in[3 + inpos]) << 19);
-            @out[2 + outpos] = (int)((uint)(@in[3 + inpos]) >> (17 - 4))
-                               | ((@in[4 + inpos]) << 4) | ((@in[5 + inpos]) << 21);
-            @out[3 + outpos] = (int)((uint)(@in[5 + inpos]) >> (17 - 6))
-                               | ((@in[6 + inpos]) << 6) | ((@in[7 + inpos]) << 23);
-            @out[4 + outpos] = (int)((uint)(@in[7 + inpos]) >> (17 - 8))
-                               | ((@in[8 + inpos]) << 8) | ((@in[9 + inpos]) << 25);
-            @out[5 + outpos] = (int)((uint)(@in[9 + inpos]) >> (17 - 10))
-                               | ((@in[10 + inpos]) << 10) | ((@in[11 + inpos]) << 27);
-            @out[6 + outpos] = (int)((uint)(@in[11 + inpos]) >> (17 - 12))
-                               | ((@in[12 + inpos]) << 12) | ((@in[13 + inpos]) << 29);
-            @out[7 + outpos] = (int)((uint)(@in[13 + inpos]) >> (17 - 14))
-                               | ((@in[14 + inpos]) << 14) | ((@in[15 + inpos]) << 31);
-            @out[8 + outpos] = (int)((uint)(@in[15 + inpos]) >> (17 - 16))
-                               | ((@in[16 + inpos]) << 16);
-            @out[9 + outpos] = (int)((uint)(@in[16 + inpos]) >> (17 - 1))
-                               | ((@in[17 + inpos]) << 1) | ((@in[18 + inpos]) << 18);
-            @out[10 + outpos] = (int)((uint)(@in[18 + inpos]) >> (17 - 3))
-                                | ((@in[19 + inpos]) << 3) | ((@in[20 + inpos]) << 20);
-            @out[11 + outpos] = (int)((uint)(@in[20 + inpos]) >> (17 - 5))
-                                | ((@in[21 + inpos]) << 5) | ((@in[22 + inpos]) << 22);
-            @out[12 + outpos] = (int)((uint)(@in[22 + inpos]) >> (17 - 7))
-                                | ((@in[23 + inpos]) << 7) | ((@in[24 + inpos]) << 24);
-            @out[13 + outpos] = (int)((uint)(@in[24 + inpos]) >> (17 - 9))
-                                | ((@in[25 + inpos]) << 9) | ((@in[26 + inpos]) << 26);
-            @out[14 + outpos] = (int)((uint)(@in[26 + inpos]) >> (17 - 11))
-                                | ((@in[27 + inpos]) << 11) | ((@in[28 + inpos]) << 28);
-            @out[15 + outpos] = (int)((uint)(@in[28 + inpos]) >> (17 - 13))
-                                | ((@in[29 + inpos]) << 13) | ((@in[30 + inpos]) << 30);
-            @out[16 + outpos] = (int)((uint)(@in[30 + inpos]) >> (17 - 15))
-                                | ((@in[31 + inpos]) << 15);
-        }
-
-        protected static void fastpackwithoutmask18(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 18);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (18 - 4))
-                               | ((@in[2 + inpos]) << 4) | ((@in[3 + inpos]) << 22);
-            @out[2 + outpos] = (int)((uint)(@in[3 + inpos]) >> (18 - 8))
-                               | ((@in[4 + inpos]) << 8) | ((@in[5 + inpos]) << 26);
-            @out[3 + outpos] = (int)((uint)(@in[5 + inpos]) >> (18 - 12))
-                               | ((@in[6 + inpos]) << 12) | ((@in[7 + inpos]) << 30);
-            @out[4 + outpos] = (int)((uint)(@in[7 + inpos]) >> (18 - 16))
-                               | ((@in[8 + inpos]) << 16);
-            @out[5 + outpos] = (int)((uint)(@in[8 + inpos]) >> (18 - 2))
-                               | ((@in[9 + inpos]) << 2) | ((@in[10 + inpos]) << 20);
-            @out[6 + outpos] = (int)((uint)(@in[10 + inpos]) >> (18 - 6))
-                               | ((@in[11 + inpos]) << 6) | ((@in[12 + inpos]) << 24);
-            @out[7 + outpos] = (int)((uint)(@in[12 + inpos]) >> (18 - 10))
-                               | ((@in[13 + inpos]) << 10) | ((@in[14 + inpos]) << 28);
-            @out[8 + outpos] = (int)((uint)(@in[14 + inpos]) >> (18 - 14))
-                               | ((@in[15 + inpos]) << 14);
-            @out[9 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 18);
-            @out[10 + outpos] = (int)((uint)(@in[17 + inpos]) >> (18 - 4))
-                                | ((@in[18 + inpos]) << 4) | ((@in[19 + inpos]) << 22);
-            @out[11 + outpos] = (int)((uint)(@in[19 + inpos]) >> (18 - 8))
-                                | ((@in[20 + inpos]) << 8) | ((@in[21 + inpos]) << 26);
-            @out[12 + outpos] = (int)((uint)(@in[21 + inpos]) >> (18 - 12))
-                                | ((@in[22 + inpos]) << 12) | ((@in[23 + inpos]) << 30);
-            @out[13 + outpos] = (int)((uint)(@in[23 + inpos]) >> (18 - 16))
-                                | ((@in[24 + inpos]) << 16);
-            @out[14 + outpos] = (int)((uint)(@in[24 + inpos]) >> (18 - 2))
-                                | ((@in[25 + inpos]) << 2) | ((@in[26 + inpos]) << 20);
-            @out[15 + outpos] = (int)((uint)(@in[26 + inpos]) >> (18 - 6))
-                                | ((@in[27 + inpos]) << 6) | ((@in[28 + inpos]) << 24);
-            @out[16 + outpos] = (int)((uint)(@in[28 + inpos]) >> (18 - 10))
-                                | ((@in[29 + inpos]) << 10) | ((@in[30 + inpos]) << 28);
-            @out[17 + outpos] = (int)((uint)(@in[30 + inpos]) >> (18 - 14))
-                                | ((@in[31 + inpos]) << 14);
-        }
-
-        protected static void fastpackwithoutmask19(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 19);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (19 - 6))
-                               | ((@in[2 + inpos]) << 6) | ((@in[3 + inpos]) << 25);
-            @out[2 + outpos] = (int)((uint)(@in[3 + inpos]) >> (19 - 12))
-                               | ((@in[4 + inpos]) << 12) | ((@in[5 + inpos]) << 31);
-            @out[3 + outpos] = (int)((uint)(@in[5 + inpos]) >> (19 - 18))
-                               | ((@in[6 + inpos]) << 18);
-            @out[4 + outpos] = (int)((uint)(@in[6 + inpos]) >> (19 - 5))
-                               | ((@in[7 + inpos]) << 5) | ((@in[8 + inpos]) << 24);
-            @out[5 + outpos] = (int)((uint)(@in[8 + inpos]) >> (19 - 11))
-                               | ((@in[9 + inpos]) << 11) | ((@in[10 + inpos]) << 30);
-            @out[6 + outpos] = (int)((uint)(@in[10 + inpos]) >> (19 - 17))
-                               | ((@in[11 + inpos]) << 17);
-            @out[7 + outpos] = (int)((uint)(@in[11 + inpos]) >> (19 - 4))
-                               | ((@in[12 + inpos]) << 4) | ((@in[13 + inpos]) << 23);
-            @out[8 + outpos] = (int)((uint)(@in[13 + inpos]) >> (19 - 10))
-                               | ((@in[14 + inpos]) << 10) | ((@in[15 + inpos]) << 29);
-            @out[9 + outpos] = (int)((uint)(@in[15 + inpos]) >> (19 - 16))
-                               | ((@in[16 + inpos]) << 16);
-            @out[10 + outpos] = (int)((uint)(@in[16 + inpos]) >> (19 - 3))
-                                | ((@in[17 + inpos]) << 3) | ((@in[18 + inpos]) << 22);
-            @out[11 + outpos] = (int)((uint)(@in[18 + inpos]) >> (19 - 9))
-                                | ((@in[19 + inpos]) << 9) | ((@in[20 + inpos]) << 28);
-            @out[12 + outpos] = (int)((uint)(@in[20 + inpos]) >> (19 - 15))
-                                | ((@in[21 + inpos]) << 15);
-            @out[13 + outpos] = (int)((uint)(@in[21 + inpos]) >> (19 - 2))
-                                | ((@in[22 + inpos]) << 2) | ((@in[23 + inpos]) << 21);
-            @out[14 + outpos] = (int)((uint)(@in[23 + inpos]) >> (19 - 8))
-                                | ((@in[24 + inpos]) << 8) | ((@in[25 + inpos]) << 27);
-            @out[15 + outpos] = (int)((uint)(@in[25 + inpos]) >> (19 - 14))
-                                | ((@in[26 + inpos]) << 14);
-            @out[16 + outpos] = (int)((uint)(@in[26 + inpos]) >> (19 - 1))
-                                | ((@in[27 + inpos]) << 1) | ((@in[28 + inpos]) << 20);
-            @out[17 + outpos] = (int)((uint)(@in[28 + inpos]) >> (19 - 7))
-                                | ((@in[29 + inpos]) << 7) | ((@in[30 + inpos]) << 26);
-            @out[18 + outpos] = (int)((uint)(@in[30 + inpos]) >> (19 - 13))
-                                | ((@in[31 + inpos]) << 13);
-        }
-
-        protected static void fastpackwithoutmask2(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 2)
-                               | ((@in[2 + inpos]) << 4) | ((@in[3 + inpos]) << 6)
-                               | ((@in[4 + inpos]) << 8) | ((@in[5 + inpos]) << 10)
-                               | ((@in[6 + inpos]) << 12) | ((@in[7 + inpos]) << 14)
-                               | ((@in[8 + inpos]) << 16) | ((@in[9 + inpos]) << 18)
-                               | ((@in[10 + inpos]) << 20) | ((@in[11 + inpos]) << 22)
-                               | ((@in[12 + inpos]) << 24) | ((@in[13 + inpos]) << 26)
-                               | ((@in[14 + inpos]) << 28) | ((@in[15 + inpos]) << 30);
-            @out[1 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 2)
-                               | ((@in[18 + inpos]) << 4) | ((@in[19 + inpos]) << 6)
-                               | ((@in[20 + inpos]) << 8) | ((@in[21 + inpos]) << 10)
-                               | ((@in[22 + inpos]) << 12) | ((@in[23 + inpos]) << 14)
-                               | ((@in[24 + inpos]) << 16) | ((@in[25 + inpos]) << 18)
-                               | ((@in[26 + inpos]) << 20) | ((@in[27 + inpos]) << 22)
-                               | ((@in[28 + inpos]) << 24) | ((@in[29 + inpos]) << 26)
-                               | ((@in[30 + inpos]) << 28) | ((@in[31 + inpos]) << 30);
-        }
-
-        protected static void fastpackwithoutmask20(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 20);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (20 - 8))
-                               | ((@in[2 + inpos]) << 8) | ((@in[3 + inpos]) << 28);
-            @out[2 + outpos] = (int)((uint)(@in[3 + inpos]) >> (20 - 16))
-                               | ((@in[4 + inpos]) << 16);
-            @out[3 + outpos] = (int)((uint)(@in[4 + inpos]) >> (20 - 4))
-                               | ((@in[5 + inpos]) << 4) | ((@in[6 + inpos]) << 24);
-            @out[4 + outpos] = (int)((uint)(@in[6 + inpos]) >> (20 - 12))
-                               | ((@in[7 + inpos]) << 12);
-            @out[5 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 20);
-            @out[6 + outpos] = (int)((uint)(@in[9 + inpos]) >> (20 - 8))
-                               | ((@in[10 + inpos]) << 8) | ((@in[11 + inpos]) << 28);
-            @out[7 + outpos] = (int)((uint)(@in[11 + inpos]) >> (20 - 16))
-                               | ((@in[12 + inpos]) << 16);
-            @out[8 + outpos] = (int)((uint)(@in[12 + inpos]) >> (20 - 4))
-                               | ((@in[13 + inpos]) << 4) | ((@in[14 + inpos]) << 24);
-            @out[9 + outpos] = (int)((uint)(@in[14 + inpos]) >> (20 - 12))
-                               | ((@in[15 + inpos]) << 12);
-            @out[10 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 20);
-            @out[11 + outpos] = (int)((uint)(@in[17 + inpos]) >> (20 - 8))
-                                | ((@in[18 + inpos]) << 8) | ((@in[19 + inpos]) << 28);
-            @out[12 + outpos] = (int)((uint)(@in[19 + inpos]) >> (20 - 16))
-                                | ((@in[20 + inpos]) << 16);
-            @out[13 + outpos] = (int)((uint)(@in[20 + inpos]) >> (20 - 4))
-                                | ((@in[21 + inpos]) << 4) | ((@in[22 + inpos]) << 24);
-            @out[14 + outpos] = (int)((uint)(@in[22 + inpos]) >> (20 - 12))
-                                | ((@in[23 + inpos]) << 12);
-            @out[15 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 20);
-            @out[16 + outpos] = (int)((uint)(@in[25 + inpos]) >> (20 - 8))
-                                | ((@in[26 + inpos]) << 8) | ((@in[27 + inpos]) << 28);
-            @out[17 + outpos] = (int)((uint)(@in[27 + inpos]) >> (20 - 16))
-                                | ((@in[28 + inpos]) << 16);
-            @out[18 + outpos] = (int)((uint)(@in[28 + inpos]) >> (20 - 4))
-                                | ((@in[29 + inpos]) << 4) | ((@in[30 + inpos]) << 24);
-            @out[19 + outpos] = (int)((uint)(@in[30 + inpos]) >> (20 - 12))
-                                | ((@in[31 + inpos]) << 12);
-        }
-
-        protected static void fastpackwithoutmask21(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 21);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (21 - 10))
-                               | ((@in[2 + inpos]) << 10) | ((@in[3 + inpos]) << 31);
-            @out[2 + outpos] = (int)((uint)(@in[3 + inpos]) >> (21 - 20))
-                               | ((@in[4 + inpos]) << 20);
-            @out[3 + outpos] = (int)((uint)(@in[4 + inpos]) >> (21 - 9))
-                               | ((@in[5 + inpos]) << 9) | ((@in[6 + inpos]) << 30);
-            @out[4 + outpos] = (int)((uint)(@in[6 + inpos]) >> (21 - 19))
-                               | ((@in[7 + inpos]) << 19);
-            @out[5 + outpos] = (int)((uint)(@in[7 + inpos]) >> (21 - 8))
-                               | ((@in[8 + inpos]) << 8) | ((@in[9 + inpos]) << 29);
-            @out[6 + outpos] = (int)((uint)(@in[9 + inpos]) >> (21 - 18))
-                               | ((@in[10 + inpos]) << 18);
-            @out[7 + outpos] = (int)((uint)(@in[10 + inpos]) >> (21 - 7))
-                               | ((@in[11 + inpos]) << 7) | ((@in[12 + inpos]) << 28);
-            @out[8 + outpos] = (int)((uint)(@in[12 + inpos]) >> (21 - 17))
-                               | ((@in[13 + inpos]) << 17);
-            @out[9 + outpos] = (int)((uint)(@in[13 + inpos]) >> (21 - 6))
-                               | ((@in[14 + inpos]) << 6) | ((@in[15 + inpos]) << 27);
-            @out[10 + outpos] = (int)((uint)(@in[15 + inpos]) >> (21 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[11 + outpos] = (int)((uint)(@in[16 + inpos]) >> (21 - 5))
-                                | ((@in[17 + inpos]) << 5) | ((@in[18 + inpos]) << 26);
-            @out[12 + outpos] = (int)((uint)(@in[18 + inpos]) >> (21 - 15))
-                                | ((@in[19 + inpos]) << 15);
-            @out[13 + outpos] = (int)((uint)(@in[19 + inpos]) >> (21 - 4))
-                                | ((@in[20 + inpos]) << 4) | ((@in[21 + inpos]) << 25);
-            @out[14 + outpos] = (int)((uint)(@in[21 + inpos]) >> (21 - 14))
-                                | ((@in[22 + inpos]) << 14);
-            @out[15 + outpos] = (int)((uint)(@in[22 + inpos]) >> (21 - 3))
-                                | ((@in[23 + inpos]) << 3) | ((@in[24 + inpos]) << 24);
-            @out[16 + outpos] = (int)((uint)(@in[24 + inpos]) >> (21 - 13))
-                                | ((@in[25 + inpos]) << 13);
-            @out[17 + outpos] = (int)((uint)(@in[25 + inpos]) >> (21 - 2))
-                                | ((@in[26 + inpos]) << 2) | ((@in[27 + inpos]) << 23);
-            @out[18 + outpos] = (int)((uint)(@in[27 + inpos]) >> (21 - 12))
-                                | ((@in[28 + inpos]) << 12);
-            @out[19 + outpos] = (int)((uint)(@in[28 + inpos]) >> (21 - 1))
-                                | ((@in[29 + inpos]) << 1) | ((@in[30 + inpos]) << 22);
-            @out[20 + outpos] = (int)((uint)(@in[30 + inpos]) >> (21 - 11))
-                                | ((@in[31 + inpos]) << 11);
-        }
-
-        protected static void fastpackwithoutmask22(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 22);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (22 - 12))
-                               | ((@in[2 + inpos]) << 12);
-            @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (22 - 2))
-                               | ((@in[3 + inpos]) << 2) | ((@in[4 + inpos]) << 24);
-            @out[3 + outpos] = (int)((uint)(@in[4 + inpos]) >> (22 - 14))
-                               | ((@in[5 + inpos]) << 14);
-            @out[4 + outpos] = (int)((uint)(@in[5 + inpos]) >> (22 - 4))
-                               | ((@in[6 + inpos]) << 4) | ((@in[7 + inpos]) << 26);
-            @out[5 + outpos] = (int)((uint)(@in[7 + inpos]) >> (22 - 16))
-                               | ((@in[8 + inpos]) << 16);
-            @out[6 + outpos] = (int)((uint)(@in[8 + inpos]) >> (22 - 6))
-                               | ((@in[9 + inpos]) << 6) | ((@in[10 + inpos]) << 28);
-            @out[7 + outpos] = (int)((uint)(@in[10 + inpos]) >> (22 - 18))
-                               | ((@in[11 + inpos]) << 18);
-            @out[8 + outpos] = (int)((uint)(@in[11 + inpos]) >> (22 - 8))
-                               | ((@in[12 + inpos]) << 8) | ((@in[13 + inpos]) << 30);
-            @out[9 + outpos] = (int)((uint)(@in[13 + inpos]) >> (22 - 20))
-                               | ((@in[14 + inpos]) << 20);
-            @out[10 + outpos] = (int)((uint)(@in[14 + inpos]) >> (22 - 10))
-                                | ((@in[15 + inpos]) << 10);
-            @out[11 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 22);
-            @out[12 + outpos] = (int)((uint)(@in[17 + inpos]) >> (22 - 12))
-                                | ((@in[18 + inpos]) << 12);
-            @out[13 + outpos] = (int)((uint)(@in[18 + inpos]) >> (22 - 2))
-                                | ((@in[19 + inpos]) << 2) | ((@in[20 + inpos]) << 24);
-            @out[14 + outpos] = (int)((uint)(@in[20 + inpos]) >> (22 - 14))
-                                | ((@in[21 + inpos]) << 14);
-            @out[15 + outpos] = (int)((uint)(@in[21 + inpos]) >> (22 - 4))
-                                | ((@in[22 + inpos]) << 4) | ((@in[23 + inpos]) << 26);
-            @out[16 + outpos] = (int)((uint)(@in[23 + inpos]) >> (22 - 16))
-                                | ((@in[24 + inpos]) << 16);
-            @out[17 + outpos] = (int)((uint)(@in[24 + inpos]) >> (22 - 6))
-                                | ((@in[25 + inpos]) << 6) | ((@in[26 + inpos]) << 28);
-            @out[18 + outpos] = (int)((uint)(@in[26 + inpos]) >> (22 - 18))
-                                | ((@in[27 + inpos]) << 18);
-            @out[19 + outpos] = (int)((uint)(@in[27 + inpos]) >> (22 - 8))
-                                | ((@in[28 + inpos]) << 8) | ((@in[29 + inpos]) << 30);
-            @out[20 + outpos] = (int)((uint)(@in[29 + inpos]) >> (22 - 20))
-                                | ((@in[30 + inpos]) << 20);
-            @out[21 + outpos] = (int)((uint)(@in[30 + inpos]) >> (22 - 10))
-                                | ((@in[31 + inpos]) << 10);
-        }
-
-        protected static void fastpackwithoutmask23(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 23);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (23 - 14))
-                               | ((@in[2 + inpos]) << 14);
-            @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (23 - 5))
-                               | ((@in[3 + inpos]) << 5) | ((@in[4 + inpos]) << 28);
-            @out[3 + outpos] = (int)((uint)(@in[4 + inpos]) >> (23 - 19))
-                               | ((@in[5 + inpos]) << 19);
-            @out[4 + outpos] = (int)((uint)(@in[5 + inpos]) >> (23 - 10))
-                               | ((@in[6 + inpos]) << 10);
-            @out[5 + outpos] = (int)((uint)(@in[6 + inpos]) >> (23 - 1))
-                               | ((@in[7 + inpos]) << 1) | ((@in[8 + inpos]) << 24);
-            @out[6 + outpos] = (int)((uint)(@in[8 + inpos]) >> (23 - 15))
-                               | ((@in[9 + inpos]) << 15);
-            @out[7 + outpos] = (int)((uint)(@in[9 + inpos]) >> (23 - 6))
-                               | ((@in[10 + inpos]) << 6) | ((@in[11 + inpos]) << 29);
-            @out[8 + outpos] = (int)((uint)(@in[11 + inpos]) >> (23 - 20))
-                               | ((@in[12 + inpos]) << 20);
-            @out[9 + outpos] = (int)((uint)(@in[12 + inpos]) >> (23 - 11))
-                               | ((@in[13 + inpos]) << 11);
-            @out[10 + outpos] = (int)((uint)(@in[13 + inpos]) >> (23 - 2))
-                                | ((@in[14 + inpos]) << 2) | ((@in[15 + inpos]) << 25);
-            @out[11 + outpos] = (int)((uint)(@in[15 + inpos]) >> (23 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[12 + outpos] = (int)((uint)(@in[16 + inpos]) >> (23 - 7))
-                                | ((@in[17 + inpos]) << 7) | ((@in[18 + inpos]) << 30);
-            @out[13 + outpos] = (int)((uint)(@in[18 + inpos]) >> (23 - 21))
-                                | ((@in[19 + inpos]) << 21);
-            @out[14 + outpos] = (int)((uint)(@in[19 + inpos]) >> (23 - 12))
-                                | ((@in[20 + inpos]) << 12);
-            @out[15 + outpos] = (int)((uint)(@in[20 + inpos]) >> (23 - 3))
-                                | ((@in[21 + inpos]) << 3) | ((@in[22 + inpos]) << 26);
-            @out[16 + outpos] = (int)((uint)(@in[22 + inpos]) >> (23 - 17))
-                                | ((@in[23 + inpos]) << 17);
-            @out[17 + outpos] = (int)((uint)(@in[23 + inpos]) >> (23 - 8))
-                                | ((@in[24 + inpos]) << 8) | ((@in[25 + inpos]) << 31);
-            @out[18 + outpos] = (int)((uint)(@in[25 + inpos]) >> (23 - 22))
-                                | ((@in[26 + inpos]) << 22);
-            @out[19 + outpos] = (int)((uint)(@in[26 + inpos]) >> (23 - 13))
-                                | ((@in[27 + inpos]) << 13);
-            @out[20 + outpos] = (int)((uint)(@in[27 + inpos]) >> (23 - 4))
-                                | ((@in[28 + inpos]) << 4) | ((@in[29 + inpos]) << 27);
-            @out[21 + outpos] = (int)((uint)(@in[29 + inpos]) >> (23 - 18))
-                                | ((@in[30 + inpos]) << 18);
-            @out[22 + outpos] = (int)((uint)(@in[30 + inpos]) >> (23 - 9))
-                                | ((@in[31 + inpos]) << 9);
-        }
-
-        protected static void fastpackwithoutmask24(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 24);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (24 - 16))
-                               | ((@in[2 + inpos]) << 16);
-            @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (24 - 8))
-                               | ((@in[3 + inpos]) << 8);
-            @out[3 + outpos] = @in[4 + inpos] | ((@in[5 + inpos]) << 24);
-            @out[4 + outpos] = (int)((uint)(@in[5 + inpos]) >> (24 - 16))
-                               | ((@in[6 + inpos]) << 16);
-            @out[5 + outpos] = (int)((uint)(@in[6 + inpos]) >> (24 - 8))
-                               | ((@in[7 + inpos]) << 8);
-            @out[6 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 24);
-            @out[7 + outpos] = (int)((uint)(@in[9 + inpos]) >> (24 - 16))
-                               | ((@in[10 + inpos]) << 16);
-            @out[8 + outpos] = (int)((uint)(@in[10 + inpos]) >> (24 - 8))
-                               | ((@in[11 + inpos]) << 8);
-            @out[9 + outpos] = @in[12 + inpos] | ((@in[13 + inpos]) << 24);
-            @out[10 + outpos] = (int)((uint)(@in[13 + inpos]) >> (24 - 16))
-                                | ((@in[14 + inpos]) << 16);
-            @out[11 + outpos] = (int)((uint)(@in[14 + inpos]) >> (24 - 8))
-                                | ((@in[15 + inpos]) << 8);
-            @out[12 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 24);
-            @out[13 + outpos] = (int)((uint)(@in[17 + inpos]) >> (24 - 16))
-                                | ((@in[18 + inpos]) << 16);
-            @out[14 + outpos] = (int)((uint)(@in[18 + inpos]) >> (24 - 8))
-                                | ((@in[19 + inpos]) << 8);
-            @out[15 + outpos] = @in[20 + inpos] | ((@in[21 + inpos]) << 24);
-            @out[16 + outpos] = (int)((uint)(@in[21 + inpos]) >> (24 - 16))
-                                | ((@in[22 + inpos]) << 16);
-            @out[17 + outpos] = (int)((uint)(@in[22 + inpos]) >> (24 - 8))
-                                | ((@in[23 + inpos]) << 8);
-            @out[18 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 24);
-            @out[19 + outpos] = (int)((uint)(@in[25 + inpos]) >> (24 - 16))
-                                | ((@in[26 + inpos]) << 16);
-            @out[20 + outpos] = (int)((uint)(@in[26 + inpos]) >> (24 - 8))
-                                | ((@in[27 + inpos]) << 8);
-            @out[21 + outpos] = @in[28 + inpos] | ((@in[29 + inpos]) << 24);
-            @out[22 + outpos] = (int)((uint)(@in[29 + inpos]) >> (24 - 16))
-                                | ((@in[30 + inpos]) << 16);
-            @out[23 + outpos] = (int)((uint)(@in[30 + inpos]) >> (24 - 8))
-                                | ((@in[31 + inpos]) << 8);
-        }
-
-        protected static void fastpackwithoutmask25(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 25);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (25 - 18))
-                               | ((@in[2 + inpos]) << 18);
-            @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (25 - 11))
-                               | ((@in[3 + inpos]) << 11);
-            @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (25 - 4))
-                               | ((@in[4 + inpos]) << 4) | ((@in[5 + inpos]) << 29);
-            @out[4 + outpos] = (int)((uint)(@in[5 + inpos]) >> (25 - 22))
-                               | ((@in[6 + inpos]) << 22);
-            @out[5 + outpos] = (int)((uint)(@in[6 + inpos]) >> (25 - 15))
-                               | ((@in[7 + inpos]) << 15);
-            @out[6 + outpos] = (int)((uint)(@in[7 + inpos]) >> (25 - 8))
-                               | ((@in[8 + inpos]) << 8);
-            @out[7 + outpos] = (int)((uint)(@in[8 + inpos]) >> (25 - 1))
-                               | ((@in[9 + inpos]) << 1) | ((@in[10 + inpos]) << 26);
-            @out[8 + outpos] = (int)((uint)(@in[10 + inpos]) >> (25 - 19))
-                               | ((@in[11 + inpos]) << 19);
-            @out[9 + outpos] = (int)((uint)(@in[11 + inpos]) >> (25 - 12))
-                               | ((@in[12 + inpos]) << 12);
-            @out[10 + outpos] = (int)((uint)(@in[12 + inpos]) >> (25 - 5))
-                                | ((@in[13 + inpos]) << 5) | ((@in[14 + inpos]) << 30);
-            @out[11 + outpos] = (int)((uint)(@in[14 + inpos]) >> (25 - 23))
-                                | ((@in[15 + inpos]) << 23);
-            @out[12 + outpos] = (int)((uint)(@in[15 + inpos]) >> (25 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[13 + outpos] = (int)((uint)(@in[16 + inpos]) >> (25 - 9))
-                                | ((@in[17 + inpos]) << 9);
-            @out[14 + outpos] = (int)((uint)(@in[17 + inpos]) >> (25 - 2))
-                                | ((@in[18 + inpos]) << 2) | ((@in[19 + inpos]) << 27);
-            @out[15 + outpos] = (int)((uint)(@in[19 + inpos]) >> (25 - 20))
-                                | ((@in[20 + inpos]) << 20);
-            @out[16 + outpos] = (int)((uint)(@in[20 + inpos]) >> (25 - 13))
-                                | ((@in[21 + inpos]) << 13);
-            @out[17 + outpos] = (int)((uint)(@in[21 + inpos]) >> (25 - 6))
-                                | ((@in[22 + inpos]) << 6) | ((@in[23 + inpos]) << 31);
-            @out[18 + outpos] = (int)((uint)(@in[23 + inpos]) >> (25 - 24))
-                                | ((@in[24 + inpos]) << 24);
-            @out[19 + outpos] = (int)((uint)(@in[24 + inpos]) >> (25 - 17))
-                                | ((@in[25 + inpos]) << 17);
-            @out[20 + outpos] = (int)((uint)(@in[25 + inpos]) >> (25 - 10))
-                                | ((@in[26 + inpos]) << 10);
-            @out[21 + outpos] = (int)((uint)(@in[26 + inpos]) >> (25 - 3))
-                                | ((@in[27 + inpos]) << 3) | ((@in[28 + inpos]) << 28);
-            @out[22 + outpos] = (int)((uint)(@in[28 + inpos]) >> (25 - 21))
-                                | ((@in[29 + inpos]) << 21);
-            @out[23 + outpos] = (int)((uint)(@in[29 + inpos]) >> (25 - 14))
-                                | ((@in[30 + inpos]) << 14);
-            @out[24 + outpos] = (int)((uint)(@in[30 + inpos]) >> (25 - 7))
-                                | ((@in[31 + inpos]) << 7);
-        }
-
-        protected static void fastpackwithoutmask26(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 26);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (26 - 20))
-                               | ((@in[2 + inpos]) << 20);
-            @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (26 - 14))
-                               | ((@in[3 + inpos]) << 14);
-            @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (26 - 8))
-                               | ((@in[4 + inpos]) << 8);
-            @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (26 - 2))
-                               | ((@in[5 + inpos]) << 2) | ((@in[6 + inpos]) << 28);
-            @out[5 + outpos] = (int)((uint)(@in[6 + inpos]) >> (26 - 22))
-                               | ((@in[7 + inpos]) << 22);
-            @out[6 + outpos] = (int)((uint)(@in[7 + inpos]) >> (26 - 16))
-                               | ((@in[8 + inpos]) << 16);
-            @out[7 + outpos] = (int)((uint)(@in[8 + inpos]) >> (26 - 10))
-                               | ((@in[9 + inpos]) << 10);
-            @out[8 + outpos] = (int)((uint)(@in[9 + inpos]) >> (26 - 4))
-                               | ((@in[10 + inpos]) << 4) | ((@in[11 + inpos]) << 30);
-            @out[9 + outpos] = (int)((uint)(@in[11 + inpos]) >> (26 - 24))
-                               | ((@in[12 + inpos]) << 24);
-            @out[10 + outpos] = (int)((uint)(@in[12 + inpos]) >> (26 - 18))
-                                | ((@in[13 + inpos]) << 18);
-            @out[11 + outpos] = (int)((uint)(@in[13 + inpos]) >> (26 - 12))
-                                | ((@in[14 + inpos]) << 12);
-            @out[12 + outpos] = (int)((uint)(@in[14 + inpos]) >> (26 - 6))
-                                | ((@in[15 + inpos]) << 6);
-            @out[13 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 26);
-            @out[14 + outpos] = (int)((uint)(@in[17 + inpos]) >> (26 - 20))
-                                | ((@in[18 + inpos]) << 20);
-            @out[15 + outpos] = (int)((uint)(@in[18 + inpos]) >> (26 - 14))
-                                | ((@in[19 + inpos]) << 14);
-            @out[16 + outpos] = (int)((uint)(@in[19 + inpos]) >> (26 - 8))
-                                | ((@in[20 + inpos]) << 8);
-            @out[17 + outpos] = (int)((uint)(@in[20 + inpos]) >> (26 - 2))
-                                | ((@in[21 + inpos]) << 2) | ((@in[22 + inpos]) << 28);
-            @out[18 + outpos] = (int)((uint)(@in[22 + inpos]) >> (26 - 22))
-                                | ((@in[23 + inpos]) << 22);
-            @out[19 + outpos] = (int)((uint)(@in[23 + inpos]) >> (26 - 16))
-                                | ((@in[24 + inpos]) << 16);
-            @out[20 + outpos] = (int)((uint)(@in[24 + inpos]) >> (26 - 10))
-                                | ((@in[25 + inpos]) << 10);
-            @out[21 + outpos] = (int)((uint)(@in[25 + inpos]) >> (26 - 4))
-                                | ((@in[26 + inpos]) << 4) | ((@in[27 + inpos]) << 30);
-            @out[22 + outpos] = (int)((uint)(@in[27 + inpos]) >> (26 - 24))
-                                | ((@in[28 + inpos]) << 24);
-            @out[23 + outpos] = (int)((uint)(@in[28 + inpos]) >> (26 - 18))
-                                | ((@in[29 + inpos]) << 18);
-            @out[24 + outpos] = (int)((uint)(@in[29 + inpos]) >> (26 - 12))
-                                | ((@in[30 + inpos]) << 12);
-            @out[25 + outpos] = (int)((uint)(@in[30 + inpos]) >> (26 - 6))
-                                | ((@in[31 + inpos]) << 6);
-        }
-
-        protected static void fastpackwithoutmask27(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 27);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (27 - 22))
-                               | ((@in[2 + inpos]) << 22);
-            @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (27 - 17))
-                               | ((@in[3 + inpos]) << 17);
-            @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (27 - 12))
-                               | ((@in[4 + inpos]) << 12);
-            @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (27 - 7))
-                               | ((@in[5 + inpos]) << 7);
-            @out[5 + outpos] = (int)((uint)(@in[5 + inpos]) >> (27 - 2))
-                               | ((@in[6 + inpos]) << 2) | ((@in[7 + inpos]) << 29);
-            @out[6 + outpos] = (int)((uint)(@in[7 + inpos]) >> (27 - 24))
-                               | ((@in[8 + inpos]) << 24);
-            @out[7 + outpos] = (int)((uint)(@in[8 + inpos]) >> (27 - 19))
-                               | ((@in[9 + inpos]) << 19);
-            @out[8 + outpos] = (int)((uint)(@in[9 + inpos]) >> (27 - 14))
-                               | ((@in[10 + inpos]) << 14);
-            @out[9 + outpos] = (int)((uint)(@in[10 + inpos]) >> (27 - 9))
-                               | ((@in[11 + inpos]) << 9);
-            @out[10 + outpos] = (int)((uint)(@in[11 + inpos]) >> (27 - 4))
-                                | ((@in[12 + inpos]) << 4) | ((@in[13 + inpos]) << 31);
-            @out[11 + outpos] = (int)((uint)(@in[13 + inpos]) >> (27 - 26))
-                                | ((@in[14 + inpos]) << 26);
-            @out[12 + outpos] = (int)((uint)(@in[14 + inpos]) >> (27 - 21))
-                                | ((@in[15 + inpos]) << 21);
-            @out[13 + outpos] = (int)((uint)(@in[15 + inpos]) >> (27 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[14 + outpos] = (int)((uint)(@in[16 + inpos]) >> (27 - 11))
-                                | ((@in[17 + inpos]) << 11);
-            @out[15 + outpos] = (int)((uint)(@in[17 + inpos]) >> (27 - 6))
-                                | ((@in[18 + inpos]) << 6);
-            @out[16 + outpos] = (int)((uint)(@in[18 + inpos]) >> (27 - 1))
-                                | ((@in[19 + inpos]) << 1) | ((@in[20 + inpos]) << 28);
-            @out[17 + outpos] = (int)((uint)(@in[20 + inpos]) >> (27 - 23))
-                                | ((@in[21 + inpos]) << 23);
-            @out[18 + outpos] = (int)((uint)(@in[21 + inpos]) >> (27 - 18))
-                                | ((@in[22 + inpos]) << 18);
-            @out[19 + outpos] = (int)((uint)(@in[22 + inpos]) >> (27 - 13))
-                                | ((@in[23 + inpos]) << 13);
-            @out[20 + outpos] = (int)((uint)(@in[23 + inpos]) >> (27 - 8))
-                                | ((@in[24 + inpos]) << 8);
-            @out[21 + outpos] = (int)((uint)(@in[24 + inpos]) >> (27 - 3))
-                                | ((@in[25 + inpos]) << 3) | ((@in[26 + inpos]) << 30);
-            @out[22 + outpos] = (int)((uint)(@in[26 + inpos]) >> (27 - 25))
-                                | ((@in[27 + inpos]) << 25);
-            @out[23 + outpos] = (int)((uint)(@in[27 + inpos]) >> (27 - 20))
-                                | ((@in[28 + inpos]) << 20);
-            @out[24 + outpos] = (int)((uint)(@in[28 + inpos]) >> (27 - 15))
-                                | ((@in[29 + inpos]) << 15);
-            @out[25 + outpos] = (int)((uint)(@in[29 + inpos]) >> (27 - 10))
-                                | ((@in[30 + inpos]) << 10);
-            @out[26 + outpos] = (int)((uint)(@in[30 + inpos]) >> (27 - 5))
-                                | ((@in[31 + inpos]) << 5);
-        }
-
-        protected static void fastpackwithoutmask28(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 28);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (28 - 24))
-                               | ((@in[2 + inpos]) << 24);
-            @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (28 - 20))
-                               | ((@in[3 + inpos]) << 20);
-            @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (28 - 16))
-                               | ((@in[4 + inpos]) << 16);
-            @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (28 - 12))
-                               | ((@in[5 + inpos]) << 12);
-            @out[5 + outpos] = (int)((uint)(@in[5 + inpos]) >> (28 - 8))
-                               | ((@in[6 + inpos]) << 8);
-            @out[6 + outpos] = (int)((uint)(@in[6 + inpos]) >> (28 - 4))
-                               | ((@in[7 + inpos]) << 4);
-            @out[7 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 28);
-            @out[8 + outpos] = (int)((uint)(@in[9 + inpos]) >> (28 - 24))
-                               | ((@in[10 + inpos]) << 24);
-            @out[9 + outpos] = (int)((uint)(@in[10 + inpos]) >> (28 - 20))
-                               | ((@in[11 + inpos]) << 20);
-            @out[10 + outpos] = (int)((uint)(@in[11 + inpos]) >> (28 - 16))
-                                | ((@in[12 + inpos]) << 16);
-            @out[11 + outpos] = (int)((uint)(@in[12 + inpos]) >> (28 - 12))
-                                | ((@in[13 + inpos]) << 12);
-            @out[12 + outpos] = (int)((uint)(@in[13 + inpos]) >> (28 - 8))
-                                | ((@in[14 + inpos]) << 8);
-            @out[13 + outpos] = (int)((uint)(@in[14 + inpos]) >> (28 - 4))
-                                | ((@in[15 + inpos]) << 4);
-            @out[14 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 28);
-            @out[15 + outpos] = (int)((uint)(@in[17 + inpos]) >> (28 - 24))
-                                | ((@in[18 + inpos]) << 24);
-            @out[16 + outpos] = (int)((uint)(@in[18 + inpos]) >> (28 - 20))
-                                | ((@in[19 + inpos]) << 20);
-            @out[17 + outpos] = (int)((uint)(@in[19 + inpos]) >> (28 - 16))
-                                | ((@in[20 + inpos]) << 16);
-            @out[18 + outpos] = (int)((uint)(@in[20 + inpos]) >> (28 - 12))
-                                | ((@in[21 + inpos]) << 12);
-            @out[19 + outpos] = (int)((uint)(@in[21 + inpos]) >> (28 - 8))
-                                | ((@in[22 + inpos]) << 8);
-            @out[20 + outpos] = (int)((uint)(@in[22 + inpos]) >> (28 - 4))
-                                | ((@in[23 + inpos]) << 4);
-            @out[21 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 28);
-            @out[22 + outpos] = (int)((uint)(@in[25 + inpos]) >> (28 - 24))
-                                | ((@in[26 + inpos]) << 24);
-            @out[23 + outpos] = (int)((uint)(@in[26 + inpos]) >> (28 - 20))
-                                | ((@in[27 + inpos]) << 20);
-            @out[24 + outpos] = (int)((uint)(@in[27 + inpos]) >> (28 - 16))
-                                | ((@in[28 + inpos]) << 16);
-            @out[25 + outpos] = (int)((uint)(@in[28 + inpos]) >> (28 - 12))
-                                | ((@in[29 + inpos]) << 12);
-            @out[26 + outpos] = (int)((uint)(@in[29 + inpos]) >> (28 - 8))
-                                | ((@in[30 + inpos]) << 8);
-            @out[27 + outpos] = (int)((uint)(@in[30 + inpos]) >> (28 - 4))
-                                | ((@in[31 + inpos]) << 4);
-        }
-
-        protected static void fastpackwithoutmask29(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 29);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (29 - 26))
-                               | ((@in[2 + inpos]) << 26);
-            @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (29 - 23))
-                               | ((@in[3 + inpos]) << 23);
-            @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (29 - 20))
-                               | ((@in[4 + inpos]) << 20);
-            @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (29 - 17))
-                               | ((@in[5 + inpos]) << 17);
-            @out[5 + outpos] = (int)((uint)(@in[5 + inpos]) >> (29 - 14))
-                               | ((@in[6 + inpos]) << 14);
-            @out[6 + outpos] = (int)((uint)(@in[6 + inpos]) >> (29 - 11))
-                               | ((@in[7 + inpos]) << 11);
-            @out[7 + outpos] = (int)((uint)(@in[7 + inpos]) >> (29 - 8))
-                               | ((@in[8 + inpos]) << 8);
-            @out[8 + outpos] = (int)((uint)(@in[8 + inpos]) >> (29 - 5))
-                               | ((@in[9 + inpos]) << 5);
-            @out[9 + outpos] = (int)((uint)(@in[9 + inpos]) >> (29 - 2))
-                               | ((@in[10 + inpos]) << 2) | ((@in[11 + inpos]) << 31);
-            @out[10 + outpos] = (int)((uint)(@in[11 + inpos]) >> (29 - 28))
-                                | ((@in[12 + inpos]) << 28);
-            @out[11 + outpos] = (int)((uint)(@in[12 + inpos]) >> (29 - 25))
-                                | ((@in[13 + inpos]) << 25);
-            @out[12 + outpos] = (int)((uint)(@in[13 + inpos]) >> (29 - 22))
-                                | ((@in[14 + inpos]) << 22);
-            @out[13 + outpos] = (int)((uint)(@in[14 + inpos]) >> (29 - 19))
-                                | ((@in[15 + inpos]) << 19);
-            @out[14 + outpos] = (int)((uint)(@in[15 + inpos]) >> (29 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[15 + outpos] = (int)((uint)(@in[16 + inpos]) >> (29 - 13))
-                                | ((@in[17 + inpos]) << 13);
-            @out[16 + outpos] = (int)((uint)(@in[17 + inpos]) >> (29 - 10))
-                                | ((@in[18 + inpos]) << 10);
-            @out[17 + outpos] = (int)((uint)(@in[18 + inpos]) >> (29 - 7))
-                                | ((@in[19 + inpos]) << 7);
-            @out[18 + outpos] = (int)((uint)(@in[19 + inpos]) >> (29 - 4))
-                                | ((@in[20 + inpos]) << 4);
-            @out[19 + outpos] = (int)((uint)(@in[20 + inpos]) >> (29 - 1))
-                                | ((@in[21 + inpos]) << 1) | ((@in[22 + inpos]) << 30);
-            @out[20 + outpos] = (int)((uint)(@in[22 + inpos]) >> (29 - 27))
-                                | ((@in[23 + inpos]) << 27);
-            @out[21 + outpos] = (int)((uint)(@in[23 + inpos]) >> (29 - 24))
-                                | ((@in[24 + inpos]) << 24);
-            @out[22 + outpos] = (int)((uint)(@in[24 + inpos]) >> (29 - 21))
-                                | ((@in[25 + inpos]) << 21);
-            @out[23 + outpos] = (int)((uint)(@in[25 + inpos]) >> (29 - 18))
-                                | ((@in[26 + inpos]) << 18);
-            @out[24 + outpos] = (int)((uint)(@in[26 + inpos]) >> (29 - 15))
-                                | ((@in[27 + inpos]) << 15);
-            @out[25 + outpos] = (int)((uint)(@in[27 + inpos]) >> (29 - 12))
-                                | ((@in[28 + inpos]) << 12);
-            @out[26 + outpos] = (int)((uint)(@in[28 + inpos]) >> (29 - 9))
-                                | ((@in[29 + inpos]) << 9);
-            @out[27 + outpos] = (int)((uint)(@in[29 + inpos]) >> (29 - 6))
-                                | ((@in[30 + inpos]) << 6);
-            @out[28 + outpos] = (int)((uint)(@in[30 + inpos]) >> (29 - 3))
-                                | ((@in[31 + inpos]) << 3);
-        }
-
-        protected static void fastpackwithoutmask3(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 3)
-                               | ((@in[2 + inpos]) << 6) | ((@in[3 + inpos]) << 9)
-                               | ((@in[4 + inpos]) << 12) | ((@in[5 + inpos]) << 15)
-                               | ((@in[6 + inpos]) << 18) | ((@in[7 + inpos]) << 21)
-                               | ((@in[8 + inpos]) << 24) | ((@in[9 + inpos]) << 27)
-                               | ((@in[10 + inpos]) << 30);
-            @out[1 + outpos] = (int)((uint)(@in[10 + inpos]) >> (3 - 1))
-                               | ((@in[11 + inpos]) << 1) | ((@in[12 + inpos]) << 4)
-                               | ((@in[13 + inpos]) << 7) | ((@in[14 + inpos]) << 10)
-                               | ((@in[15 + inpos]) << 13) | ((@in[16 + inpos]) << 16)
-                               | ((@in[17 + inpos]) << 19) | ((@in[18 + inpos]) << 22)
-                               | ((@in[19 + inpos]) << 25) | ((@in[20 + inpos]) << 28)
-                               | ((@in[21 + inpos]) << 31);
-            @out[2 + outpos] = (int)((uint)(@in[21 + inpos]) >> (3 - 2))
-                               | ((@in[22 + inpos]) << 2) | ((@in[23 + inpos]) << 5)
-                               | ((@in[24 + inpos]) << 8) | ((@in[25 + inpos]) << 11)
-                               | ((@in[26 + inpos]) << 14) | ((@in[27 + inpos]) << 17)
-                               | ((@in[28 + inpos]) << 20) | ((@in[29 + inpos]) << 23)
-                               | ((@in[30 + inpos]) << 26) | ((@in[31 + inpos]) << 29);
-        }
-
-        protected static void fastpackwithoutmask30(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 30);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (30 - 28))
-                               | ((@in[2 + inpos]) << 28);
-            @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (30 - 26))
-                               | ((@in[3 + inpos]) << 26);
-            @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (30 - 24))
-                               | ((@in[4 + inpos]) << 24);
-            @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (30 - 22))
-                               | ((@in[5 + inpos]) << 22);
-            @out[5 + outpos] = (int)((uint)(@in[5 + inpos]) >> (30 - 20))
-                               | ((@in[6 + inpos]) << 20);
-            @out[6 + outpos] = (int)((uint)(@in[6 + inpos]) >> (30 - 18))
-                               | ((@in[7 + inpos]) << 18);
-            @out[7 + outpos] = (int)((uint)(@in[7 + inpos]) >> (30 - 16))
-                               | ((@in[8 + inpos]) << 16);
-            @out[8 + outpos] = (int)((uint)(@in[8 + inpos]) >> (30 - 14))
-                               | ((@in[9 + inpos]) << 14);
-            @out[9 + outpos] = (int)((uint)(@in[9 + inpos]) >> (30 - 12))
-                               | ((@in[10 + inpos]) << 12);
-            @out[10 + outpos] = (int)((uint)(@in[10 + inpos]) >> (30 - 10))
-                                | ((@in[11 + inpos]) << 10);
-            @out[11 + outpos] = (int)((uint)(@in[11 + inpos]) >> (30 - 8))
-                                | ((@in[12 + inpos]) << 8);
-            @out[12 + outpos] = (int)((uint)(@in[12 + inpos]) >> (30 - 6))
-                                | ((@in[13 + inpos]) << 6);
-            @out[13 + outpos] = (int)((uint)(@in[13 + inpos]) >> (30 - 4))
-                                | ((@in[14 + inpos]) << 4);
-            @out[14 + outpos] = (int)((uint)(@in[14 + inpos]) >> (30 - 2))
-                                | ((@in[15 + inpos]) << 2);
-            @out[15 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 30);
-            @out[16 + outpos] = (int)((uint)(@in[17 + inpos]) >> (30 - 28))
-                                | ((@in[18 + inpos]) << 28);
-            @out[17 + outpos] = (int)((uint)(@in[18 + inpos]) >> (30 - 26))
-                                | ((@in[19 + inpos]) << 26);
-            @out[18 + outpos] = (int)((uint)(@in[19 + inpos]) >> (30 - 24))
-                                | ((@in[20 + inpos]) << 24);
-            @out[19 + outpos] = (int)((uint)(@in[20 + inpos]) >> (30 - 22))
-                                | ((@in[21 + inpos]) << 22);
-            @out[20 + outpos] = (int)((uint)(@in[21 + inpos]) >> (30 - 20))
-                                | ((@in[22 + inpos]) << 20);
-            @out[21 + outpos] = (int)((uint)(@in[22 + inpos]) >> (30 - 18))
-                                | ((@in[23 + inpos]) << 18);
-            @out[22 + outpos] = (int)((uint)(@in[23 + inpos]) >> (30 - 16))
-                                | ((@in[24 + inpos]) << 16);
-            @out[23 + outpos] = (int)((uint)(@in[24 + inpos]) >> (30 - 14))
-                                | ((@in[25 + inpos]) << 14);
-            @out[24 + outpos] = (int)((uint)(@in[25 + inpos]) >> (30 - 12))
-                                | ((@in[26 + inpos]) << 12);
-            @out[25 + outpos] = (int)((uint)(@in[26 + inpos]) >> (30 - 10))
-                                | ((@in[27 + inpos]) << 10);
-            @out[26 + outpos] = (int)((uint)(@in[27 + inpos]) >> (30 - 8))
-                                | ((@in[28 + inpos]) << 8);
-            @out[27 + outpos] = (int)((uint)(@in[28 + inpos]) >> (30 - 6))
-                                | ((@in[29 + inpos]) << 6);
-            @out[28 + outpos] = (int)((uint)(@in[29 + inpos]) >> (30 - 4))
-                                | ((@in[30 + inpos]) << 4);
-            @out[29 + outpos] = (int)((uint)(@in[30 + inpos]) >> (30 - 2))
-                                | ((@in[31 + inpos]) << 2);
-        }
-
-        protected static void fastpackwithoutmask31(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 31);
-            @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (31 - 30))
-                               | ((@in[2 + inpos]) << 30);
-            @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (31 - 29))
-                               | ((@in[3 + inpos]) << 29);
-            @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (31 - 28))
-                               | ((@in[4 + inpos]) << 28);
-            @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (31 - 27))
-                               | ((@in[5 + inpos]) << 27);
-            @out[5 + outpos] = (int)((uint)(@in[5 + inpos]) >> (31 - 26))
-                               | ((@in[6 + inpos]) << 26);
-            @out[6 + outpos] = (int)((uint)(@in[6 + inpos]) >> (31 - 25))
-                               | ((@in[7 + inpos]) << 25);
-            @out[7 + outpos] = (int)((uint)(@in[7 + inpos]) >> (31 - 24))
-                               | ((@in[8 + inpos]) << 24);
-            @out[8 + outpos] = (int)((uint)(@in[8 + inpos]) >> (31 - 23))
-                               | ((@in[9 + inpos]) << 23);
-            @out[9 + outpos] = (int)((uint)(@in[9 + inpos]) >> (31 - 22))
-                               | ((@in[10 + inpos]) << 22);
-            @out[10 + outpos] = (int)((uint)(@in[10 + inpos]) >> (31 - 21))
-                                | ((@in[11 + inpos]) << 21);
-            @out[11 + outpos] = (int)((uint)(@in[11 + inpos]) >> (31 - 20))
-                                | ((@in[12 + inpos]) << 20);
-            @out[12 + outpos] = (int)((uint)(@in[12 + inpos]) >> (31 - 19))
-                                | ((@in[13 + inpos]) << 19);
-            @out[13 + outpos] = (int)((uint)(@in[13 + inpos]) >> (31 - 18))
-                                | ((@in[14 + inpos]) << 18);
-            @out[14 + outpos] = (int)((uint)(@in[14 + inpos]) >> (31 - 17))
-                                | ((@in[15 + inpos]) << 17);
-            @out[15 + outpos] = (int)((uint)(@in[15 + inpos]) >> (31 - 16))
-                                | ((@in[16 + inpos]) << 16);
-            @out[16 + outpos] = (int)((uint)(@in[16 + inpos]) >> (31 - 15))
-                                | ((@in[17 + inpos]) << 15);
-            @out[17 + outpos] = (int)((uint)(@in[17 + inpos]) >> (31 - 14))
-                                | ((@in[18 + inpos]) << 14);
-            @out[18 + outpos] = (int)((uint)(@in[18 + inpos]) >> (31 - 13))
-                                | ((@in[19 + inpos]) << 13);
-            @out[19 + outpos] = (int)((uint)(@in[19 + inpos]) >> (31 - 12))
-                                | ((@in[20 + inpos]) << 12);
-            @out[20 + outpos] = (int)((uint)(@in[20 + inpos]) >> (31 - 11))
-                                | ((@in[21 + inpos]) << 11);
-            @out[21 + outpos] = (int)((uint)(@in[21 + inpos]) >> (31 - 10))
-                                | ((@in[22 + inpos]) << 10);
-            @out[22 + outpos] = (int)((uint)(@in[22 + inpos]) >> (31 - 9))
-                                | ((@in[23 + inpos]) << 9);
-            @out[23 + outpos] = (int)((uint)(@in[23 + inpos]) >> (31 - 8))
-                                | ((@in[24 + inpos]) << 8);
-            @out[24 + outpos] = (int)((uint)(@in[24 + inpos]) >> (31 - 7))
-                                | ((@in[25 + inpos]) << 7);
-            @out[25 + outpos] = (int)((uint)(@in[25 + inpos]) >> (31 - 6))
-                                | ((@in[26 + inpos]) << 6);
-            @out[26 + outpos] = (int)((uint)(@in[26 + inpos]) >> (31 - 5))
-                                | ((@in[27 + inpos]) << 5);
-            @out[27 + outpos] = (int)((uint)(@in[27 + inpos]) >> (31 - 4))
-                                | ((@in[28 + inpos]) << 4);
-            @out[28 + outpos] = (int)((uint)(@in[28 + inpos]) >> (31 - 3))
-                                | ((@in[29 + inpos]) << 3);
-            @out[29 + outpos] = (int)((uint)(@in[29 + inpos]) >> (31 - 2))
-                                | ((@in[30 + inpos]) << 2);
-            @out[30 + outpos] = (int)((uint)(@in[30 + inpos]) >> (31 - 1))
-                                | ((@in[31 + inpos]) << 1);
-        }
-
-        protected static void fastpackwithoutmask32(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            Array.Copy(@in, inpos, @out, outpos, 32);
-        }
-
-        protected static void fastpackwithoutmask4(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 4)
-                               | ((@in[2 + inpos]) << 8) | ((@in[3 + inpos]) << 12)
-                               | ((@in[4 + inpos]) << 16) | ((@in[5 + inpos]) << 20)
-                               | ((@in[6 + inpos]) << 24) | ((@in[7 + inpos]) << 28);
-            @out[1 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 4)
-                               | ((@in[10 + inpos]) << 8) | ((@in[11 + inpos]) << 12)
-                               | ((@in[12 + inpos]) << 16) | ((@in[13 + inpos]) << 20)
-                               | ((@in[14 + inpos]) << 24) | ((@in[15 + inpos]) << 28);
-            @out[2 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 4)
-                               | ((@in[18 + inpos]) << 8) | ((@in[19 + inpos]) << 12)
-                               | ((@in[20 + inpos]) << 16) | ((@in[21 + inpos]) << 20)
-                               | ((@in[22 + inpos]) << 24) | ((@in[23 + inpos]) << 28);
-            @out[3 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 4)
-                               | ((@in[26 + inpos]) << 8) | ((@in[27 + inpos]) << 12)
-                               | ((@in[28 + inpos]) << 16) | ((@in[29 + inpos]) << 20)
-                               | ((@in[30 + inpos]) << 24) | ((@in[31 + inpos]) << 28);
-        }
-
-        protected static void fastpackwithoutmask5(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 5)
-                               | ((@in[2 + inpos]) << 10) | ((@in[3 + inpos]) << 15)
-                               | ((@in[4 + inpos]) << 20) | ((@in[5 + inpos]) << 25)
-                               | ((@in[6 + inpos]) << 30);
-            @out[1 + outpos] = (int)((uint)(@in[6 + inpos]) >> (5 - 3))
-                               | ((@in[7 + inpos]) << 3) | ((@in[8 + inpos]) << 8)
-                               | ((@in[9 + inpos]) << 13) | ((@in[10 + inpos]) << 18)
-                               | ((@in[11 + inpos]) << 23) | ((@in[12 + inpos]) << 28);
-            @out[2 + outpos] = (int)((uint)(@in[12 + inpos]) >> (5 - 1))
-                               | ((@in[13 + inpos]) << 1) | ((@in[14 + inpos]) << 6)
-                               | ((@in[15 + inpos]) << 11) | ((@in[16 + inpos]) << 16)
-                               | ((@in[17 + inpos]) << 21) | ((@in[18 + inpos]) << 26)
-                               | ((@in[19 + inpos]) << 31);
-            @out[3 + outpos] = (int)((uint)(@in[19 + inpos]) >> (5 - 4))
-                               | ((@in[20 + inpos]) << 4) | ((@in[21 + inpos]) << 9)
-                               | ((@in[22 + inpos]) << 14) | ((@in[23 + inpos]) << 19)
-                               | ((@in[24 + inpos]) << 24) | ((@in[25 + inpos]) << 29);
-            @out[4 + outpos] = (int)((uint)(@in[25 + inpos]) >> (5 - 2))
-                               | ((@in[26 + inpos]) << 2) | ((@in[27 + inpos]) << 7)
-                               | ((@in[28 + inpos]) << 12) | ((@in[29 + inpos]) << 17)
-                               | ((@in[30 + inpos]) << 22) | ((@in[31 + inpos]) << 27);
-        }
-
-        protected static void fastpackwithoutmask6(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 6)
-                               | ((@in[2 + inpos]) << 12) | ((@in[3 + inpos]) << 18)
-                               | ((@in[4 + inpos]) << 24) | ((@in[5 + inpos]) << 30);
-            @out[1 + outpos] = (int)((uint)(@in[5 + inpos]) >> (6 - 4))
-                               | ((@in[6 + inpos]) << 4) | ((@in[7 + inpos]) << 10)
-                               | ((@in[8 + inpos]) << 16) | ((@in[9 + inpos]) << 22)
-                               | ((@in[10 + inpos]) << 28);
-            @out[2 + outpos] = (int)((uint)(@in[10 + inpos]) >> (6 - 2))
-                               | ((@in[11 + inpos]) << 2) | ((@in[12 + inpos]) << 8)
-                               | ((@in[13 + inpos]) << 14) | ((@in[14 + inpos]) << 20)
-                               | ((@in[15 + inpos]) << 26);
-            @out[3 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 6)
-                               | ((@in[18 + inpos]) << 12) | ((@in[19 + inpos]) << 18)
-                               | ((@in[20 + inpos]) << 24) | ((@in[21 + inpos]) << 30);
-            @out[4 + outpos] = (int)((uint)(@in[21 + inpos]) >> (6 - 4))
-                               | ((@in[22 + inpos]) << 4) | ((@in[23 + inpos]) << 10)
-                               | ((@in[24 + inpos]) << 16) | ((@in[25 + inpos]) << 22)
-                               | ((@in[26 + inpos]) << 28);
-            @out[5 + outpos] = (int)((uint)(@in[26 + inpos]) >> (6 - 2))
-                               | ((@in[27 + inpos]) << 2) | ((@in[28 + inpos]) << 8)
-                               | ((@in[29 + inpos]) << 14) | ((@in[30 + inpos]) << 20)
-                               | ((@in[31 + inpos]) << 26);
-        }
-
-        protected static void fastpackwithoutmask7(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 7)
-                               | ((@in[2 + inpos]) << 14) | ((@in[3 + inpos]) << 21)
-                               | ((@in[4 + inpos]) << 28);
-            @out[1 + outpos] = (int)((uint)(@in[4 + inpos]) >> (7 - 3))
-                               | ((@in[5 + inpos]) << 3) | ((@in[6 + inpos]) << 10)
-                               | ((@in[7 + inpos]) << 17) | ((@in[8 + inpos]) << 24)
-                               | ((@in[9 + inpos]) << 31);
-            @out[2 + outpos] = (int)((uint)(@in[9 + inpos]) >> (7 - 6))
-                               | ((@in[10 + inpos]) << 6) | ((@in[11 + inpos]) << 13)
-                               | ((@in[12 + inpos]) << 20) | ((@in[13 + inpos]) << 27);
-            @out[3 + outpos] = (int)((uint)(@in[13 + inpos]) >> (7 - 2))
-                               | ((@in[14 + inpos]) << 2) | ((@in[15 + inpos]) << 9)
-                               | ((@in[16 + inpos]) << 16) | ((@in[17 + inpos]) << 23)
-                               | ((@in[18 + inpos]) << 30);
-            @out[4 + outpos] = (int)((uint)(@in[18 + inpos]) >> (7 - 5))
-                               | ((@in[19 + inpos]) << 5) | ((@in[20 + inpos]) << 12)
-                               | ((@in[21 + inpos]) << 19) | ((@in[22 + inpos]) << 26);
-            @out[5 + outpos] = (int)((uint)(@in[22 + inpos]) >> (7 - 1))
-                               | ((@in[23 + inpos]) << 1) | ((@in[24 + inpos]) << 8)
-                               | ((@in[25 + inpos]) << 15) | ((@in[26 + inpos]) << 22)
-                               | ((@in[27 + inpos]) << 29);
-            @out[6 + outpos] = (int)((uint)(@in[27 + inpos]) >> (7 - 4))
-                               | ((@in[28 + inpos]) << 4) | ((@in[29 + inpos]) << 11)
-                               | ((@in[30 + inpos]) << 18) | ((@in[31 + inpos]) << 25);
-        }
-
-        protected static void fastpackwithoutmask8(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 8)
-                               | ((@in[2 + inpos]) << 16) | ((@in[3 + inpos]) << 24);
-            @out[1 + outpos] = @in[4 + inpos] | ((@in[5 + inpos]) << 8)
-                               | ((@in[6 + inpos]) << 16) | ((@in[7 + inpos]) << 24);
-            @out[2 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 8)
-                               | ((@in[10 + inpos]) << 16) | ((@in[11 + inpos]) << 24);
-            @out[3 + outpos] = @in[12 + inpos] | ((@in[13 + inpos]) << 8)
-                               | ((@in[14 + inpos]) << 16) | ((@in[15 + inpos]) << 24);
-            @out[4 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 8)
-                               | ((@in[18 + inpos]) << 16) | ((@in[19 + inpos]) << 24);
-            @out[5 + outpos] = @in[20 + inpos] | ((@in[21 + inpos]) << 8)
-                               | ((@in[22 + inpos]) << 16) | ((@in[23 + inpos]) << 24);
-            @out[6 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 8)
-                               | ((@in[26 + inpos]) << 16) | ((@in[27 + inpos]) << 24);
-            @out[7 + outpos] = @in[28 + inpos] | ((@in[29 + inpos]) << 8)
-                               | ((@in[30 + inpos]) << 16) | ((@in[31 + inpos]) << 24);
-        }
-
-        protected static void fastpackwithoutmask9(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 9)
-                               | ((@in[2 + inpos]) << 18) | ((@in[3 + inpos]) << 27);
-            @out[1 + outpos] = (int)((uint)(@in[3 + inpos]) >> (9 - 4))
-                               | ((@in[4 + inpos]) << 4) | ((@in[5 + inpos]) << 13)
-                               | ((@in[6 + inpos]) << 22) | ((@in[7 + inpos]) << 31);
-            @out[2 + outpos] = (int)((uint)(@in[7 + inpos]) >> (9 - 8))
-                               | ((@in[8 + inpos]) << 8) | ((@in[9 + inpos]) << 17)
-                               | ((@in[10 + inpos]) << 26);
-            @out[3 + outpos] = (int)((uint)(@in[10 + inpos]) >> (9 - 3))
-                               | ((@in[11 + inpos]) << 3) | ((@in[12 + inpos]) << 12)
-                               | ((@in[13 + inpos]) << 21) | ((@in[14 + inpos]) << 30);
-            @out[4 + outpos] = (int)((uint)(@in[14 + inpos]) >> (9 - 7))
-                               | ((@in[15 + inpos]) << 7) | ((@in[16 + inpos]) << 16)
-                               | ((@in[17 + inpos]) << 25);
-            @out[5 + outpos] = (int)((uint)(@in[17 + inpos]) >> (9 - 2))
-                               | ((@in[18 + inpos]) << 2) | ((@in[19 + inpos]) << 11)
-                               | ((@in[20 + inpos]) << 20) | ((@in[21 + inpos]) << 29);
-            @out[6 + outpos] = (int)((uint)(@in[21 + inpos]) >> (9 - 6))
-                               | ((@in[22 + inpos]) << 6) | ((@in[23 + inpos]) << 15)
-                               | ((@in[24 + inpos]) << 24);
-            @out[7 + outpos] = (int)((uint)(@in[24 + inpos]) >> (9 - 1))
-                               | ((@in[25 + inpos]) << 1) | ((@in[26 + inpos]) << 10)
-                               | ((@in[27 + inpos]) << 19) | ((@in[28 + inpos]) << 28);
-            @out[8 + outpos] = (int)((uint)(@in[28 + inpos]) >> (9 - 5))
-                               | ((@in[29 + inpos]) << 5) | ((@in[30 + inpos]) << 14)
-                               | ((@in[31 + inpos]) << 23);
-        }
-
-        /**
-         * Pack the 32 integers
-         * 
-         * @param in
-         *                source array
-         * @param inpos
-         *                starting point in the source array
-         * @param out
-         *                output array
-         * @param outpos
-         *                starting point in the output array
-         * @param bit
-         *                how many bits to use per integer
-         */
-        public static void fastunpack(int[] @in, int inpos, int[] @out, int outpos, int bit)
-        {
-            switch (bit)
-            {
-                case 0:
-                    fastunpack0(@in, inpos, @out, outpos);
-                    break;
-                case 1:
-                    fastunpack1(@in, inpos, @out, outpos);
-                    break;
-                case 2:
-                    fastunpack2(@in, inpos, @out, outpos);
-                    break;
-                case 3:
-                    fastunpack3(@in, inpos, @out, outpos);
-                    break;
-                case 4:
-                    fastunpack4(@in, inpos, @out, outpos);
-                    break;
-                case 5:
-                    fastunpack5(@in, inpos, @out, outpos);
-                    break;
-                case 6:
-                    fastunpack6(@in, inpos, @out, outpos);
-                    break;
-                case 7:
-                    fastunpack7(@in, inpos, @out, outpos);
-                    break;
-                case 8:
-                    fastunpack8(@in, inpos, @out, outpos);
-                    break;
-                case 9:
-                    fastunpack9(@in, inpos, @out, outpos);
-                    break;
-                case 10:
-                    fastunpack10(@in, inpos, @out, outpos);
-                    break;
-                case 11:
-                    fastunpack11(@in, inpos, @out, outpos);
-                    break;
-                case 12:
-                    fastunpack12(@in, inpos, @out, outpos);
-                    break;
-                case 13:
-                    fastunpack13(@in, inpos, @out, outpos);
-                    break;
-                case 14:
-                    fastunpack14(@in, inpos, @out, outpos);
-                    break;
-                case 15:
-                    fastunpack15(@in, inpos, @out, outpos);
-                    break;
-                case 16:
-                    fastunpack16(@in, inpos, @out, outpos);
-                    break;
-                case 17:
-                    fastunpack17(@in, inpos, @out, outpos);
-                    break;
-                case 18:
-                    fastunpack18(@in, inpos, @out, outpos);
-                    break;
-                case 19:
-                    fastunpack19(@in, inpos, @out, outpos);
-                    break;
-                case 20:
-                    fastunpack20(@in, inpos, @out, outpos);
-                    break;
-                case 21:
-                    fastunpack21(@in, inpos, @out, outpos);
-                    break;
-                case 22:
-                    fastunpack22(@in, inpos, @out, outpos);
-                    break;
-                case 23:
-                    fastunpack23(@in, inpos, @out, outpos);
-                    break;
-                case 24:
-                    fastunpack24(@in, inpos, @out, outpos);
-                    break;
-                case 25:
-                    fastunpack25(@in, inpos, @out, outpos);
-                    break;
-                case 26:
-                    fastunpack26(@in, inpos, @out, outpos);
-                    break;
-                case 27:
-                    fastunpack27(@in, inpos, @out, outpos);
-                    break;
-                case 28:
-                    fastunpack28(@in, inpos, @out, outpos);
-                    break;
-                case 29:
-                    fastunpack29(@in, inpos, @out, outpos);
-                    break;
-                case 30:
-                    fastunpack30(@in, inpos, @out, outpos);
-                    break;
-                case 31:
-                    fastunpack31(@in, inpos, @out, outpos);
-                    break;
-                case 32:
-                    fastunpack32(@in, inpos, @out, outpos);
-                    break;
-                default:
-                    throw new ArgumentException(
-                        "Unsupported bit width.");
-            }
-        }
-
-        protected static void fastunpack0(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            Arrays.fill(@out, outpos, outpos + 32, 0);
-        }
-
-        protected static void fastunpack1(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 1);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 1) & 1);
-            @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 2) & 1);
-            @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 3) & 1);
-            @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 4) & 1);
-            @out[5 + outpos] = (int)(((uint)@in[0 + inpos] >> 5) & 1);
-            @out[6 + outpos] = (int)(((uint)@in[0 + inpos] >> 6) & 1);
-            @out[7 + outpos] = (int)(((uint)@in[0 + inpos] >> 7) & 1);
-            @out[8 + outpos] = (int)(((uint)@in[0 + inpos] >> 8) & 1);
-            @out[9 + outpos] = (int)(((uint)@in[0 + inpos] >> 9) & 1);
-            @out[10 + outpos] = (int)(((uint)@in[0 + inpos] >> 10) & 1);
-            @out[11 + outpos] = (int)(((uint)@in[0 + inpos] >> 11) & 1);
-            @out[12 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 1);
-            @out[13 + outpos] = (int)(((uint)@in[0 + inpos] >> 13) & 1);
-            @out[14 + outpos] = (int)(((uint)@in[0 + inpos] >> 14) & 1);
-            @out[15 + outpos] = (int)(((uint)@in[0 + inpos] >> 15) & 1);
-            @out[16 + outpos] = (int)(((uint)@in[0 + inpos] >> 16) & 1);
-            @out[17 + outpos] = (int)(((uint)@in[0 + inpos] >> 17) & 1);
-            @out[18 + outpos] = (int)(((uint)@in[0 + inpos] >> 18) & 1);
-            @out[19 + outpos] = (int)(((uint)@in[0 + inpos] >> 19) & 1);
-            @out[20 + outpos] = (int)(((uint)@in[0 + inpos] >> 20) & 1);
-            @out[21 + outpos] = (int)(((uint)@in[0 + inpos] >> 21) & 1);
-            @out[22 + outpos] = (int)(((uint)@in[0 + inpos] >> 22) & 1);
-            @out[23 + outpos] = (int)(((uint)@in[0 + inpos] >> 23) & 1);
-            @out[24 + outpos] = (int)(((uint)@in[0 + inpos] >> 24) & 1);
-            @out[25 + outpos] = (int)(((uint)@in[0 + inpos] >> 25) & 1);
-            @out[26 + outpos] = (int)(((uint)@in[0 + inpos] >> 26) & 1);
-            @out[27 + outpos] = (int)(((uint)@in[0 + inpos] >> 27) & 1);
-            @out[28 + outpos] = (int)(((uint)@in[0 + inpos] >> 28) & 1);
-            @out[29 + outpos] = (int)(((uint)@in[0 + inpos] >> 29) & 1);
-            @out[30 + outpos] = (int)(((uint)@in[0 + inpos] >> 30) & 1);
-            @out[31 + outpos] = (int)((uint)@in[0 + inpos] >> 31);
-        }
-
-        protected static void fastunpack10(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 1023);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 10) & 1023);
-            @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 20) & 1023);
-            @out[3 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
-                               | ((@in[1 + inpos] & 255) << (10 - 8));
-            @out[4 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 1023);
-            @out[5 + outpos] = (int)(((uint)@in[1 + inpos] >> 18) & 1023);
-            @out[6 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
-                               | ((@in[2 + inpos] & 63) << (10 - 6));
-            @out[7 + outpos] = (int)(((uint)@in[2 + inpos] >> 6) & 1023);
-            @out[8 + outpos] = (int)(((uint)@in[2 + inpos] >> 16) & 1023);
-            @out[9 + outpos] = (int)((uint)@in[2 + inpos] >> 26)
-                               | ((@in[3 + inpos] & 15) << (10 - 4));
-            @out[10 + outpos] = (int)(((uint)@in[3 + inpos] >> 4) & 1023);
-            @out[11 + outpos] = (int)(((uint)@in[3 + inpos] >> 14) & 1023);
-            @out[12 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
-                                | ((@in[4 + inpos] & 3) << (10 - 2));
-            @out[13 + outpos] = (int)(((uint)@in[4 + inpos] >> 2) & 1023);
-            @out[14 + outpos] = (int)(((uint)@in[4 + inpos] >> 12) & 1023);
-            @out[15 + outpos] = (int)((uint)@in[4 + inpos] >> 22);
-            @out[16 + outpos] = (int)(((uint)@in[5 + inpos] >> 0) & 1023);
-            @out[17 + outpos] = (int)(((uint)@in[5 + inpos] >> 10) & 1023);
-            @out[18 + outpos] = (int)(((uint)@in[5 + inpos] >> 20) & 1023);
-            @out[19 + outpos] = (int)((uint)@in[5 + inpos] >> 30)
-                                | ((@in[6 + inpos] & 255) << (10 - 8));
-            @out[20 + outpos] = (int)(((uint)@in[6 + inpos] >> 8) & 1023);
-            @out[21 + outpos] = (int)(((uint)@in[6 + inpos] >> 18) & 1023);
-            @out[22 + outpos] = (int)((uint)@in[6 + inpos] >> 28)
-                                | ((@in[7 + inpos] & 63) << (10 - 6));
-            @out[23 + outpos] = (int)(((uint)@in[7 + inpos] >> 6) & 1023);
-            @out[24 + outpos] = (int)(((uint)@in[7 + inpos] >> 16) & 1023);
-            @out[25 + outpos] = (int)((uint)@in[7 + inpos] >> 26)
-                                | ((@in[8 + inpos] & 15) << (10 - 4));
-            @out[26 + outpos] = (int)(((uint)@in[8 + inpos] >> 4) & 1023);
-            @out[27 + outpos] = (int)(((uint)@in[8 + inpos] >> 14) & 1023);
-            @out[28 + outpos] = (int)((uint)@in[8 + inpos] >> 24)
-                                | ((@in[9 + inpos] & 3) << (10 - 2));
-            @out[29 + outpos] = (int)(((uint)@in[9 + inpos] >> 2) & 1023);
-            @out[30 + outpos] = (int)(((uint)@in[9 + inpos] >> 12) & 1023);
-            @out[31 + outpos] = (int)((uint)@in[9 + inpos] >> 22);
-        }
-
-        protected static void fastunpack11(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 2047);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 11) & 2047);
-            @out[2 + outpos] = (int)((uint)@in[0 + inpos] >> 22)
-                               | ((@in[1 + inpos] & 1) << (11 - 1));
-            @out[3 + outpos] = (int)(((uint)@in[1 + inpos] >> 1) & 2047);
-            @out[4 + outpos] = (int)(((uint)@in[1 + inpos] >> 12) & 2047);
-            @out[5 + outpos] = (int)((uint)@in[1 + inpos] >> 23)
-                               | ((@in[2 + inpos] & 3) << (11 - 2));
-            @out[6 + outpos] = (int)(((uint)@in[2 + inpos] >> 2) & 2047);
-            @out[7 + outpos] = (int)(((uint)@in[2 + inpos] >> 13) & 2047);
-            @out[8 + outpos] = (int)((uint)@in[2 + inpos] >> 24)
-                               | ((@in[3 + inpos] & 7) << (11 - 3));
-            @out[9 + outpos] = (int)(((uint)@in[3 + inpos] >> 3) & 2047);
-            @out[10 + outpos] = (int)(((uint)@in[3 + inpos] >> 14) & 2047);
-            @out[11 + outpos] = (int)((uint)@in[3 + inpos] >> 25)
-                                | ((@in[4 + inpos] & 15) << (11 - 4));
-            @out[12 + outpos] = (int)(((uint)@in[4 + inpos] >> 4) & 2047);
-            @out[13 + outpos] = (int)(((uint)@in[4 + inpos] >> 15) & 2047);
-            @out[14 + outpos] = (int)((uint)@in[4 + inpos] >> 26)
-                                | ((@in[5 + inpos] & 31) << (11 - 5));
-            @out[15 + outpos] = (int)(((uint)@in[5 + inpos] >> 5) & 2047);
-            @out[16 + outpos] = (int)(((uint)@in[5 + inpos] >> 16) & 2047);
-            @out[17 + outpos] = (int)((uint)@in[5 + inpos] >> 27)
-                                | ((@in[6 + inpos] & 63) << (11 - 6));
-            @out[18 + outpos] = (int)(((uint)@in[6 + inpos] >> 6) & 2047);
-            @out[19 + outpos] = (int)(((uint)@in[6 + inpos] >> 17) & 2047);
-            @out[20 + outpos] = (int)((uint)@in[6 + inpos] >> 28)
-                                | ((@in[7 + inpos] & 127) << (11 - 7));
-            @out[21 + outpos] = (int)(((uint)@in[7 + inpos] >> 7) & 2047);
-            @out[22 + outpos] = (int)(((uint)@in[7 + inpos] >> 18) & 2047);
-            @out[23 + outpos] = (int)((uint)@in[7 + inpos] >> 29)
-                                | ((@in[8 + inpos] & 255) << (11 - 8));
-            @out[24 + outpos] = (int)(((uint)@in[8 + inpos] >> 8) & 2047);
-            @out[25 + outpos] = (int)(((uint)@in[8 + inpos] >> 19) & 2047);
-            @out[26 + outpos] = (int)((uint)@in[8 + inpos] >> 30)
-                                | ((@in[9 + inpos] & 511) << (11 - 9));
-            @out[27 + outpos] = (int)(((uint)@in[9 + inpos] >> 9) & 2047);
-            @out[28 + outpos] = (int)(((uint)@in[9 + inpos] >> 20) & 2047);
-            @out[29 + outpos] = (int)((uint)@in[9 + inpos] >> 31)
-                                | ((@in[10 + inpos] & 1023) << (11 - 10));
-            @out[30 + outpos] = (int)(((uint)@in[10 + inpos] >> 10) & 2047);
-            @out[31 + outpos] = (int)((uint)@in[10 + inpos] >> 21);
-        }
-
-        protected static void fastunpack12(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 4095);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 4095);
-            @out[2 + outpos] = (int)((uint)@in[0 + inpos] >> 24)
-                               | ((@in[1 + inpos] & 15) << (12 - 4));
-            @out[3 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 4095);
-            @out[4 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 4095);
-            @out[5 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
-                               | ((@in[2 + inpos] & 255) << (12 - 8));
-            @out[6 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 4095);
-            @out[7 + outpos] = (int)((uint)@in[2 + inpos] >> 20);
-            @out[8 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 4095);
-            @out[9 + outpos] = (int)(((uint)@in[3 + inpos] >> 12) & 4095);
-            @out[10 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
-                                | ((@in[4 + inpos] & 15) << (12 - 4));
-            @out[11 + outpos] = (int)(((uint)@in[4 + inpos] >> 4) & 4095);
-            @out[12 + outpos] = (int)(((uint)@in[4 + inpos] >> 16) & 4095);
-            @out[13 + outpos] = (int)((uint)@in[4 + inpos] >> 28)
-                                | ((@in[5 + inpos] & 255) << (12 - 8));
-            @out[14 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 4095);
-            @out[15 + outpos] = (int)((uint)@in[5 + inpos] >> 20);
-            @out[16 + outpos] = (int)(((uint)@in[6 + inpos] >> 0) & 4095);
-            @out[17 + outpos] = (int)(((uint)@in[6 + inpos] >> 12) & 4095);
-            @out[18 + outpos] = (int)((uint)@in[6 + inpos] >> 24)
-                                | ((@in[7 + inpos] & 15) << (12 - 4));
-            @out[19 + outpos] = (int)(((uint)@in[7 + inpos] >> 4) & 4095);
-            @out[20 + outpos] = (int)(((uint)@in[7 + inpos] >> 16) & 4095);
-            @out[21 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
-                                | ((@in[8 + inpos] & 255) << (12 - 8));
-            @out[22 + outpos] = (int)(((uint)@in[8 + inpos] >> 8) & 4095);
-            @out[23 + outpos] = (int)((uint)@in[8 + inpos] >> 20);
-            @out[24 + outpos] = (int)(((uint)@in[9 + inpos] >> 0) & 4095);
-            @out[25 + outpos] = (int)(((uint)@in[9 + inpos] >> 12) & 4095);
-            @out[26 + outpos] = (int)((uint)@in[9 + inpos] >> 24)
-                                | ((@in[10 + inpos] & 15) << (12 - 4));
-            @out[27 + outpos] = (int)(((uint)@in[10 + inpos] >> 4) & 4095);
-            @out[28 + outpos] = (int)(((uint)@in[10 + inpos] >> 16) & 4095);
-            @out[29 + outpos] = (int)((uint)@in[10 + inpos] >> 28)
-                                | ((@in[11 + inpos] & 255) << (12 - 8));
-            @out[30 + outpos] = (int)(((uint)@in[11 + inpos] >> 8) & 4095);
-            @out[31 + outpos] = (int)((uint)@in[11 + inpos] >> 20);
-        }
-
-        protected static void fastunpack13(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 8191);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 13) & 8191);
-            @out[2 + outpos] = (int)((uint)@in[0 + inpos] >> 26)
-                               | ((@in[1 + inpos] & 127) << (13 - 7));
-            @out[3 + outpos] = (int)(((uint)@in[1 + inpos] >> 7) & 8191);
-            @out[4 + outpos] = (int)((uint)@in[1 + inpos] >> 20)
-                               | ((@in[2 + inpos] & 1) << (13 - 1));
-            @out[5 + outpos] = (int)(((uint)@in[2 + inpos] >> 1) & 8191);
-            @out[6 + outpos] = (int)(((uint)@in[2 + inpos] >> 14) & 8191);
-            @out[7 + outpos] = (int)((uint)@in[2 + inpos] >> 27)
-                               | ((@in[3 + inpos] & 255) << (13 - 8));
-            @out[8 + outpos] = (int)(((uint)@in[3 + inpos] >> 8) & 8191);
-            @out[9 + outpos] = (int)((uint)@in[3 + inpos] >> 21)
-                               | ((@in[4 + inpos] & 3) << (13 - 2));
-            @out[10 + outpos] = (int)(((uint)@in[4 + inpos] >> 2) & 8191);
-            @out[11 + outpos] = (int)(((uint)@in[4 + inpos] >> 15) & 8191);
-            @out[12 + outpos] = (int)((uint)@in[4 + inpos] >> 28)
-                                | ((@in[5 + inpos] & 511) << (13 - 9));
-            @out[13 + outpos] = (int)(((uint)@in[5 + inpos] >> 9) & 8191);
-            @out[14 + outpos] = (int)((uint)@in[5 + inpos] >> 22)
-                                | ((@in[6 + inpos] & 7) << (13 - 3));
-            @out[15 + outpos] = (int)(((uint)@in[6 + inpos] >> 3) & 8191);
-            @out[16 + outpos] = (int)(((uint)@in[6 + inpos] >> 16) & 8191);
-            @out[17 + outpos] = (int)((uint)@in[6 + inpos] >> 29)
-                                | ((@in[7 + inpos] & 1023) << (13 - 10));
-            @out[18 + outpos] = (int)(((uint)@in[7 + inpos] >> 10) & 8191);
-            @out[19 + outpos] = (int)((uint)@in[7 + inpos] >> 23)
-                                | ((@in[8 + inpos] & 15) << (13 - 4));
-            @out[20 + outpos] = (int)(((uint)@in[8 + inpos] >> 4) & 8191);
-            @out[21 + outpos] = (int)(((uint)@in[8 + inpos] >> 17) & 8191);
-            @out[22 + outpos] = (int)((uint)@in[8 + inpos] >> 30)
-                                | ((@in[9 + inpos] & 2047) << (13 - 11));
-            @out[23 + outpos] = (int)(((uint)@in[9 + inpos] >> 11) & 8191);
-            @out[24 + outpos] = (int)((uint)@in[9 + inpos] >> 24)
-                                | ((@in[10 + inpos] & 31) << (13 - 5));
-            @out[25 + outpos] = (int)(((uint)@in[10 + inpos] >> 5) & 8191);
-            @out[26 + outpos] = (int)(((uint)@in[10 + inpos] >> 18) & 8191);
-            @out[27 + outpos] = (int)((uint)@in[10 + inpos] >> 31)
-                                | ((@in[11 + inpos] & 4095) << (13 - 12));
-            @out[28 + outpos] = (int)(((uint)@in[11 + inpos] >> 12) & 8191);
-            @out[29 + outpos] = (int)((uint)@in[11 + inpos] >> 25)
-                                | ((@in[12 + inpos] & 63) << (13 - 6));
-            @out[30 + outpos] = (int)(((uint)@in[12 + inpos] >> 6) & 8191);
-            @out[31 + outpos] = (int)((uint)@in[12 + inpos] >> 19);
-        }
-
-        protected static void fastunpack14(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 16383);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 14) & 16383);
-            @out[2 + outpos] = (int)((uint)@in[0 + inpos] >> 28)
-                               | ((@in[1 + inpos] & 1023) << (14 - 10));
-            @out[3 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 16383);
-            @out[4 + outpos] = (int)((uint)@in[1 + inpos] >> 24)
-                               | ((@in[2 + inpos] & 63) << (14 - 6));
-            @out[5 + outpos] = (int)(((uint)@in[2 + inpos] >> 6) & 16383);
-            @out[6 + outpos] = (int)((uint)@in[2 + inpos] >> 20)
-                               | ((@in[3 + inpos] & 3) << (14 - 2));
-            @out[7 + outpos] = (int)(((uint)@in[3 + inpos] >> 2) & 16383);
-            @out[8 + outpos] = (int)(((uint)@in[3 + inpos] >> 16) & 16383);
-            @out[9 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
-                               | ((@in[4 + inpos] & 4095) << (14 - 12));
-            @out[10 + outpos] = (int)(((uint)@in[4 + inpos] >> 12) & 16383);
-            @out[11 + outpos] = (int)((uint)@in[4 + inpos] >> 26)
-                                | ((@in[5 + inpos] & 255) << (14 - 8));
-            @out[12 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 16383);
-            @out[13 + outpos] = (int)((uint)@in[5 + inpos] >> 22)
-                                | ((@in[6 + inpos] & 15) << (14 - 4));
-            @out[14 + outpos] = (int)(((uint)@in[6 + inpos] >> 4) & 16383);
-            @out[15 + outpos] = (int)((uint)@in[6 + inpos] >> 18);
-            @out[16 + outpos] = (int)(((uint)@in[7 + inpos] >> 0) & 16383);
-            @out[17 + outpos] = (int)(((uint)@in[7 + inpos] >> 14) & 16383);
-            @out[18 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
-                                | ((@in[8 + inpos] & 1023) << (14 - 10));
-            @out[19 + outpos] = (int)(((uint)@in[8 + inpos] >> 10) & 16383);
-            @out[20 + outpos] = (int)((uint)@in[8 + inpos] >> 24)
-                                | ((@in[9 + inpos] & 63) << (14 - 6));
-            @out[21 + outpos] = (int)(((uint)@in[9 + inpos] >> 6) & 16383);
-            @out[22 + outpos] = (int)((uint)@in[9 + inpos] >> 20)
-                                | ((@in[10 + inpos] & 3) << (14 - 2));
-            @out[23 + outpos] = (int)(((uint)@in[10 + inpos] >> 2) & 16383);
-            @out[24 + outpos] = (int)(((uint)@in[10 + inpos] >> 16) & 16383);
-            @out[25 + outpos] = (int)((uint)@in[10 + inpos] >> 30)
-                                | ((@in[11 + inpos] & 4095) << (14 - 12));
-            @out[26 + outpos] = (int)(((uint)@in[11 + inpos] >> 12) & 16383);
-            @out[27 + outpos] = (int)((uint)@in[11 + inpos] >> 26)
-                                | ((@in[12 + inpos] & 255) << (14 - 8));
-            @out[28 + outpos] = (int)(((uint)@in[12 + inpos] >> 8) & 16383);
-            @out[29 + outpos] = (int)((uint)@in[12 + inpos] >> 22)
-                                | ((@in[13 + inpos] & 15) << (14 - 4));
-            @out[30 + outpos] = (int)(((uint)@in[13 + inpos] >> 4) & 16383);
-            @out[31 + outpos] = (int)((uint)@in[13 + inpos] >> 18);
-        }
-
-        protected static void fastunpack15(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 32767);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 15) & 32767);
-            @out[2 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
-                               | ((@in[1 + inpos] & 8191) << (15 - 13));
-            @out[3 + outpos] = (int)(((uint)@in[1 + inpos] >> 13) & 32767);
-            @out[4 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
-                               | ((@in[2 + inpos] & 2047) << (15 - 11));
-            @out[5 + outpos] = (int)(((uint)@in[2 + inpos] >> 11) & 32767);
-            @out[6 + outpos] = (int)((uint)@in[2 + inpos] >> 26)
-                               | ((@in[3 + inpos] & 511) << (15 - 9));
-            @out[7 + outpos] = (int)(((uint)@in[3 + inpos] >> 9) & 32767);
-            @out[8 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
-                               | ((@in[4 + inpos] & 127) << (15 - 7));
-            @out[9 + outpos] = (int)(((uint)@in[4 + inpos] >> 7) & 32767);
-            @out[10 + outpos] = (int)((uint)@in[4 + inpos] >> 22)
-                                | ((@in[5 + inpos] & 31) << (15 - 5));
-            @out[11 + outpos] = (int)(((uint)@in[5 + inpos] >> 5) & 32767);
-            @out[12 + outpos] = (int)((uint)@in[5 + inpos] >> 20)
-                                | ((@in[6 + inpos] & 7) << (15 - 3));
-            @out[13 + outpos] = (int)(((uint)@in[6 + inpos] >> 3) & 32767);
-            @out[14 + outpos] = (int)((uint)@in[6 + inpos] >> 18)
-                                | ((@in[7 + inpos] & 1) << (15 - 1));
-            @out[15 + outpos] = (int)(((uint)@in[7 + inpos] >> 1) & 32767);
-            @out[16 + outpos] = (int)(((uint)@in[7 + inpos] >> 16) & 32767);
-            @out[17 + outpos] = (int)((uint)@in[7 + inpos] >> 31)
-                                | ((@in[8 + inpos] & 16383) << (15 - 14));
-            @out[18 + outpos] = (int)(((uint)@in[8 + inpos] >> 14) & 32767);
-            @out[19 + outpos] = (int)((uint)@in[8 + inpos] >> 29)
-                                | ((@in[9 + inpos] & 4095) << (15 - 12));
-            @out[20 + outpos] = (int)(((uint)@in[9 + inpos] >> 12) & 32767);
-            @out[21 + outpos] = (int)((uint)@in[9 + inpos] >> 27)
-                                | ((@in[10 + inpos] & 1023) << (15 - 10));
-            @out[22 + outpos] = (int)(((uint)@in[10 + inpos] >> 10) & 32767);
-            @out[23 + outpos] = (int)((uint)@in[10 + inpos] >> 25)
-                                | ((@in[11 + inpos] & 255) << (15 - 8));
-            @out[24 + outpos] = (int)(((uint)@in[11 + inpos] >> 8) & 32767);
-            @out[25 + outpos] = (int)((uint)@in[11 + inpos] >> 23)
-                                | ((@in[12 + inpos] & 63) << (15 - 6));
-            @out[26 + outpos] = (int)(((uint)@in[12 + inpos] >> 6) & 32767);
-            @out[27 + outpos] = (int)((uint)@in[12 + inpos] >> 21)
-                                | ((@in[13 + inpos] & 15) << (15 - 4));
-            @out[28 + outpos] = (int)(((uint)@in[13 + inpos] >> 4) & 32767);
-            @out[29 + outpos] = (int)((uint)@in[13 + inpos] >> 19)
-                                | ((@in[14 + inpos] & 3) << (15 - 2));
-            @out[30 + outpos] = (int)(((uint)@in[14 + inpos] >> 2) & 32767);
-            @out[31 + outpos] = (int)((uint)@in[14 + inpos] >> 17);
-        }
-
-        protected static void fastunpack16(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 65535);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 16);
-            @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 0) & 65535);
-            @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 16);
-            @out[4 + outpos] = (int)(((uint)@in[2 + inpos] >> 0) & 65535);
-            @out[5 + outpos] = (int)((uint)@in[2 + inpos] >> 16);
-            @out[6 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 65535);
-            @out[7 + outpos] = (int)((uint)@in[3 + inpos] >> 16);
-            @out[8 + outpos] = (int)(((uint)@in[4 + inpos] >> 0) & 65535);
-            @out[9 + outpos] = (int)((uint)@in[4 + inpos] >> 16);
-            @out[10 + outpos] = (int)(((uint)@in[5 + inpos] >> 0) & 65535);
-            @out[11 + outpos] = (int)((uint)@in[5 + inpos] >> 16);
-            @out[12 + outpos] = (int)(((uint)@in[6 + inpos] >> 0) & 65535);
-            @out[13 + outpos] = (int)((uint)@in[6 + inpos] >> 16);
-            @out[14 + outpos] = (int)(((uint)@in[7 + inpos] >> 0) & 65535);
-            @out[15 + outpos] = (int)((uint)@in[7 + inpos] >> 16);
-            @out[16 + outpos] = (int)(((uint)@in[8 + inpos] >> 0) & 65535);
-            @out[17 + outpos] = (int)((uint)@in[8 + inpos] >> 16);
-            @out[18 + outpos] = (int)(((uint)@in[9 + inpos] >> 0) & 65535);
-            @out[19 + outpos] = (int)((uint)@in[9 + inpos] >> 16);
-            @out[20 + outpos] = (int)(((uint)@in[10 + inpos] >> 0) & 65535);
-            @out[21 + outpos] = (int)((uint)@in[10 + inpos] >> 16);
-            @out[22 + outpos] = (int)(((uint)@in[11 + inpos] >> 0) & 65535);
-            @out[23 + outpos] = (int)((uint)@in[11 + inpos] >> 16);
-            @out[24 + outpos] = (int)(((uint)@in[12 + inpos] >> 0) & 65535);
-            @out[25 + outpos] = (int)((uint)@in[12 + inpos] >> 16);
-            @out[26 + outpos] = (int)(((uint)@in[13 + inpos] >> 0) & 65535);
-            @out[27 + outpos] = (int)((uint)@in[13 + inpos] >> 16);
-            @out[28 + outpos] = (int)(((uint)@in[14 + inpos] >> 0) & 65535);
-            @out[29 + outpos] = (int)((uint)@in[14 + inpos] >> 16);
-            @out[30 + outpos] = (int)(((uint)@in[15 + inpos] >> 0) & 65535);
-            @out[31 + outpos] = (int)((uint)@in[15 + inpos] >> 16);
-        }
-
-        protected static void fastunpack17(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 131071);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 17)
-                               | ((@in[1 + inpos] & 3) << (17 - 2));
-            @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 2) & 131071);
-            @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 19)
-                               | ((@in[2 + inpos] & 15) << (17 - 4));
-            @out[4 + outpos] = (int)(((uint)@in[2 + inpos] >> 4) & 131071);
-            @out[5 + outpos] = (int)((uint)@in[2 + inpos] >> 21)
-                               | ((@in[3 + inpos] & 63) << (17 - 6));
-            @out[6 + outpos] = (int)(((uint)@in[3 + inpos] >> 6) & 131071);
-            @out[7 + outpos] = (int)((uint)@in[3 + inpos] >> 23)
-                               | ((@in[4 + inpos] & 255) << (17 - 8));
-            @out[8 + outpos] = (int)(((uint)@in[4 + inpos] >> 8) & 131071);
-            @out[9 + outpos] = (int)((uint)@in[4 + inpos] >> 25)
-                               | ((@in[5 + inpos] & 1023) << (17 - 10));
-            @out[10 + outpos] = (int)(((uint)@in[5 + inpos] >> 10) & 131071);
-            @out[11 + outpos] = (int)((uint)@in[5 + inpos] >> 27)
-                                | ((@in[6 + inpos] & 4095) << (17 - 12));
-            @out[12 + outpos] = (int)(((uint)@in[6 + inpos] >> 12) & 131071);
-            @out[13 + outpos] = (int)((uint)@in[6 + inpos] >> 29)
-                                | ((@in[7 + inpos] & 16383) << (17 - 14));
-            @out[14 + outpos] = (int)(((uint)@in[7 + inpos] >> 14) & 131071);
-            @out[15 + outpos] = (int)((uint)@in[7 + inpos] >> 31)
-                                | ((@in[8 + inpos] & 65535) << (17 - 16));
-            @out[16 + outpos] = (int)((uint)@in[8 + inpos] >> 16)
-                                | ((@in[9 + inpos] & 1) << (17 - 1));
-            @out[17 + outpos] = (int)(((uint)@in[9 + inpos] >> 1) & 131071);
-            @out[18 + outpos] = (int)((uint)@in[9 + inpos] >> 18)
-                                | ((@in[10 + inpos] & 7) << (17 - 3));
-            @out[19 + outpos] = (int)(((uint)@in[10 + inpos] >> 3) & 131071);
-            @out[20 + outpos] = (int)((uint)@in[10 + inpos] >> 20)
-                                | ((@in[11 + inpos] & 31) << (17 - 5));
-            @out[21 + outpos] = (int)(((uint)@in[11 + inpos] >> 5) & 131071);
-            @out[22 + outpos] = (int)((uint)@in[11 + inpos] >> 22)
-                                | ((@in[12 + inpos] & 127) << (17 - 7));
-            @out[23 + outpos] = (int)(((uint)@in[12 + inpos] >> 7) & 131071);
-            @out[24 + outpos] = (int)((uint)@in[12 + inpos] >> 24)
-                                | ((@in[13 + inpos] & 511) << (17 - 9));
-            @out[25 + outpos] = (int)(((uint)@in[13 + inpos] >> 9) & 131071);
-            @out[26 + outpos] = (int)((uint)@in[13 + inpos] >> 26)
-                                | ((@in[14 + inpos] & 2047) << (17 - 11));
-            @out[27 + outpos] = (int)(((uint)@in[14 + inpos] >> 11) & 131071);
-            @out[28 + outpos] = (int)((uint)@in[14 + inpos] >> 28)
-                                | ((@in[15 + inpos] & 8191) << (17 - 13));
-            @out[29 + outpos] = (int)(((uint)@in[15 + inpos] >> 13) & 131071);
-            @out[30 + outpos] = (int)((uint)@in[15 + inpos] >> 30)
-                                | ((@in[16 + inpos] & 32767) << (17 - 15));
-            @out[31 + outpos] = (int)((uint)@in[16 + inpos] >> 15);
-        }
-
-        protected static void fastunpack18(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 262143);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 18)
-                               | ((@in[1 + inpos] & 15) << (18 - 4));
-            @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 262143);
-            @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 22)
-                               | ((@in[2 + inpos] & 255) << (18 - 8));
-            @out[4 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 262143);
-            @out[5 + outpos] = (int)((uint)@in[2 + inpos] >> 26)
-                               | ((@in[3 + inpos] & 4095) << (18 - 12));
-            @out[6 + outpos] = (int)(((uint)@in[3 + inpos] >> 12) & 262143);
-            @out[7 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
-                               | ((@in[4 + inpos] & 65535) << (18 - 16));
-            @out[8 + outpos] = (int)((uint)@in[4 + inpos] >> 16)
-                               | ((@in[5 + inpos] & 3) << (18 - 2));
-            @out[9 + outpos] = (int)(((uint)@in[5 + inpos] >> 2) & 262143);
-            @out[10 + outpos] = (int)((uint)@in[5 + inpos] >> 20)
-                                | ((@in[6 + inpos] & 63) << (18 - 6));
-            @out[11 + outpos] = (int)(((uint)@in[6 + inpos] >> 6) & 262143);
-            @out[12 + outpos] = (int)((uint)@in[6 + inpos] >> 24)
-                                | ((@in[7 + inpos] & 1023) << (18 - 10));
-            @out[13 + outpos] = (int)(((uint)@in[7 + inpos] >> 10) & 262143);
-            @out[14 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
-                                | ((@in[8 + inpos] & 16383) << (18 - 14));
-            @out[15 + outpos] = (int)((uint)@in[8 + inpos] >> 14);
-            @out[16 + outpos] = (int)(((uint)@in[9 + inpos] >> 0) & 262143);
-            @out[17 + outpos] = (int)((uint)@in[9 + inpos] >> 18)
-                                | ((@in[10 + inpos] & 15) << (18 - 4));
-            @out[18 + outpos] = (int)(((uint)@in[10 + inpos] >> 4) & 262143);
-            @out[19 + outpos] = (int)((uint)@in[10 + inpos] >> 22)
-                                | ((@in[11 + inpos] & 255) << (18 - 8));
-            @out[20 + outpos] = (int)(((uint)@in[11 + inpos] >> 8) & 262143);
-            @out[21 + outpos] = (int)((uint)@in[11 + inpos] >> 26)
-                                | ((@in[12 + inpos] & 4095) << (18 - 12));
-            @out[22 + outpos] = (int)(((uint)@in[12 + inpos] >> 12) & 262143);
-            @out[23 + outpos] = (int)((uint)@in[12 + inpos] >> 30)
-                                | ((@in[13 + inpos] & 65535) << (18 - 16));
-            @out[24 + outpos] = (int)((uint)@in[13 + inpos] >> 16)
-                                | ((@in[14 + inpos] & 3) << (18 - 2));
-            @out[25 + outpos] = (int)(((uint)@in[14 + inpos] >> 2) & 262143);
-            @out[26 + outpos] = (int)((uint)@in[14 + inpos] >> 20)
-                                | ((@in[15 + inpos] & 63) << (18 - 6));
-            @out[27 + outpos] = (int)(((uint)@in[15 + inpos] >> 6) & 262143);
-            @out[28 + outpos] = (int)((uint)@in[15 + inpos] >> 24)
-                                | ((@in[16 + inpos] & 1023) << (18 - 10));
-            @out[29 + outpos] = (int)(((uint)@in[16 + inpos] >> 10) & 262143);
-            @out[30 + outpos] = (int)((uint)@in[16 + inpos] >> 28)
-                                | ((@in[17 + inpos] & 16383) << (18 - 14));
-            @out[31 + outpos] = (int)((uint)@in[17 + inpos] >> 14);
-        }
-
-        protected static void fastunpack19(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 524287);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 19)
-                               | ((@in[1 + inpos] & 63) << (19 - 6));
-            @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 6) & 524287);
-            @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 25)
-                               | ((@in[2 + inpos] & 4095) << (19 - 12));
-            @out[4 + outpos] = (int)(((uint)@in[2 + inpos] >> 12) & 524287);
-            @out[5 + outpos] = (int)((uint)@in[2 + inpos] >> 31)
-                               | ((@in[3 + inpos] & 262143) << (19 - 18));
-            @out[6 + outpos] = (int)((uint)@in[3 + inpos] >> 18)
-                               | ((@in[4 + inpos] & 31) << (19 - 5));
-            @out[7 + outpos] = (int)(((uint)@in[4 + inpos] >> 5) & 524287);
-            @out[8 + outpos] = (int)((uint)@in[4 + inpos] >> 24)
-                               | ((@in[5 + inpos] & 2047) << (19 - 11));
-            @out[9 + outpos] = (int)(((uint)@in[5 + inpos] >> 11) & 524287);
-            @out[10 + outpos] = (int)((uint)@in[5 + inpos] >> 30)
-                                | ((@in[6 + inpos] & 131071) << (19 - 17));
-            @out[11 + outpos] = (int)((uint)@in[6 + inpos] >> 17)
-                                | ((@in[7 + inpos] & 15) << (19 - 4));
-            @out[12 + outpos] = (int)(((uint)@in[7 + inpos] >> 4) & 524287);
-            @out[13 + outpos] = (int)((uint)@in[7 + inpos] >> 23)
-                                | ((@in[8 + inpos] & 1023) << (19 - 10));
-            @out[14 + outpos] = (int)(((uint)@in[8 + inpos] >> 10) & 524287);
-            @out[15 + outpos] = (int)((uint)@in[8 + inpos] >> 29)
-                                | ((@in[9 + inpos] & 65535) << (19 - 16));
-            @out[16 + outpos] = (int)((uint)@in[9 + inpos] >> 16)
-                                | ((@in[10 + inpos] & 7) << (19 - 3));
-            @out[17 + outpos] = (int)(((uint)@in[10 + inpos] >> 3) & 524287);
-            @out[18 + outpos] = (int)((uint)@in[10 + inpos] >> 22)
-                                | ((@in[11 + inpos] & 511) << (19 - 9));
-            @out[19 + outpos] = (int)(((uint)@in[11 + inpos] >> 9) & 524287);
-            @out[20 + outpos] = (int)((uint)@in[11 + inpos] >> 28)
-                                | ((@in[12 + inpos] & 32767) << (19 - 15));
-            @out[21 + outpos] = (int)((uint)@in[12 + inpos] >> 15)
-                                | ((@in[13 + inpos] & 3) << (19 - 2));
-            @out[22 + outpos] = (int)(((uint)@in[13 + inpos] >> 2) & 524287);
-            @out[23 + outpos] = (int)((uint)@in[13 + inpos] >> 21)
-                                | ((@in[14 + inpos] & 255) << (19 - 8));
-            @out[24 + outpos] = (int)(((uint)@in[14 + inpos] >> 8) & 524287);
-            @out[25 + outpos] = (int)((uint)@in[14 + inpos] >> 27)
-                                | ((@in[15 + inpos] & 16383) << (19 - 14));
-            @out[26 + outpos] = (int)((uint)@in[15 + inpos] >> 14)
-                                | ((@in[16 + inpos] & 1) << (19 - 1));
-            @out[27 + outpos] = (int)(((uint)@in[16 + inpos] >> 1) & 524287);
-            @out[28 + outpos] = (int)((uint)@in[16 + inpos] >> 20)
-                                | ((@in[17 + inpos] & 127) << (19 - 7));
-            @out[29 + outpos] = (int)(((uint)@in[17 + inpos] >> 7) & 524287);
-            @out[30 + outpos] = (int)((uint)@in[17 + inpos] >> 26)
-                                | ((@in[18 + inpos] & 8191) << (19 - 13));
-            @out[31 + outpos] = (int)((uint)@in[18 + inpos] >> 13);
-        }
-
-        protected static void fastunpack2(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 3);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 2) & 3);
-            @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 4) & 3);
-            @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 6) & 3);
-            @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 8) & 3);
-            @out[5 + outpos] = (int)(((uint)@in[0 + inpos] >> 10) & 3);
-            @out[6 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 3);
-            @out[7 + outpos] = (int)(((uint)@in[0 + inpos] >> 14) & 3);
-            @out[8 + outpos] = (int)(((uint)@in[0 + inpos] >> 16) & 3);
-            @out[9 + outpos] = (int)(((uint)@in[0 + inpos] >> 18) & 3);
-            @out[10 + outpos] = (int)(((uint)@in[0 + inpos] >> 20) & 3);
-            @out[11 + outpos] = (int)(((uint)@in[0 + inpos] >> 22) & 3);
-            @out[12 + outpos] = (int)(((uint)@in[0 + inpos] >> 24) & 3);
-            @out[13 + outpos] = (int)(((uint)@in[0 + inpos] >> 26) & 3);
-            @out[14 + outpos] = (int)(((uint)@in[0 + inpos] >> 28) & 3);
-            @out[15 + outpos] = (int)((uint)@in[0 + inpos] >> 30);
-            @out[16 + outpos] = (int)(((uint)@in[1 + inpos] >> 0) & 3);
-            @out[17 + outpos] = (int)(((uint)@in[1 + inpos] >> 2) & 3);
-            @out[18 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 3);
-            @out[19 + outpos] = (int)(((uint)@in[1 + inpos] >> 6) & 3);
-            @out[20 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 3);
-            @out[21 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 3);
-            @out[22 + outpos] = (int)(((uint)@in[1 + inpos] >> 12) & 3);
-            @out[23 + outpos] = (int)(((uint)@in[1 + inpos] >> 14) & 3);
-            @out[24 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 3);
-            @out[25 + outpos] = (int)(((uint)@in[1 + inpos] >> 18) & 3);
-            @out[26 + outpos] = (int)(((uint)@in[1 + inpos] >> 20) & 3);
-            @out[27 + outpos] = (int)(((uint)@in[1 + inpos] >> 22) & 3);
-            @out[28 + outpos] = (int)(((uint)@in[1 + inpos] >> 24) & 3);
-            @out[29 + outpos] = (int)(((uint)@in[1 + inpos] >> 26) & 3);
-            @out[30 + outpos] = (int)(((uint)@in[1 + inpos] >> 28) & 3);
-            @out[31 + outpos] = (int)((uint)@in[1 + inpos] >> 30);
-        }
-
-        protected static void fastunpack20(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 1048575);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 20)
-                               | ((@in[1 + inpos] & 255) << (20 - 8));
-            @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 1048575);
-            @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
-                               | ((@in[2 + inpos] & 65535) << (20 - 16));
-            @out[4 + outpos] = (int)((uint)@in[2 + inpos] >> 16)
-                               | ((@in[3 + inpos] & 15) << (20 - 4));
-            @out[5 + outpos] = (int)(((uint)@in[3 + inpos] >> 4) & 1048575);
-            @out[6 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
-                               | ((@in[4 + inpos] & 4095) << (20 - 12));
-            @out[7 + outpos] = (int)((uint)@in[4 + inpos] >> 12);
-            @out[8 + outpos] = (int)(((uint)@in[5 + inpos] >> 0) & 1048575);
-            @out[9 + outpos] = (int)((uint)@in[5 + inpos] >> 20)
-                               | ((@in[6 + inpos] & 255) << (20 - 8));
-            @out[10 + outpos] = (int)(((uint)@in[6 + inpos] >> 8) & 1048575);
-            @out[11 + outpos] = (int)((uint)@in[6 + inpos] >> 28)
-                                | ((@in[7 + inpos] & 65535) << (20 - 16));
-            @out[12 + outpos] = (int)((uint)@in[7 + inpos] >> 16)
-                                | ((@in[8 + inpos] & 15) << (20 - 4));
-            @out[13 + outpos] = (int)(((uint)@in[8 + inpos] >> 4) & 1048575);
-            @out[14 + outpos] = (int)((uint)@in[8 + inpos] >> 24)
-                                | ((@in[9 + inpos] & 4095) << (20 - 12));
-            @out[15 + outpos] = (int)((uint)@in[9 + inpos] >> 12);
-            @out[16 + outpos] = (int)(((uint)@in[10 + inpos] >> 0) & 1048575);
-            @out[17 + outpos] = (int)((uint)@in[10 + inpos] >> 20)
-                                | ((@in[11 + inpos] & 255) << (20 - 8));
-            @out[18 + outpos] = (int)(((uint)@in[11 + inpos] >> 8) & 1048575);
-            @out[19 + outpos] = (int)((uint)@in[11 + inpos] >> 28)
-                                | ((@in[12 + inpos] & 65535) << (20 - 16));
-            @out[20 + outpos] = (int)((uint)@in[12 + inpos] >> 16)
-                                | ((@in[13 + inpos] & 15) << (20 - 4));
-            @out[21 + outpos] = (int)(((uint)@in[13 + inpos] >> 4) & 1048575);
-            @out[22 + outpos] = (int)((uint)@in[13 + inpos] >> 24)
-                                | ((@in[14 + inpos] & 4095) << (20 - 12));
-            @out[23 + outpos] = (int)((uint)@in[14 + inpos] >> 12);
-            @out[24 + outpos] = (int)(((uint)@in[15 + inpos] >> 0) & 1048575);
-            @out[25 + outpos] = (int)((uint)@in[15 + inpos] >> 20)
-                                | ((@in[16 + inpos] & 255) << (20 - 8));
-            @out[26 + outpos] = (int)(((uint)@in[16 + inpos] >> 8) & 1048575);
-            @out[27 + outpos] = (int)((uint)@in[16 + inpos] >> 28)
-                                | ((@in[17 + inpos] & 65535) << (20 - 16));
-            @out[28 + outpos] = (int)((uint)@in[17 + inpos] >> 16)
-                                | ((@in[18 + inpos] & 15) << (20 - 4));
-            @out[29 + outpos] = (int)(((uint)@in[18 + inpos] >> 4) & 1048575);
-            @out[30 + outpos] = (int)((uint)@in[18 + inpos] >> 24)
-                                | ((@in[19 + inpos] & 4095) << (20 - 12));
-            @out[31 + outpos] = (int)((uint)@in[19 + inpos] >> 12);
-        }
-
-        protected static void fastunpack21(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 2097151);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 21)
-                               | ((@in[1 + inpos] & 1023) << (21 - 10));
-            @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 2097151);
-            @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 31)
-                               | ((@in[2 + inpos] & 1048575) << (21 - 20));
-            @out[4 + outpos] = (int)((uint)@in[2 + inpos] >> 20)
-                               | ((@in[3 + inpos] & 511) << (21 - 9));
-            @out[5 + outpos] = (int)(((uint)@in[3 + inpos] >> 9) & 2097151);
-            @out[6 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
-                               | ((@in[4 + inpos] & 524287) << (21 - 19));
-            @out[7 + outpos] = (int)((uint)@in[4 + inpos] >> 19)
-                               | ((@in[5 + inpos] & 255) << (21 - 8));
-            @out[8 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 2097151);
-            @out[9 + outpos] = (int)((uint)@in[5 + inpos] >> 29)
-                               | ((@in[6 + inpos] & 262143) << (21 - 18));
-            @out[10 + outpos] = (int)((uint)@in[6 + inpos] >> 18)
-                                | ((@in[7 + inpos] & 127) << (21 - 7));
-            @out[11 + outpos] = (int)(((uint)@in[7 + inpos] >> 7) & 2097151);
-            @out[12 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
-                                | ((@in[8 + inpos] & 131071) << (21 - 17));
-            @out[13 + outpos] = (int)((uint)@in[8 + inpos] >> 17)
-                                | ((@in[9 + inpos] & 63) << (21 - 6));
-            @out[14 + outpos] = (int)(((uint)@in[9 + inpos] >> 6) & 2097151);
-            @out[15 + outpos] = (int)((uint)@in[9 + inpos] >> 27)
-                                | ((@in[10 + inpos] & 65535) << (21 - 16));
-            @out[16 + outpos] = (int)((uint)@in[10 + inpos] >> 16)
-                                | ((@in[11 + inpos] & 31) << (21 - 5));
-            @out[17 + outpos] = (int)(((uint)@in[11 + inpos] >> 5) & 2097151);
-            @out[18 + outpos] = (int)((uint)@in[11 + inpos] >> 26)
-                                | ((@in[12 + inpos] & 32767) << (21 - 15));
-            @out[19 + outpos] = (int)((uint)@in[12 + inpos] >> 15)
-                                | ((@in[13 + inpos] & 15) << (21 - 4));
-            @out[20 + outpos] = (int)(((uint)@in[13 + inpos] >> 4) & 2097151);
-            @out[21 + outpos] = (int)((uint)@in[13 + inpos] >> 25)
-                                | ((@in[14 + inpos] & 16383) << (21 - 14));
-            @out[22 + outpos] = (int)((uint)@in[14 + inpos] >> 14)
-                                | ((@in[15 + inpos] & 7) << (21 - 3));
-            @out[23 + outpos] = (int)(((uint)@in[15 + inpos] >> 3) & 2097151);
-            @out[24 + outpos] = (int)((uint)@in[15 + inpos] >> 24)
-                                | ((@in[16 + inpos] & 8191) << (21 - 13));
-            @out[25 + outpos] = (int)((uint)@in[16 + inpos] >> 13)
-                                | ((@in[17 + inpos] & 3) << (21 - 2));
-            @out[26 + outpos] = (int)(((uint)@in[17 + inpos] >> 2) & 2097151);
-            @out[27 + outpos] = (int)((uint)@in[17 + inpos] >> 23)
-                                | ((@in[18 + inpos] & 4095) << (21 - 12));
-            @out[28 + outpos] = (int)((uint)@in[18 + inpos] >> 12)
-                                | ((@in[19 + inpos] & 1) << (21 - 1));
-            @out[29 + outpos] = (int)(((uint)@in[19 + inpos] >> 1) & 2097151);
-            @out[30 + outpos] = (int)((uint)@in[19 + inpos] >> 22)
-                                | ((@in[20 + inpos] & 2047) << (21 - 11));
-            @out[31 + outpos] = (int)((uint)@in[20 + inpos] >> 11);
-        }
-
-        protected static void fastunpack22(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 4194303);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 22)
-                               | ((@in[1 + inpos] & 4095) << (22 - 12));
-            @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 12)
-                               | ((@in[2 + inpos] & 3) << (22 - 2));
-            @out[3 + outpos] = (int)(((uint)@in[2 + inpos] >> 2) & 4194303);
-            @out[4 + outpos] = (int)((uint)@in[2 + inpos] >> 24)
-                               | ((@in[3 + inpos] & 16383) << (22 - 14));
-            @out[5 + outpos] = (int)((uint)@in[3 + inpos] >> 14)
-                               | ((@in[4 + inpos] & 15) << (22 - 4));
-            @out[6 + outpos] = (int)(((uint)@in[4 + inpos] >> 4) & 4194303);
-            @out[7 + outpos] = (int)((uint)@in[4 + inpos] >> 26)
-                               | ((@in[5 + inpos] & 65535) << (22 - 16));
-            @out[8 + outpos] = (int)((uint)@in[5 + inpos] >> 16)
-                               | ((@in[6 + inpos] & 63) << (22 - 6));
-            @out[9 + outpos] = (int)(((uint)@in[6 + inpos] >> 6) & 4194303);
-            @out[10 + outpos] = (int)((uint)@in[6 + inpos] >> 28)
-                                | ((@in[7 + inpos] & 262143) << (22 - 18));
-            @out[11 + outpos] = (int)((uint)@in[7 + inpos] >> 18)
-                                | ((@in[8 + inpos] & 255) << (22 - 8));
-            @out[12 + outpos] = (int)(((uint)@in[8 + inpos] >> 8) & 4194303);
-            @out[13 + outpos] = (int)((uint)@in[8 + inpos] >> 30)
-                                | ((@in[9 + inpos] & 1048575) << (22 - 20));
-            @out[14 + outpos] = (int)((uint)@in[9 + inpos] >> 20)
-                                | ((@in[10 + inpos] & 1023) << (22 - 10));
-            @out[15 + outpos] = (int)((uint)@in[10 + inpos] >> 10);
-            @out[16 + outpos] = (int)(((uint)@in[11 + inpos] >> 0) & 4194303);
-            @out[17 + outpos] = (int)((uint)@in[11 + inpos] >> 22)
-                                | ((@in[12 + inpos] & 4095) << (22 - 12));
-            @out[18 + outpos] = (int)((uint)@in[12 + inpos] >> 12)
-                                | ((@in[13 + inpos] & 3) << (22 - 2));
-            @out[19 + outpos] = (int)(((uint)@in[13 + inpos] >> 2) & 4194303);
-            @out[20 + outpos] = (int)((uint)@in[13 + inpos] >> 24)
-                                | ((@in[14 + inpos] & 16383) << (22 - 14));
-            @out[21 + outpos] = (int)((uint)@in[14 + inpos] >> 14)
-                                | ((@in[15 + inpos] & 15) << (22 - 4));
-            @out[22 + outpos] = (int)(((uint)@in[15 + inpos] >> 4) & 4194303);
-            @out[23 + outpos] = (int)((uint)@in[15 + inpos] >> 26)
-                                | ((@in[16 + inpos] & 65535) << (22 - 16));
-            @out[24 + outpos] = (int)((uint)@in[16 + inpos] >> 16)
-                                | ((@in[17 + inpos] & 63) << (22 - 6));
-            @out[25 + outpos] = (int)(((uint)@in[17 + inpos] >> 6) & 4194303);
-            @out[26 + outpos] = (int)((uint)@in[17 + inpos] >> 28)
-                                | ((@in[18 + inpos] & 262143) << (22 - 18));
-            @out[27 + outpos] = (int)((uint)@in[18 + inpos] >> 18)
-                                | ((@in[19 + inpos] & 255) << (22 - 8));
-            @out[28 + outpos] = (int)(((uint)@in[19 + inpos] >> 8) & 4194303);
-            @out[29 + outpos] = (int)((uint)@in[19 + inpos] >> 30)
-                                | ((@in[20 + inpos] & 1048575) << (22 - 20));
-            @out[30 + outpos] = (int)((uint)@in[20 + inpos] >> 20)
-                                | ((@in[21 + inpos] & 1023) << (22 - 10));
-            @out[31 + outpos] = (int)((uint)@in[21 + inpos] >> 10);
-        }
-
-        protected static void fastunpack23(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 8388607);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 23)
-                               | ((@in[1 + inpos] & 16383) << (23 - 14));
-            @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 14)
-                               | ((@in[2 + inpos] & 31) << (23 - 5));
-            @out[3 + outpos] = (int)(((uint)@in[2 + inpos] >> 5) & 8388607);
-            @out[4 + outpos] = (int)((uint)@in[2 + inpos] >> 28)
-                               | ((@in[3 + inpos] & 524287) << (23 - 19));
-            @out[5 + outpos] = (int)((uint)@in[3 + inpos] >> 19)
-                               | ((@in[4 + inpos] & 1023) << (23 - 10));
-            @out[6 + outpos] = (int)((uint)@in[4 + inpos] >> 10)
-                               | ((@in[5 + inpos] & 1) << (23 - 1));
-            @out[7 + outpos] = (int)(((uint)@in[5 + inpos] >> 1) & 8388607);
-            @out[8 + outpos] = (int)((uint)@in[5 + inpos] >> 24)
-                               | ((@in[6 + inpos] & 32767) << (23 - 15));
-            @out[9 + outpos] = (int)((uint)@in[6 + inpos] >> 15)
-                               | ((@in[7 + inpos] & 63) << (23 - 6));
-            @out[10 + outpos] = (int)(((uint)@in[7 + inpos] >> 6) & 8388607);
-            @out[11 + outpos] = (int)((uint)@in[7 + inpos] >> 29)
-                                | ((@in[8 + inpos] & 1048575) << (23 - 20));
-            @out[12 + outpos] = (int)((uint)@in[8 + inpos] >> 20)
-                                | ((@in[9 + inpos] & 2047) << (23 - 11));
-            @out[13 + outpos] = (int)((uint)@in[9 + inpos] >> 11)
-                                | ((@in[10 + inpos] & 3) << (23 - 2));
-            @out[14 + outpos] = (int)(((uint)@in[10 + inpos] >> 2) & 8388607);
-            @out[15 + outpos] = (int)((uint)@in[10 + inpos] >> 25)
-                                | ((@in[11 + inpos] & 65535) << (23 - 16));
-            @out[16 + outpos] = (int)((uint)@in[11 + inpos] >> 16)
-                                | ((@in[12 + inpos] & 127) << (23 - 7));
-            @out[17 + outpos] = (int)(((uint)@in[12 + inpos] >> 7) & 8388607);
-            @out[18 + outpos] = (int)((uint)@in[12 + inpos] >> 30)
-                                | ((@in[13 + inpos] & 2097151) << (23 - 21));
-            @out[19 + outpos] = (int)((uint)@in[13 + inpos] >> 21)
-                                | ((@in[14 + inpos] & 4095) << (23 - 12));
-            @out[20 + outpos] = (int)((uint)@in[14 + inpos] >> 12)
-                                | ((@in[15 + inpos] & 7) << (23 - 3));
-            @out[21 + outpos] = (int)(((uint)@in[15 + inpos] >> 3) & 8388607);
-            @out[22 + outpos] = (int)((uint)@in[15 + inpos] >> 26)
-                                | ((@in[16 + inpos] & 131071) << (23 - 17));
-            @out[23 + outpos] = (int)((uint)@in[16 + inpos] >> 17)
-                                | ((@in[17 + inpos] & 255) << (23 - 8));
-            @out[24 + outpos] = (int)(((uint)@in[17 + inpos] >> 8) & 8388607);
-            @out[25 + outpos] = (int)((uint)@in[17 + inpos] >> 31)
-                                | ((@in[18 + inpos] & 4194303) << (23 - 22));
-            @out[26 + outpos] = (int)((uint)@in[18 + inpos] >> 22)
-                                | ((@in[19 + inpos] & 8191) << (23 - 13));
-            @out[27 + outpos] = (int)((uint)@in[19 + inpos] >> 13)
-                                | ((@in[20 + inpos] & 15) << (23 - 4));
-            @out[28 + outpos] = (int)(((uint)@in[20 + inpos] >> 4) & 8388607);
-            @out[29 + outpos] = (int)((uint)@in[20 + inpos] >> 27)
-                                | ((@in[21 + inpos] & 262143) << (23 - 18));
-            @out[30 + outpos] = (int)((uint)@in[21 + inpos] >> 18)
-                                | ((@in[22 + inpos] & 511) << (23 - 9));
-            @out[31 + outpos] = (int)((uint)@in[22 + inpos] >> 9);
-        }
-
-        protected static void fastunpack24(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 16777215);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 24)
-                               | ((@in[1 + inpos] & 65535) << (24 - 16));
-            @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 16)
-                               | ((@in[2 + inpos] & 255) << (24 - 8));
-            @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 8);
-            @out[4 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 16777215);
-            @out[5 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
-                               | ((@in[4 + inpos] & 65535) << (24 - 16));
-            @out[6 + outpos] = (int)((uint)@in[4 + inpos] >> 16)
-                               | ((@in[5 + inpos] & 255) << (24 - 8));
-            @out[7 + outpos] = (int)((uint)@in[5 + inpos] >> 8);
-            @out[8 + outpos] = (int)(((uint)@in[6 + inpos] >> 0) & 16777215);
-            @out[9 + outpos] = (int)((uint)@in[6 + inpos] >> 24)
-                               | ((@in[7 + inpos] & 65535) << (24 - 16));
-            @out[10 + outpos] = (int)((uint)@in[7 + inpos] >> 16)
-                                | ((@in[8 + inpos] & 255) << (24 - 8));
-            @out[11 + outpos] = (int)((uint)@in[8 + inpos] >> 8);
-            @out[12 + outpos] = (int)(((uint)@in[9 + inpos] >> 0) & 16777215);
-            @out[13 + outpos] = (int)((uint)@in[9 + inpos] >> 24)
-                                | ((@in[10 + inpos] & 65535) << (24 - 16));
-            @out[14 + outpos] = (int)((uint)@in[10 + inpos] >> 16)
-                                | ((@in[11 + inpos] & 255) << (24 - 8));
-            @out[15 + outpos] = (int)((uint)@in[11 + inpos] >> 8);
-            @out[16 + outpos] = (int)(((uint)@in[12 + inpos] >> 0) & 16777215);
-            @out[17 + outpos] = (int)((uint)@in[12 + inpos] >> 24)
-                                | ((@in[13 + inpos] & 65535) << (24 - 16));
-            @out[18 + outpos] = (int)((uint)@in[13 + inpos] >> 16)
-                                | ((@in[14 + inpos] & 255) << (24 - 8));
-            @out[19 + outpos] = (int)((uint)@in[14 + inpos] >> 8);
-            @out[20 + outpos] = (int)(((uint)@in[15 + inpos] >> 0) & 16777215);
-            @out[21 + outpos] = (int)((uint)@in[15 + inpos] >> 24)
-                                | ((@in[16 + inpos] & 65535) << (24 - 16));
-            @out[22 + outpos] = (int)((uint)@in[16 + inpos] >> 16)
-                                | ((@in[17 + inpos] & 255) << (24 - 8));
-            @out[23 + outpos] = (int)((uint)@in[17 + inpos] >> 8);
-            @out[24 + outpos] = (int)(((uint)@in[18 + inpos] >> 0) & 16777215);
-            @out[25 + outpos] = (int)((uint)@in[18 + inpos] >> 24)
-                                | ((@in[19 + inpos] & 65535) << (24 - 16));
-            @out[26 + outpos] = (int)((uint)@in[19 + inpos] >> 16)
-                                | ((@in[20 + inpos] & 255) << (24 - 8));
-            @out[27 + outpos] = (int)((uint)@in[20 + inpos] >> 8);
-            @out[28 + outpos] = (int)(((uint)@in[21 + inpos] >> 0) & 16777215);
-            @out[29 + outpos] = (int)((uint)@in[21 + inpos] >> 24)
-                                | ((@in[22 + inpos] & 65535) << (24 - 16));
-            @out[30 + outpos] = (int)((uint)@in[22 + inpos] >> 16)
-                                | ((@in[23 + inpos] & 255) << (24 - 8));
-            @out[31 + outpos] = (int)((uint)@in[23 + inpos] >> 8);
-        }
-
-        protected static void fastunpack25(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 33554431);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 25)
-                               | ((@in[1 + inpos] & 262143) << (25 - 18));
-            @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 18)
-                               | ((@in[2 + inpos] & 2047) << (25 - 11));
-            @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 11)
-                               | ((@in[3 + inpos] & 15) << (25 - 4));
-            @out[4 + outpos] = (int)(((uint)@in[3 + inpos] >> 4) & 33554431);
-            @out[5 + outpos] = (int)((uint)@in[3 + inpos] >> 29)
-                               | ((@in[4 + inpos] & 4194303) << (25 - 22));
-            @out[6 + outpos] = (int)((uint)@in[4 + inpos] >> 22)
-                               | ((@in[5 + inpos] & 32767) << (25 - 15));
-            @out[7 + outpos] = (int)((uint)@in[5 + inpos] >> 15)
-                               | ((@in[6 + inpos] & 255) << (25 - 8));
-            @out[8 + outpos] = (int)((uint)@in[6 + inpos] >> 8)
-                               | ((@in[7 + inpos] & 1) << (25 - 1));
-            @out[9 + outpos] = (int)(((uint)@in[7 + inpos] >> 1) & 33554431);
-            @out[10 + outpos] = (int)((uint)@in[7 + inpos] >> 26)
-                                | ((@in[8 + inpos] & 524287) << (25 - 19));
-            @out[11 + outpos] = (int)((uint)@in[8 + inpos] >> 19)
-                                | ((@in[9 + inpos] & 4095) << (25 - 12));
-            @out[12 + outpos] = (int)((uint)@in[9 + inpos] >> 12)
-                                | ((@in[10 + inpos] & 31) << (25 - 5));
-            @out[13 + outpos] = (int)(((uint)@in[10 + inpos] >> 5) & 33554431);
-            @out[14 + outpos] = (int)((uint)@in[10 + inpos] >> 30)
-                                | ((@in[11 + inpos] & 8388607) << (25 - 23));
-            @out[15 + outpos] = (int)((uint)@in[11 + inpos] >> 23)
-                                | ((@in[12 + inpos] & 65535) << (25 - 16));
-            @out[16 + outpos] = (int)((uint)@in[12 + inpos] >> 16)
-                                | ((@in[13 + inpos] & 511) << (25 - 9));
-            @out[17 + outpos] = (int)((uint)@in[13 + inpos] >> 9)
-                                | ((@in[14 + inpos] & 3) << (25 - 2));
-            @out[18 + outpos] = (int)(((uint)@in[14 + inpos] >> 2) & 33554431);
-            @out[19 + outpos] = (int)((uint)@in[14 + inpos] >> 27)
-                                | ((@in[15 + inpos] & 1048575) << (25 - 20));
-            @out[20 + outpos] = (int)((uint)@in[15 + inpos] >> 20)
-                                | ((@in[16 + inpos] & 8191) << (25 - 13));
-            @out[21 + outpos] = (int)((uint)@in[16 + inpos] >> 13)
-                                | ((@in[17 + inpos] & 63) << (25 - 6));
-            @out[22 + outpos] = (int)(((uint)@in[17 + inpos] >> 6) & 33554431);
-            @out[23 + outpos] = (int)((uint)@in[17 + inpos] >> 31)
-                                | ((@in[18 + inpos] & 16777215) << (25 - 24));
-            @out[24 + outpos] = (int)((uint)@in[18 + inpos] >> 24)
-                                | ((@in[19 + inpos] & 131071) << (25 - 17));
-            @out[25 + outpos] = (int)((uint)@in[19 + inpos] >> 17)
-                                | ((@in[20 + inpos] & 1023) << (25 - 10));
-            @out[26 + outpos] = (int)((uint)@in[20 + inpos] >> 10)
-                                | ((@in[21 + inpos] & 7) << (25 - 3));
-            @out[27 + outpos] = (int)(((uint)@in[21 + inpos] >> 3) & 33554431);
-            @out[28 + outpos] = (int)((uint)@in[21 + inpos] >> 28)
-                                | ((@in[22 + inpos] & 2097151) << (25 - 21));
-            @out[29 + outpos] = (int)((uint)@in[22 + inpos] >> 21)
-                                | ((@in[23 + inpos] & 16383) << (25 - 14));
-            @out[30 + outpos] = (int)((uint)@in[23 + inpos] >> 14)
-                                | ((@in[24 + inpos] & 127) << (25 - 7));
-            @out[31 + outpos] = (int)((uint)@in[24 + inpos] >> 7);
-        }
-
-        protected static void fastunpack26(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 67108863);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 26)
-                               | ((@in[1 + inpos] & 1048575) << (26 - 20));
-            @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 20)
-                               | ((@in[2 + inpos] & 16383) << (26 - 14));
-            @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 14)
-                               | ((@in[3 + inpos] & 255) << (26 - 8));
-            @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 8)
-                               | ((@in[4 + inpos] & 3) << (26 - 2));
-            @out[5 + outpos] = (int)(((uint)@in[4 + inpos] >> 2) & 67108863);
-            @out[6 + outpos] = (int)((uint)@in[4 + inpos] >> 28)
-                               | ((@in[5 + inpos] & 4194303) << (26 - 22));
-            @out[7 + outpos] = (int)((uint)@in[5 + inpos] >> 22)
-                               | ((@in[6 + inpos] & 65535) << (26 - 16));
-            @out[8 + outpos] = (int)((uint)@in[6 + inpos] >> 16)
-                               | ((@in[7 + inpos] & 1023) << (26 - 10));
-            @out[9 + outpos] = (int)((uint)@in[7 + inpos] >> 10)
-                               | ((@in[8 + inpos] & 15) << (26 - 4));
-            @out[10 + outpos] = (int)(((uint)@in[8 + inpos] >> 4) & 67108863);
-            @out[11 + outpos] = (int)((uint)@in[8 + inpos] >> 30)
-                                | ((@in[9 + inpos] & 16777215) << (26 - 24));
-            @out[12 + outpos] = (int)((uint)@in[9 + inpos] >> 24)
-                                | ((@in[10 + inpos] & 262143) << (26 - 18));
-            @out[13 + outpos] = (int)((uint)@in[10 + inpos] >> 18)
-                                | ((@in[11 + inpos] & 4095) << (26 - 12));
-            @out[14 + outpos] = (int)((uint)@in[11 + inpos] >> 12)
-                                | ((@in[12 + inpos] & 63) << (26 - 6));
-            @out[15 + outpos] = (int)((uint)@in[12 + inpos] >> 6);
-            @out[16 + outpos] = (int)(((uint)@in[13 + inpos] >> 0) & 67108863);
-            @out[17 + outpos] = (int)((uint)@in[13 + inpos] >> 26)
-                                | ((@in[14 + inpos] & 1048575) << (26 - 20));
-            @out[18 + outpos] = (int)((uint)@in[14 + inpos] >> 20)
-                                | ((@in[15 + inpos] & 16383) << (26 - 14));
-            @out[19 + outpos] = (int)((uint)@in[15 + inpos] >> 14)
-                                | ((@in[16 + inpos] & 255) << (26 - 8));
-            @out[20 + outpos] = (int)((uint)@in[16 + inpos] >> 8)
-                                | ((@in[17 + inpos] & 3) << (26 - 2));
-            @out[21 + outpos] = (int)(((uint)@in[17 + inpos] >> 2) & 67108863);
-            @out[22 + outpos] = (int)((uint)@in[17 + inpos] >> 28)
-                                | ((@in[18 + inpos] & 4194303) << (26 - 22));
-            @out[23 + outpos] = (int)((uint)@in[18 + inpos] >> 22)
-                                | ((@in[19 + inpos] & 65535) << (26 - 16));
-            @out[24 + outpos] = (int)((uint)@in[19 + inpos] >> 16)
-                                | ((@in[20 + inpos] & 1023) << (26 - 10));
-            @out[25 + outpos] = (int)((uint)@in[20 + inpos] >> 10)
-                                | ((@in[21 + inpos] & 15) << (26 - 4));
-            @out[26 + outpos] = (int)(((uint)@in[21 + inpos] >> 4) & 67108863);
-            @out[27 + outpos] = (int)((uint)@in[21 + inpos] >> 30)
-                                | ((@in[22 + inpos] & 16777215) << (26 - 24));
-            @out[28 + outpos] = (int)((uint)@in[22 + inpos] >> 24)
-                                | ((@in[23 + inpos] & 262143) << (26 - 18));
-            @out[29 + outpos] = (int)((uint)@in[23 + inpos] >> 18)
-                                | ((@in[24 + inpos] & 4095) << (26 - 12));
-            @out[30 + outpos] = (int)((uint)@in[24 + inpos] >> 12)
-                                | ((@in[25 + inpos] & 63) << (26 - 6));
-            @out[31 + outpos] = (int)((uint)@in[25 + inpos] >> 6);
-        }
-
-        protected static void fastunpack27(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 134217727);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 27)
-                               | ((@in[1 + inpos] & 4194303) << (27 - 22));
-            @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 22)
-                               | ((@in[2 + inpos] & 131071) << (27 - 17));
-            @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 17)
-                               | ((@in[3 + inpos] & 4095) << (27 - 12));
-            @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 12)
-                               | ((@in[4 + inpos] & 127) << (27 - 7));
-            @out[5 + outpos] = (int)((uint)@in[4 + inpos] >> 7)
-                               | ((@in[5 + inpos] & 3) << (27 - 2));
-            @out[6 + outpos] = (int)(((uint)@in[5 + inpos] >> 2) & 134217727);
-            @out[7 + outpos] = (int)((uint)@in[5 + inpos] >> 29)
-                               | ((@in[6 + inpos] & 16777215) << (27 - 24));
-            @out[8 + outpos] = (int)((uint)@in[6 + inpos] >> 24)
-                               | ((@in[7 + inpos] & 524287) << (27 - 19));
-            @out[9 + outpos] = (int)((uint)@in[7 + inpos] >> 19)
-                               | ((@in[8 + inpos] & 16383) << (27 - 14));
-            @out[10 + outpos] = (int)((uint)@in[8 + inpos] >> 14)
-                                | ((@in[9 + inpos] & 511) << (27 - 9));
-            @out[11 + outpos] = (int)((uint)@in[9 + inpos] >> 9)
-                                | ((@in[10 + inpos] & 15) << (27 - 4));
-            @out[12 + outpos] = (int)(((uint)@in[10 + inpos] >> 4) & 134217727);
-            @out[13 + outpos] = (int)((uint)@in[10 + inpos] >> 31)
-                                | ((@in[11 + inpos] & 67108863) << (27 - 26));
-            @out[14 + outpos] = (int)((uint)@in[11 + inpos] >> 26)
-                                | ((@in[12 + inpos] & 2097151) << (27 - 21));
-            @out[15 + outpos] = (int)((uint)@in[12 + inpos] >> 21)
-                                | ((@in[13 + inpos] & 65535) << (27 - 16));
-            @out[16 + outpos] = (int)((uint)@in[13 + inpos] >> 16)
-                                | ((@in[14 + inpos] & 2047) << (27 - 11));
-            @out[17 + outpos] = (int)((uint)@in[14 + inpos] >> 11)
-                                | ((@in[15 + inpos] & 63) << (27 - 6));
-            @out[18 + outpos] = (int)((uint)@in[15 + inpos] >> 6)
-                                | ((@in[16 + inpos] & 1) << (27 - 1));
-            @out[19 + outpos] = (int)(((uint)@in[16 + inpos] >> 1) & 134217727);
-            @out[20 + outpos] = (int)((uint)@in[16 + inpos] >> 28)
-                                | ((@in[17 + inpos] & 8388607) << (27 - 23));
-            @out[21 + outpos] = (int)((uint)@in[17 + inpos] >> 23)
-                                | ((@in[18 + inpos] & 262143) << (27 - 18));
-            @out[22 + outpos] = (int)((uint)@in[18 + inpos] >> 18)
-                                | ((@in[19 + inpos] & 8191) << (27 - 13));
-            @out[23 + outpos] = (int)((uint)@in[19 + inpos] >> 13)
-                                | ((@in[20 + inpos] & 255) << (27 - 8));
-            @out[24 + outpos] = (int)((uint)@in[20 + inpos] >> 8)
-                                | ((@in[21 + inpos] & 7) << (27 - 3));
-            @out[25 + outpos] = (int)(((uint)@in[21 + inpos] >> 3) & 134217727);
-            @out[26 + outpos] = (int)((uint)@in[21 + inpos] >> 30)
-                                | ((@in[22 + inpos] & 33554431) << (27 - 25));
-            @out[27 + outpos] = (int)((uint)@in[22 + inpos] >> 25)
-                                | ((@in[23 + inpos] & 1048575) << (27 - 20));
-            @out[28 + outpos] = (int)((uint)@in[23 + inpos] >> 20)
-                                | ((@in[24 + inpos] & 32767) << (27 - 15));
-            @out[29 + outpos] = (int)((uint)@in[24 + inpos] >> 15)
-                                | ((@in[25 + inpos] & 1023) << (27 - 10));
-            @out[30 + outpos] = (int)((uint)@in[25 + inpos] >> 10)
-                                | ((@in[26 + inpos] & 31) << (27 - 5));
-            @out[31 + outpos] = (int)((uint)@in[26 + inpos] >> 5);
-        }
-
-        protected static void fastunpack28(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 268435455);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 28)
-                               | ((@in[1 + inpos] & 16777215) << (28 - 24));
-            @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 24)
-                               | ((@in[2 + inpos] & 1048575) << (28 - 20));
-            @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 20)
-                               | ((@in[3 + inpos] & 65535) << (28 - 16));
-            @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 16)
-                               | ((@in[4 + inpos] & 4095) << (28 - 12));
-            @out[5 + outpos] = (int)((uint)@in[4 + inpos] >> 12)
-                               | ((@in[5 + inpos] & 255) << (28 - 8));
-            @out[6 + outpos] = (int)((uint)@in[5 + inpos] >> 8)
-                               | ((@in[6 + inpos] & 15) << (28 - 4));
-            @out[7 + outpos] = (int)((uint)@in[6 + inpos] >> 4);
-            @out[8 + outpos] = (int)(((uint)@in[7 + inpos] >> 0) & 268435455);
-            @out[9 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
-                               | ((@in[8 + inpos] & 16777215) << (28 - 24));
-            @out[10 + outpos] = (int)((uint)@in[8 + inpos] >> 24)
-                                | ((@in[9 + inpos] & 1048575) << (28 - 20));
-            @out[11 + outpos] = (int)((uint)@in[9 + inpos] >> 20)
-                                | ((@in[10 + inpos] & 65535) << (28 - 16));
-            @out[12 + outpos] = (int)((uint)@in[10 + inpos] >> 16)
-                                | ((@in[11 + inpos] & 4095) << (28 - 12));
-            @out[13 + outpos] = (int)((uint)@in[11 + inpos] >> 12)
-                                | ((@in[12 + inpos] & 255) << (28 - 8));
-            @out[14 + outpos] = (int)((uint)@in[12 + inpos] >> 8)
-                                | ((@in[13 + inpos] & 15) << (28 - 4));
-            @out[15 + outpos] = (int)((uint)@in[13 + inpos] >> 4);
-            @out[16 + outpos] = (int)(((uint)@in[14 + inpos] >> 0) & 268435455);
-            @out[17 + outpos] = (int)((uint)@in[14 + inpos] >> 28)
-                                | ((@in[15 + inpos] & 16777215) << (28 - 24));
-            @out[18 + outpos] = (int)((uint)@in[15 + inpos] >> 24)
-                                | ((@in[16 + inpos] & 1048575) << (28 - 20));
-            @out[19 + outpos] = (int)((uint)@in[16 + inpos] >> 20)
-                                | ((@in[17 + inpos] & 65535) << (28 - 16));
-            @out[20 + outpos] = (int)((uint)@in[17 + inpos] >> 16)
-                                | ((@in[18 + inpos] & 4095) << (28 - 12));
-            @out[21 + outpos] = (int)((uint)@in[18 + inpos] >> 12)
-                                | ((@in[19 + inpos] & 255) << (28 - 8));
-            @out[22 + outpos] = (int)((uint)@in[19 + inpos] >> 8)
-                                | ((@in[20 + inpos] & 15) << (28 - 4));
-            @out[23 + outpos] = (int)((uint)@in[20 + inpos] >> 4);
-            @out[24 + outpos] = (int)(((uint)@in[21 + inpos] >> 0) & 268435455);
-            @out[25 + outpos] = (int)((uint)@in[21 + inpos] >> 28)
-                                | ((@in[22 + inpos] & 16777215) << (28 - 24));
-            @out[26 + outpos] = (int)((uint)@in[22 + inpos] >> 24)
-                                | ((@in[23 + inpos] & 1048575) << (28 - 20));
-            @out[27 + outpos] = (int)((uint)@in[23 + inpos] >> 20)
-                                | ((@in[24 + inpos] & 65535) << (28 - 16));
-            @out[28 + outpos] = (int)((uint)@in[24 + inpos] >> 16)
-                                | ((@in[25 + inpos] & 4095) << (28 - 12));
-            @out[29 + outpos] = (int)((uint)@in[25 + inpos] >> 12)
-                                | ((@in[26 + inpos] & 255) << (28 - 8));
-            @out[30 + outpos] = (int)((uint)@in[26 + inpos] >> 8)
-                                | ((@in[27 + inpos] & 15) << (28 - 4));
-            @out[31 + outpos] = (int)((uint)@in[27 + inpos] >> 4);
-        }
-
-        protected static void fastunpack29(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 536870911);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 29)
-                               | ((@in[1 + inpos] & 67108863) << (29 - 26));
-            @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 26)
-                               | ((@in[2 + inpos] & 8388607) << (29 - 23));
-            @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 23)
-                               | ((@in[3 + inpos] & 1048575) << (29 - 20));
-            @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 20)
-                               | ((@in[4 + inpos] & 131071) << (29 - 17));
-            @out[5 + outpos] = (int)((uint)@in[4 + inpos] >> 17)
-                               | ((@in[5 + inpos] & 16383) << (29 - 14));
-            @out[6 + outpos] = (int)((uint)@in[5 + inpos] >> 14)
-                               | ((@in[6 + inpos] & 2047) << (29 - 11));
-            @out[7 + outpos] = (int)((uint)@in[6 + inpos] >> 11)
-                               | ((@in[7 + inpos] & 255) << (29 - 8));
-            @out[8 + outpos] = (int)((uint)@in[7 + inpos] >> 8)
-                               | ((@in[8 + inpos] & 31) << (29 - 5));
-            @out[9 + outpos] = (int)((uint)@in[8 + inpos] >> 5)
-                               | ((@in[9 + inpos] & 3) << (29 - 2));
-            @out[10 + outpos] = (int)(((uint)@in[9 + inpos] >> 2) & 536870911);
-            @out[11 + outpos] = (int)((uint)@in[9 + inpos] >> 31)
-                                | ((@in[10 + inpos] & 268435455) << (29 - 28));
-            @out[12 + outpos] = (int)((uint)@in[10 + inpos] >> 28)
-                                | ((@in[11 + inpos] & 33554431) << (29 - 25));
-            @out[13 + outpos] = (int)((uint)@in[11 + inpos] >> 25)
-                                | ((@in[12 + inpos] & 4194303) << (29 - 22));
-            @out[14 + outpos] = (int)((uint)@in[12 + inpos] >> 22)
-                                | ((@in[13 + inpos] & 524287) << (29 - 19));
-            @out[15 + outpos] = (int)((uint)@in[13 + inpos] >> 19)
-                                | ((@in[14 + inpos] & 65535) << (29 - 16));
-            @out[16 + outpos] = (int)((uint)@in[14 + inpos] >> 16)
-                                | ((@in[15 + inpos] & 8191) << (29 - 13));
-            @out[17 + outpos] = (int)((uint)@in[15 + inpos] >> 13)
-                                | ((@in[16 + inpos] & 1023) << (29 - 10));
-            @out[18 + outpos] = (int)((uint)@in[16 + inpos] >> 10)
-                                | ((@in[17 + inpos] & 127) << (29 - 7));
-            @out[19 + outpos] = (int)((uint)@in[17 + inpos] >> 7)
-                                | ((@in[18 + inpos] & 15) << (29 - 4));
-            @out[20 + outpos] = (int)((uint)@in[18 + inpos] >> 4)
-                                | ((@in[19 + inpos] & 1) << (29 - 1));
-            @out[21 + outpos] = (int)(((uint)@in[19 + inpos] >> 1) & 536870911);
-            @out[22 + outpos] = (int)((uint)@in[19 + inpos] >> 30)
-                                | ((@in[20 + inpos] & 134217727) << (29 - 27));
-            @out[23 + outpos] = (int)((uint)@in[20 + inpos] >> 27)
-                                | ((@in[21 + inpos] & 16777215) << (29 - 24));
-            @out[24 + outpos] = (int)((uint)@in[21 + inpos] >> 24)
-                                | ((@in[22 + inpos] & 2097151) << (29 - 21));
-            @out[25 + outpos] = (int)((uint)@in[22 + inpos] >> 21)
-                                | ((@in[23 + inpos] & 262143) << (29 - 18));
-            @out[26 + outpos] = (int)((uint)@in[23 + inpos] >> 18)
-                                | ((@in[24 + inpos] & 32767) << (29 - 15));
-            @out[27 + outpos] = (int)((uint)@in[24 + inpos] >> 15)
-                                | ((@in[25 + inpos] & 4095) << (29 - 12));
-            @out[28 + outpos] = (int)((uint)@in[25 + inpos] >> 12)
-                                | ((@in[26 + inpos] & 511) << (29 - 9));
-            @out[29 + outpos] = (int)((uint)@in[26 + inpos] >> 9)
-                                | ((@in[27 + inpos] & 63) << (29 - 6));
-            @out[30 + outpos] = (int)((uint)@in[27 + inpos] >> 6)
-                                | ((@in[28 + inpos] & 7) << (29 - 3));
-            @out[31 + outpos] = (int)((uint)@in[28 + inpos] >> 3);
-        }
-
-        protected static void fastunpack3(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 7);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 3) & 7);
-            @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 6) & 7);
-            @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 9) & 7);
-            @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 7);
-            @out[5 + outpos] = (int)(((uint)@in[0 + inpos] >> 15) & 7);
-            @out[6 + outpos] = (int)(((uint)@in[0 + inpos] >> 18) & 7);
-            @out[7 + outpos] = (int)(((uint)@in[0 + inpos] >> 21) & 7);
-            @out[8 + outpos] = (int)(((uint)@in[0 + inpos] >> 24) & 7);
-            @out[9 + outpos] = (int)(((uint)@in[0 + inpos] >> 27) & 7);
-            @out[10 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
-                                | ((@in[1 + inpos] & 1) << (3 - 1));
-            @out[11 + outpos] = (int)(((uint)@in[1 + inpos] >> 1) & 7);
-            @out[12 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 7);
-            @out[13 + outpos] = (int)(((uint)@in[1 + inpos] >> 7) & 7);
-            @out[14 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 7);
-            @out[15 + outpos] = (int)(((uint)@in[1 + inpos] >> 13) & 7);
-            @out[16 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 7);
-            @out[17 + outpos] = (int)(((uint)@in[1 + inpos] >> 19) & 7);
-            @out[18 + outpos] = (int)(((uint)@in[1 + inpos] >> 22) & 7);
-            @out[19 + outpos] = (int)(((uint)@in[1 + inpos] >> 25) & 7);
-            @out[20 + outpos] = (int)(((uint)@in[1 + inpos] >> 28) & 7);
-            @out[21 + outpos] = (int)((uint)@in[1 + inpos] >> 31)
-                                | ((@in[2 + inpos] & 3) << (3 - 2));
-            @out[22 + outpos] = (int)(((uint)@in[2 + inpos] >> 2) & 7);
-            @out[23 + outpos] = (int)(((uint)@in[2 + inpos] >> 5) & 7);
-            @out[24 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 7);
-            @out[25 + outpos] = (int)(((uint)@in[2 + inpos] >> 11) & 7);
-            @out[26 + outpos] = (int)(((uint)@in[2 + inpos] >> 14) & 7);
-            @out[27 + outpos] = (int)(((uint)@in[2 + inpos] >> 17) & 7);
-            @out[28 + outpos] = (int)(((uint)@in[2 + inpos] >> 20) & 7);
-            @out[29 + outpos] = (int)(((uint)@in[2 + inpos] >> 23) & 7);
-            @out[30 + outpos] = (int)(((uint)@in[2 + inpos] >> 26) & 7);
-            @out[31 + outpos] = (int)((uint)@in[2 + inpos] >> 29);
-        }
-
-        protected static void fastunpack30(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 1073741823);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
-                               | ((@in[1 + inpos] & 268435455) << (30 - 28));
-            @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
-                               | ((@in[2 + inpos] & 67108863) << (30 - 26));
-            @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 26)
-                               | ((@in[3 + inpos] & 16777215) << (30 - 24));
-            @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
-                               | ((@in[4 + inpos] & 4194303) << (30 - 22));
-            @out[5 + outpos] = (int)((uint)@in[4 + inpos] >> 22)
-                               | ((@in[5 + inpos] & 1048575) << (30 - 20));
-            @out[6 + outpos] = (int)((uint)@in[5 + inpos] >> 20)
-                               | ((@in[6 + inpos] & 262143) << (30 - 18));
-            @out[7 + outpos] = (int)((uint)@in[6 + inpos] >> 18)
-                               | ((@in[7 + inpos] & 65535) << (30 - 16));
-            @out[8 + outpos] = (int)((uint)@in[7 + inpos] >> 16)
-                               | ((@in[8 + inpos] & 16383) << (30 - 14));
-            @out[9 + outpos] = (int)((uint)@in[8 + inpos] >> 14)
-                               | ((@in[9 + inpos] & 4095) << (30 - 12));
-            @out[10 + outpos] = (int)((uint)@in[9 + inpos] >> 12)
-                                | ((@in[10 + inpos] & 1023) << (30 - 10));
-            @out[11 + outpos] = (int)((uint)@in[10 + inpos] >> 10)
-                                | ((@in[11 + inpos] & 255) << (30 - 8));
-            @out[12 + outpos] = (int)((uint)@in[11 + inpos] >> 8)
-                                | ((@in[12 + inpos] & 63) << (30 - 6));
-            @out[13 + outpos] = (int)((uint)@in[12 + inpos] >> 6)
-                                | ((@in[13 + inpos] & 15) << (30 - 4));
-            @out[14 + outpos] = (int)((uint)@in[13 + inpos] >> 4)
-                                | ((@in[14 + inpos] & 3) << (30 - 2));
-            @out[15 + outpos] = (int)((uint)@in[14 + inpos] >> 2);
-            @out[16 + outpos] = (int)(((uint)@in[15 + inpos] >> 0) & 1073741823);
-            @out[17 + outpos] = (int)((uint)@in[15 + inpos] >> 30)
-                                | ((@in[16 + inpos] & 268435455) << (30 - 28));
-            @out[18 + outpos] = (int)((uint)@in[16 + inpos] >> 28)
-                                | ((@in[17 + inpos] & 67108863) << (30 - 26));
-            @out[19 + outpos] = (int)((uint)@in[17 + inpos] >> 26)
-                                | ((@in[18 + inpos] & 16777215) << (30 - 24));
-            @out[20 + outpos] = (int)((uint)@in[18 + inpos] >> 24)
-                                | ((@in[19 + inpos] & 4194303) << (30 - 22));
-            @out[21 + outpos] = (int)((uint)@in[19 + inpos] >> 22)
-                                | ((@in[20 + inpos] & 1048575) << (30 - 20));
-            @out[22 + outpos] = (int)((uint)@in[20 + inpos] >> 20)
-                                | ((@in[21 + inpos] & 262143) << (30 - 18));
-            @out[23 + outpos] = (int)((uint)@in[21 + inpos] >> 18)
-                                | ((@in[22 + inpos] & 65535) << (30 - 16));
-            @out[24 + outpos] = (int)((uint)@in[22 + inpos] >> 16)
-                                | ((@in[23 + inpos] & 16383) << (30 - 14));
-            @out[25 + outpos] = (int)((uint)@in[23 + inpos] >> 14)
-                                | ((@in[24 + inpos] & 4095) << (30 - 12));
-            @out[26 + outpos] = (int)((uint)@in[24 + inpos] >> 12)
-                                | ((@in[25 + inpos] & 1023) << (30 - 10));
-            @out[27 + outpos] = (int)((uint)@in[25 + inpos] >> 10)
-                                | ((@in[26 + inpos] & 255) << (30 - 8));
-            @out[28 + outpos] = (int)((uint)@in[26 + inpos] >> 8)
-                                | ((@in[27 + inpos] & 63) << (30 - 6));
-            @out[29 + outpos] = (int)((uint)@in[27 + inpos] >> 6)
-                                | ((@in[28 + inpos] & 15) << (30 - 4));
-            @out[30 + outpos] = (int)((uint)@in[28 + inpos] >> 4)
-                                | ((@in[29 + inpos] & 3) << (30 - 2));
-            @out[31 + outpos] = (int)((uint)@in[29 + inpos] >> 2);
-        }
-
-        protected static void fastunpack31(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 2147483647);
-            @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 31)
-                               | ((@in[1 + inpos] & 1073741823) << (31 - 30));
-            @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 30)
-                               | ((@in[2 + inpos] & 536870911) << (31 - 29));
-            @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 29)
-                               | ((@in[3 + inpos] & 268435455) << (31 - 28));
-            @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 28)
-                               | ((@in[4 + inpos] & 134217727) << (31 - 27));
-            @out[5 + outpos] = (int)((uint)@in[4 + inpos] >> 27)
-                               | ((@in[5 + inpos] & 67108863) << (31 - 26));
-            @out[6 + outpos] = (int)((uint)@in[5 + inpos] >> 26)
-                               | ((@in[6 + inpos] & 33554431) << (31 - 25));
-            @out[7 + outpos] = (int)((uint)@in[6 + inpos] >> 25)
-                               | ((@in[7 + inpos] & 16777215) << (31 - 24));
-            @out[8 + outpos] = (int)((uint)@in[7 + inpos] >> 24)
-                               | ((@in[8 + inpos] & 8388607) << (31 - 23));
-            @out[9 + outpos] = (int)((uint)@in[8 + inpos] >> 23)
-                               | ((@in[9 + inpos] & 4194303) << (31 - 22));
-            @out[10 + outpos] = (int)((uint)@in[9 + inpos] >> 22)
-                                | ((@in[10 + inpos] & 2097151) << (31 - 21));
-            @out[11 + outpos] = (int)((uint)@in[10 + inpos] >> 21)
-                                | ((@in[11 + inpos] & 1048575) << (31 - 20));
-            @out[12 + outpos] = (int)((uint)@in[11 + inpos] >> 20)
-                                | ((@in[12 + inpos] & 524287) << (31 - 19));
-            @out[13 + outpos] = (int)((uint)@in[12 + inpos] >> 19)
-                                | ((@in[13 + inpos] & 262143) << (31 - 18));
-            @out[14 + outpos] = (int)((uint)@in[13 + inpos] >> 18)
-                                | ((@in[14 + inpos] & 131071) << (31 - 17));
-            @out[15 + outpos] = (int)((uint)@in[14 + inpos] >> 17)
-                                | ((@in[15 + inpos] & 65535) << (31 - 16));
-            @out[16 + outpos] = (int)((uint)@in[15 + inpos] >> 16)
-                                | ((@in[16 + inpos] & 32767) << (31 - 15));
-            @out[17 + outpos] = (int)((uint)@in[16 + inpos] >> 15)
-                                | ((@in[17 + inpos] & 16383) << (31 - 14));
-            @out[18 + outpos] = (int)((uint)@in[17 + inpos] >> 14)
-                                | ((@in[18 + inpos] & 8191) << (31 - 13));
-            @out[19 + outpos] = (int)((uint)@in[18 + inpos] >> 13)
-                                | ((@in[19 + inpos] & 4095) << (31 - 12));
-            @out[20 + outpos] = (int)((uint)@in[19 + inpos] >> 12)
-                                | ((@in[20 + inpos] & 2047) << (31 - 11));
-            @out[21 + outpos] = (int)((uint)@in[20 + inpos] >> 11)
-                                | ((@in[21 + inpos] & 1023) << (31 - 10));
-            @out[22 + outpos] = (int)((uint)@in[21 + inpos] >> 10)
-                                | ((@in[22 + inpos] & 511) << (31 - 9));
-            @out[23 + outpos] = (int)((uint)@in[22 + inpos] >> 9)
-                                | ((@in[23 + inpos] & 255) << (31 - 8));
-            @out[24 + outpos] = (int)((uint)@in[23 + inpos] >> 8)
-                                | ((@in[24 + inpos] & 127) << (31 - 7));
-            @out[25 + outpos] = (int)((uint)@in[24 + inpos] >> 7)
-                                | ((@in[25 + inpos] & 63) << (31 - 6));
-            @out[26 + outpos] = (int)((uint)@in[25 + inpos] >> 6)
-                                | ((@in[26 + inpos] & 31) << (31 - 5));
-            @out[27 + outpos] = (int)((uint)@in[26 + inpos] >> 5)
-                                | ((@in[27 + inpos] & 15) << (31 - 4));
-            @out[28 + outpos] = (int)((uint)@in[27 + inpos] >> 4)
-                                | ((@in[28 + inpos] & 7) << (31 - 3));
-            @out[29 + outpos] = (int)((uint)@in[28 + inpos] >> 3)
-                                | ((@in[29 + inpos] & 3) << (31 - 2));
-            @out[30 + outpos] = (int)((uint)@in[29 + inpos] >> 2)
-                                | ((@in[30 + inpos] & 1) << (31 - 1));
-            @out[31 + outpos] = (int)((uint)@in[30 + inpos] >> 1);
-        }
-
-        protected static void fastunpack32(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            Array.Copy(@in, inpos, @out, outpos, 32);
-        }
-
-        protected static void fastunpack4(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 15);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 4) & 15);
-            @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 8) & 15);
-            @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 15);
-            @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 16) & 15);
-            @out[5 + outpos] = (int)(((uint)@in[0 + inpos] >> 20) & 15);
-            @out[6 + outpos] = (int)(((uint)@in[0 + inpos] >> 24) & 15);
-            @out[7 + outpos] = (int)((uint)@in[0 + inpos] >> 28);
-            @out[8 + outpos] = (int)(((uint)@in[1 + inpos] >> 0) & 15);
-            @out[9 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 15);
-            @out[10 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 15);
-            @out[11 + outpos] = (int)(((uint)@in[1 + inpos] >> 12) & 15);
-            @out[12 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 15);
-            @out[13 + outpos] = (int)(((uint)@in[1 + inpos] >> 20) & 15);
-            @out[14 + outpos] = (int)(((uint)@in[1 + inpos] >> 24) & 15);
-            @out[15 + outpos] = (int)((uint)@in[1 + inpos] >> 28);
-            @out[16 + outpos] = (int)(((uint)@in[2 + inpos] >> 0) & 15);
-            @out[17 + outpos] = (int)(((uint)@in[2 + inpos] >> 4) & 15);
-            @out[18 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 15);
-            @out[19 + outpos] = (int)(((uint)@in[2 + inpos] >> 12) & 15);
-            @out[20 + outpos] = (int)(((uint)@in[2 + inpos] >> 16) & 15);
-            @out[21 + outpos] = (int)(((uint)@in[2 + inpos] >> 20) & 15);
-            @out[22 + outpos] = (int)(((uint)@in[2 + inpos] >> 24) & 15);
-            @out[23 + outpos] = (int)((uint)@in[2 + inpos] >> 28);
-            @out[24 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 15);
-            @out[25 + outpos] = (int)(((uint)@in[3 + inpos] >> 4) & 15);
-            @out[26 + outpos] = (int)(((uint)@in[3 + inpos] >> 8) & 15);
-            @out[27 + outpos] = (int)(((uint)@in[3 + inpos] >> 12) & 15);
-            @out[28 + outpos] = (int)(((uint)@in[3 + inpos] >> 16) & 15);
-            @out[29 + outpos] = (int)(((uint)@in[3 + inpos] >> 20) & 15);
-            @out[30 + outpos] = (int)(((uint)@in[3 + inpos] >> 24) & 15);
-            @out[31 + outpos] = (int)((uint)@in[3 + inpos] >> 28);
-        }
-
-        protected static void fastunpack5(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 31);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 5) & 31);
-            @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 10) & 31);
-            @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 15) & 31);
-            @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 20) & 31);
-            @out[5 + outpos] = (int)(((uint)@in[0 + inpos] >> 25) & 31);
-            @out[6 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
-                               | ((@in[1 + inpos] & 7) << (5 - 3));
-            @out[7 + outpos] = (int)(((uint)@in[1 + inpos] >> 3) & 31);
-            @out[8 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 31);
-            @out[9 + outpos] = (int)(((uint)@in[1 + inpos] >> 13) & 31);
-            @out[10 + outpos] = (int)(((uint)@in[1 + inpos] >> 18) & 31);
-            @out[11 + outpos] = (int)(((uint)@in[1 + inpos] >> 23) & 31);
-            @out[12 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
-                                | ((@in[2 + inpos] & 1) << (5 - 1));
-            @out[13 + outpos] = (int)(((uint)@in[2 + inpos] >> 1) & 31);
-            @out[14 + outpos] = (int)(((uint)@in[2 + inpos] >> 6) & 31);
-            @out[15 + outpos] = (int)(((uint)@in[2 + inpos] >> 11) & 31);
-            @out[16 + outpos] = (int)(((uint)@in[2 + inpos] >> 16) & 31);
-            @out[17 + outpos] = (int)(((uint)@in[2 + inpos] >> 21) & 31);
-            @out[18 + outpos] = (int)(((uint)@in[2 + inpos] >> 26) & 31);
-            @out[19 + outpos] = (int)((uint)@in[2 + inpos] >> 31)
-                                | ((@in[3 + inpos] & 15) << (5 - 4));
-            @out[20 + outpos] = (int)(((uint)@in[3 + inpos] >> 4) & 31);
-            @out[21 + outpos] = (int)(((uint)@in[3 + inpos] >> 9) & 31);
-            @out[22 + outpos] = (int)(((uint)@in[3 + inpos] >> 14) & 31);
-            @out[23 + outpos] = (int)(((uint)@in[3 + inpos] >> 19) & 31);
-            @out[24 + outpos] = (int)(((uint)@in[3 + inpos] >> 24) & 31);
-            @out[25 + outpos] = (int)((uint)@in[3 + inpos] >> 29)
-                                | ((@in[4 + inpos] & 3) << (5 - 2));
-            @out[26 + outpos] = (int)(((uint)@in[4 + inpos] >> 2) & 31);
-            @out[27 + outpos] = (int)(((uint)@in[4 + inpos] >> 7) & 31);
-            @out[28 + outpos] = (int)(((uint)@in[4 + inpos] >> 12) & 31);
-            @out[29 + outpos] = (int)(((uint)@in[4 + inpos] >> 17) & 31);
-            @out[30 + outpos] = (int)(((uint)@in[4 + inpos] >> 22) & 31);
-            @out[31 + outpos] = (int)((uint)@in[4 + inpos] >> 27);
-        }
-
-        protected static void fastunpack6(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 63);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 6) & 63);
-            @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 63);
-            @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 18) & 63);
-            @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 24) & 63);
-            @out[5 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
-                               | ((@in[1 + inpos] & 15) << (6 - 4));
-            @out[6 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 63);
-            @out[7 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 63);
-            @out[8 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 63);
-            @out[9 + outpos] = (int)(((uint)@in[1 + inpos] >> 22) & 63);
-            @out[10 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
-                                | ((@in[2 + inpos] & 3) << (6 - 2));
-            @out[11 + outpos] = (int)(((uint)@in[2 + inpos] >> 2) & 63);
-            @out[12 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 63);
-            @out[13 + outpos] = (int)(((uint)@in[2 + inpos] >> 14) & 63);
-            @out[14 + outpos] = (int)(((uint)@in[2 + inpos] >> 20) & 63);
-            @out[15 + outpos] = (int)((uint)@in[2 + inpos] >> 26);
-            @out[16 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 63);
-            @out[17 + outpos] = (int)(((uint)@in[3 + inpos] >> 6) & 63);
-            @out[18 + outpos] = (int)(((uint)@in[3 + inpos] >> 12) & 63);
-            @out[19 + outpos] = (int)(((uint)@in[3 + inpos] >> 18) & 63);
-            @out[20 + outpos] = (int)(((uint)@in[3 + inpos] >> 24) & 63);
-            @out[21 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
-                                | ((@in[4 + inpos] & 15) << (6 - 4));
-            @out[22 + outpos] = (int)(((uint)@in[4 + inpos] >> 4) & 63);
-            @out[23 + outpos] = (int)(((uint)@in[4 + inpos] >> 10) & 63);
-            @out[24 + outpos] = (int)(((uint)@in[4 + inpos] >> 16) & 63);
-            @out[25 + outpos] = (int)(((uint)@in[4 + inpos] >> 22) & 63);
-            @out[26 + outpos] = (int)((uint)@in[4 + inpos] >> 28)
-                                | ((@in[5 + inpos] & 3) << (6 - 2));
-            @out[27 + outpos] = (int)(((uint)@in[5 + inpos] >> 2) & 63);
-            @out[28 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 63);
-            @out[29 + outpos] = (int)(((uint)@in[5 + inpos] >> 14) & 63);
-            @out[30 + outpos] = (int)(((uint)@in[5 + inpos] >> 20) & 63);
-            @out[31 + outpos] = (int)((uint)@in[5 + inpos] >> 26);
-        }
-
-        protected static void fastunpack7(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 127);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 7) & 127);
-            @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 14) & 127);
-            @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 21) & 127);
-            @out[4 + outpos] = (int)((uint)@in[0 + inpos] >> 28)
-                               | ((@in[1 + inpos] & 7) << (7 - 3));
-            @out[5 + outpos] = (int)(((uint)@in[1 + inpos] >> 3) & 127);
-            @out[6 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 127);
-            @out[7 + outpos] = (int)(((uint)@in[1 + inpos] >> 17) & 127);
-            @out[8 + outpos] = (int)(((uint)@in[1 + inpos] >> 24) & 127);
-            @out[9 + outpos] = (int)((uint)@in[1 + inpos] >> 31)
-                               | ((@in[2 + inpos] & 63) << (7 - 6));
-            @out[10 + outpos] = (int)(((uint)@in[2 + inpos] >> 6) & 127);
-            @out[11 + outpos] = (int)(((uint)@in[2 + inpos] >> 13) & 127);
-            @out[12 + outpos] = (int)(((uint)@in[2 + inpos] >> 20) & 127);
-            @out[13 + outpos] = (int)((uint)@in[2 + inpos] >> 27)
-                                | ((@in[3 + inpos] & 3) << (7 - 2));
-            @out[14 + outpos] = (int)(((uint)@in[3 + inpos] >> 2) & 127);
-            @out[15 + outpos] = (int)(((uint)@in[3 + inpos] >> 9) & 127);
-            @out[16 + outpos] = (int)(((uint)@in[3 + inpos] >> 16) & 127);
-            @out[17 + outpos] = (int)(((uint)@in[3 + inpos] >> 23) & 127);
-            @out[18 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
-                                | ((@in[4 + inpos] & 31) << (7 - 5));
-            @out[19 + outpos] = (int)(((uint)@in[4 + inpos] >> 5) & 127);
-            @out[20 + outpos] = (int)(((uint)@in[4 + inpos] >> 12) & 127);
-            @out[21 + outpos] = (int)(((uint)@in[4 + inpos] >> 19) & 127);
-            @out[22 + outpos] = (int)((uint)@in[4 + inpos] >> 26)
-                                | ((@in[5 + inpos] & 1) << (7 - 1));
-            @out[23 + outpos] = (int)(((uint)@in[5 + inpos] >> 1) & 127);
-            @out[24 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 127);
-            @out[25 + outpos] = (int)(((uint)@in[5 + inpos] >> 15) & 127);
-            @out[26 + outpos] = (int)(((uint)@in[5 + inpos] >> 22) & 127);
-            @out[27 + outpos] = (int)((uint)@in[5 + inpos] >> 29)
-                                | ((@in[6 + inpos] & 15) << (7 - 4));
-            @out[28 + outpos] = (int)(((uint)@in[6 + inpos] >> 4) & 127);
-            @out[29 + outpos] = (int)(((uint)@in[6 + inpos] >> 11) & 127);
-            @out[30 + outpos] = (int)(((uint)@in[6 + inpos] >> 18) & 127);
-            @out[31 + outpos] = (int)((uint)@in[6 + inpos] >> 25);
-        }
-
-        protected static void fastunpack8(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 255);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 8) & 255);
-            @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 16) & 255);
-            @out[3 + outpos] = (int)((uint)@in[0 + inpos] >> 24);
-            @out[4 + outpos] = (int)(((uint)@in[1 + inpos] >> 0) & 255);
-            @out[5 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 255);
-            @out[6 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 255);
-            @out[7 + outpos] = (int)((uint)@in[1 + inpos] >> 24);
-            @out[8 + outpos] = (int)(((uint)@in[2 + inpos] >> 0) & 255);
-            @out[9 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 255);
-            @out[10 + outpos] = (int)(((uint)@in[2 + inpos] >> 16) & 255);
-            @out[11 + outpos] = (int)((uint)@in[2 + inpos] >> 24);
-            @out[12 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 255);
-            @out[13 + outpos] = (int)(((uint)@in[3 + inpos] >> 8) & 255);
-            @out[14 + outpos] = (int)(((uint)@in[3 + inpos] >> 16) & 255);
-            @out[15 + outpos] = (int)((uint)@in[3 + inpos] >> 24);
-            @out[16 + outpos] = (int)(((uint)@in[4 + inpos] >> 0) & 255);
-            @out[17 + outpos] = (int)(((uint)@in[4 + inpos] >> 8) & 255);
-            @out[18 + outpos] = (int)(((uint)@in[4 + inpos] >> 16) & 255);
-            @out[19 + outpos] = (int)((uint)@in[4 + inpos] >> 24);
-            @out[20 + outpos] = (int)(((uint)@in[5 + inpos] >> 0) & 255);
-            @out[21 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 255);
-            @out[22 + outpos] = (int)(((uint)@in[5 + inpos] >> 16) & 255);
-            @out[23 + outpos] = (int)((uint)@in[5 + inpos] >> 24);
-            @out[24 + outpos] = (int)(((uint)@in[6 + inpos] >> 0) & 255);
-            @out[25 + outpos] = (int)(((uint)@in[6 + inpos] >> 8) & 255);
-            @out[26 + outpos] = (int)(((uint)@in[6 + inpos] >> 16) & 255);
-            @out[27 + outpos] = (int)((uint)@in[6 + inpos] >> 24);
-            @out[28 + outpos] = (int)(((uint)@in[7 + inpos] >> 0) & 255);
-            @out[29 + outpos] = (int)(((uint)@in[7 + inpos] >> 8) & 255);
-            @out[30 + outpos] = (int)(((uint)@in[7 + inpos] >> 16) & 255);
-            @out[31 + outpos] = (int)((uint)@in[7 + inpos] >> 24);
-        }
-
-        protected static void fastunpack9(int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 511);
-            @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 9) & 511);
-            @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 18) & 511);
-            @out[3 + outpos] = (int)((uint)@in[0 + inpos] >> 27)
-                               | ((@in[1 + inpos] & 15) << (9 - 4));
-            @out[4 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 511);
-            @out[5 + outpos] = (int)(((uint)@in[1 + inpos] >> 13) & 511);
-            @out[6 + outpos] = (int)(((uint)@in[1 + inpos] >> 22) & 511);
-            @out[7 + outpos] = (int)((uint)@in[1 + inpos] >> 31)
-                               | ((@in[2 + inpos] & 255) << (9 - 8));
-            @out[8 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 511);
-            @out[9 + outpos] = (int)(((uint)@in[2 + inpos] >> 17) & 511);
-            @out[10 + outpos] = (int)((uint)@in[2 + inpos] >> 26)
-                                | ((@in[3 + inpos] & 7) << (9 - 3));
-            @out[11 + outpos] = (int)(((uint)@in[3 + inpos] >> 3) & 511);
-            @out[12 + outpos] = (int)(((uint)@in[3 + inpos] >> 12) & 511);
-            @out[13 + outpos] = (int)(((uint)@in[3 + inpos] >> 21) & 511);
-            @out[14 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
-                                | ((@in[4 + inpos] & 127) << (9 - 7));
-            @out[15 + outpos] = (int)(((uint)@in[4 + inpos] >> 7) & 511);
-            @out[16 + outpos] = (int)(((uint)@in[4 + inpos] >> 16) & 511);
-            @out[17 + outpos] = (int)((uint)@in[4 + inpos] >> 25)
-                                | ((@in[5 + inpos] & 3) << (9 - 2));
-            @out[18 + outpos] = (int)(((uint)@in[5 + inpos] >> 2) & 511);
-            @out[19 + outpos] = (int)(((uint)@in[5 + inpos] >> 11) & 511);
-            @out[20 + outpos] = (int)(((uint)@in[5 + inpos] >> 20) & 511);
-            @out[21 + outpos] = (int)((uint)@in[5 + inpos] >> 29)
-                                | ((@in[6 + inpos] & 63) << (9 - 6));
-            @out[22 + outpos] = (int)(((uint)@in[6 + inpos] >> 6) & 511);
-            @out[23 + outpos] = (int)(((uint)@in[6 + inpos] >> 15) & 511);
-            @out[24 + outpos] = (int)((uint)@in[6 + inpos] >> 24)
-                                | ((@in[7 + inpos] & 1) << (9 - 1));
-            @out[25 + outpos] = (int)(((uint)@in[7 + inpos] >> 1) & 511);
-            @out[26 + outpos] = (int)(((uint)@in[7 + inpos] >> 10) & 511);
-            @out[27 + outpos] = (int)(((uint)@in[7 + inpos] >> 19) & 511);
-            @out[28 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
-                                | ((@in[8 + inpos] & 31) << (9 - 5));
-            @out[29 + outpos] = (int)(((uint)@in[8 + inpos] >> 5) & 511);
-            @out[30 + outpos] = (int)(((uint)@in[8 + inpos] >> 14) & 511);
-            @out[31 + outpos] = (int)((uint)@in[8 + inpos] >> 23);
+        switch (bit)
+        {
+            case 0:
+                fastpack0(@in, inpos, @out, outpos);
+                break;
+            case 1:
+                fastpack1(@in, inpos, @out, outpos);
+                break;
+            case 2:
+                fastpack2(@in, inpos, @out, outpos);
+                break;
+            case 3:
+                fastpack3(@in, inpos, @out, outpos);
+                break;
+            case 4:
+                fastpack4(@in, inpos, @out, outpos);
+                break;
+            case 5:
+                fastpack5(@in, inpos, @out, outpos);
+                break;
+            case 6:
+                fastpack6(@in, inpos, @out, outpos);
+                break;
+            case 7:
+                fastpack7(@in, inpos, @out, outpos);
+                break;
+            case 8:
+                fastpack8(@in, inpos, @out, outpos);
+                break;
+            case 9:
+                fastpack9(@in, inpos, @out, outpos);
+                break;
+            case 10:
+                fastpack10(@in, inpos, @out, outpos);
+                break;
+            case 11:
+                fastpack11(@in, inpos, @out, outpos);
+                break;
+            case 12:
+                fastpack12(@in, inpos, @out, outpos);
+                break;
+            case 13:
+                fastpack13(@in, inpos, @out, outpos);
+                break;
+            case 14:
+                fastpack14(@in, inpos, @out, outpos);
+                break;
+            case 15:
+                fastpack15(@in, inpos, @out, outpos);
+                break;
+            case 16:
+                fastpack16(@in, inpos, @out, outpos);
+                break;
+            case 17:
+                fastpack17(@in, inpos, @out, outpos);
+                break;
+            case 18:
+                fastpack18(@in, inpos, @out, outpos);
+                break;
+            case 19:
+                fastpack19(@in, inpos, @out, outpos);
+                break;
+            case 20:
+                fastpack20(@in, inpos, @out, outpos);
+                break;
+            case 21:
+                fastpack21(@in, inpos, @out, outpos);
+                break;
+            case 22:
+                fastpack22(@in, inpos, @out, outpos);
+                break;
+            case 23:
+                fastpack23(@in, inpos, @out, outpos);
+                break;
+            case 24:
+                fastpack24(@in, inpos, @out, outpos);
+                break;
+            case 25:
+                fastpack25(@in, inpos, @out, outpos);
+                break;
+            case 26:
+                fastpack26(@in, inpos, @out, outpos);
+                break;
+            case 27:
+                fastpack27(@in, inpos, @out, outpos);
+                break;
+            case 28:
+                fastpack28(@in, inpos, @out, outpos);
+                break;
+            case 29:
+                fastpack29(@in, inpos, @out, outpos);
+                break;
+            case 30:
+                fastpack30(@in, inpos, @out, outpos);
+                break;
+            case 31:
+                fastpack31(@in, inpos, @out, outpos);
+                break;
+            case 32:
+                fastpack32(@in, inpos, @out, outpos);
+                break;
+            default:
+                throw new ArgumentException("Unsupported bit width.");
         }
-
     }
+
+    protected static void fastpack0(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        // nothing
+    }
+
+    protected static void fastpack1(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 1)
+                           | ((@in[1 + inpos] & 1) << 1)
+                           | ((@in[2 + inpos] & 1) << 2)
+                           | ((@in[3 + inpos] & 1) << 3)
+                           | ((@in[4 + inpos] & 1) << 4)
+                           | ((@in[5 + inpos] & 1) << 5)
+                           | ((@in[6 + inpos] & 1) << 6)
+                           | ((@in[7 + inpos] & 1) << 7)
+                           | ((@in[8 + inpos] & 1) << 8)
+                           | ((@in[9 + inpos] & 1) << 9)
+                           | ((@in[10 + inpos] & 1) << 10)
+                           | ((@in[11 + inpos] & 1) << 11)
+                           | ((@in[12 + inpos] & 1) << 12)
+                           | ((@in[13 + inpos] & 1) << 13)
+                           | ((@in[14 + inpos] & 1) << 14)
+                           | ((@in[15 + inpos] & 1) << 15)
+                           | ((@in[16 + inpos] & 1) << 16)
+                           | ((@in[17 + inpos] & 1) << 17)
+                           | ((@in[18 + inpos] & 1) << 18)
+                           | ((@in[19 + inpos] & 1) << 19)
+                           | ((@in[20 + inpos] & 1) << 20)
+                           | ((@in[21 + inpos] & 1) << 21)
+                           | ((@in[22 + inpos] & 1) << 22)
+                           | ((@in[23 + inpos] & 1) << 23)
+                           | ((@in[24 + inpos] & 1) << 24)
+                           | ((@in[25 + inpos] & 1) << 25)
+                           | ((@in[26 + inpos] & 1) << 26)
+                           | ((@in[27 + inpos] & 1) << 27)
+                           | ((@in[28 + inpos] & 1) << 28)
+                           | ((@in[29 + inpos] & 1) << 29)
+                           | ((@in[30 + inpos] & 1) << 30)
+                           | ((@in[31 + inpos]) << 31);
+    }
+
+    protected static void fastpack10(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 1023)
+                           | ((@in[1 + inpos] & 1023) << 10)
+                           | ((@in[2 + inpos] & 1023) << 20)
+                           | ((@in[3 + inpos]) << 30);
+        @out[1 + outpos] = (int)(((uint)@in[3 + inpos] & 1023) >> (10 - 8))
+                           | ((@in[4 + inpos] & 1023) << 8)
+                           | ((@in[5 + inpos] & 1023) << 18)
+                           | ((@in[6 + inpos]) << 28);
+        @out[2 + outpos] = (int)(((uint)@in[6 + inpos] & 1023) >> (10 - 6))
+                           | ((@in[7 + inpos] & 1023) << 6)
+                           | ((@in[8 + inpos] & 1023) << 16)
+                           | ((@in[9 + inpos]) << 26);
+        @out[3 + outpos] = (int)(((uint)@in[9 + inpos] & 1023) >> (10 - 4))
+                           | ((@in[10 + inpos] & 1023) << 4)
+                           | ((@in[11 + inpos] & 1023) << 14)
+                           | ((@in[12 + inpos]) << 24);
+        @out[4 + outpos] = (int)(((uint)@in[12 + inpos] & 1023) >> (10 - 2))
+                           | ((@in[13 + inpos] & 1023) << 2)
+                           | ((@in[14 + inpos] & 1023) << 12)
+                           | ((@in[15 + inpos]) << 22);
+        @out[5 + outpos] = (@in[16 + inpos] & 1023)
+                           | ((@in[17 + inpos] & 1023) << 10)
+                           | ((@in[18 + inpos] & 1023) << 20)
+                           | ((@in[19 + inpos]) << 30);
+        @out[6 + outpos] = (int)(((uint)@in[19 + inpos] & 1023) >> (10 - 8))
+                           | ((@in[20 + inpos] & 1023) << 8)
+                           | ((@in[21 + inpos] & 1023) << 18)
+                           | ((@in[22 + inpos]) << 28);
+        @out[7 + outpos] = (int)(((uint)@in[22 + inpos] & 1023) >> (10 - 6))
+                           | ((@in[23 + inpos] & 1023) << 6)
+                           | ((@in[24 + inpos] & 1023) << 16)
+                           | ((@in[25 + inpos]) << 26);
+        @out[8 + outpos] = (int)(((uint)@in[25 + inpos] & 1023) >> (10 - 4))
+                           | ((@in[26 + inpos] & 1023) << 4)
+                           | ((@in[27 + inpos] & 1023) << 14)
+                           | ((@in[28 + inpos]) << 24);
+        @out[9 + outpos] = (int)(((uint)@in[28 + inpos] & 1023) >> (10 - 2))
+                           | ((@in[29 + inpos] & 1023) << 2)
+                           | ((@in[30 + inpos] & 1023) << 12)
+                           | ((@in[31 + inpos]) << 22);
+    }
+
+    protected static void fastpack11(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 2047)
+                           | ((@in[1 + inpos] & 2047) << 11)
+                           | ((@in[2 + inpos]) << 22);
+        @out[1 + outpos] = (int)(((uint)@in[2 + inpos] & 2047) >> (11 - 1))
+                           | ((@in[3 + inpos] & 2047) << 1)
+                           | ((@in[4 + inpos] & 2047) << 12)
+                           | ((@in[5 + inpos]) << 23);
+        @out[2 + outpos] = (int)(((uint)@in[5 + inpos] & 2047) >> (11 - 2))
+                           | ((@in[6 + inpos] & 2047) << 2)
+                           | ((@in[7 + inpos] & 2047) << 13)
+                           | ((@in[8 + inpos]) << 24);
+        @out[3 + outpos] = (int)(((uint)@in[8 + inpos] & 2047) >> (11 - 3))
+                           | ((@in[9 + inpos] & 2047) << 3)
+                           | ((@in[10 + inpos] & 2047) << 14)
+                           | ((@in[11 + inpos]) << 25);
+        @out[4 + outpos] = (int)(((uint)@in[11 + inpos] & 2047) >> (11 - 4))
+                           | ((@in[12 + inpos] & 2047) << 4)
+                           | ((@in[13 + inpos] & 2047) << 15)
+                           | ((@in[14 + inpos]) << 26);
+        @out[5 + outpos] = (int)(((uint)@in[14 + inpos] & 2047) >> (11 - 5))
+                           | ((@in[15 + inpos] & 2047) << 5)
+                           | ((@in[16 + inpos] & 2047) << 16)
+                           | ((@in[17 + inpos]) << 27);
+        @out[6 + outpos] = (int)(((uint)@in[17 + inpos] & 2047) >> (11 - 6))
+                           | ((@in[18 + inpos] & 2047) << 6)
+                           | ((@in[19 + inpos] & 2047) << 17)
+                           | ((@in[20 + inpos]) << 28);
+        @out[7 + outpos] = (int)(((uint)@in[20 + inpos] & 2047) >> (11 - 7))
+                           | ((@in[21 + inpos] & 2047) << 7)
+                           | ((@in[22 + inpos] & 2047) << 18)
+                           | ((@in[23 + inpos]) << 29);
+        @out[8 + outpos] = (int)(((uint)@in[23 + inpos] & 2047) >> (11 - 8))
+                           | ((@in[24 + inpos] & 2047) << 8)
+                           | ((@in[25 + inpos] & 2047) << 19)
+                           | ((@in[26 + inpos]) << 30);
+        @out[9 + outpos] = (int)(((uint)@in[26 + inpos] & 2047) >> (11 - 9))
+                           | ((@in[27 + inpos] & 2047) << 9)
+                           | ((@in[28 + inpos] & 2047) << 20)
+                           | ((@in[29 + inpos]) << 31);
+        @out[10 + outpos] = (int)(((uint)@in[29 + inpos] & 2047) >> (11 - 10))
+                            | ((@in[30 + inpos] & 2047) << 10)
+                            | ((@in[31 + inpos]) << 21);
+    }
+
+    protected static void fastpack12(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 4095)
+                           | ((@in[1 + inpos] & 4095) << 12)
+                           | ((@in[2 + inpos]) << 24);
+        @out[1 + outpos] = (int)(((uint)@in[2 + inpos] & 4095) >> (12 - 4))
+                           | ((@in[3 + inpos] & 4095) << 4)
+                           | ((@in[4 + inpos] & 4095) << 16)
+                           | ((@in[5 + inpos]) << 28);
+        @out[2 + outpos] = (int)(((uint)@in[5 + inpos] & 4095) >> (12 - 8))
+                           | ((@in[6 + inpos] & 4095) << 8)
+                           | ((@in[7 + inpos]) << 20);
+        @out[3 + outpos] = (@in[8 + inpos] & 4095)
+                           | ((@in[9 + inpos] & 4095) << 12)
+                           | ((@in[10 + inpos]) << 24);
+        @out[4 + outpos] = (int)(((uint)@in[10 + inpos] & 4095) >> (12 - 4))
+                           | ((@in[11 + inpos] & 4095) << 4)
+                           | ((@in[12 + inpos] & 4095) << 16)
+                           | ((@in[13 + inpos]) << 28);
+        @out[5 + outpos] = (int)(((uint)@in[13 + inpos] & 4095) >> (12 - 8))
+                           | ((@in[14 + inpos] & 4095) << 8)
+                           | ((@in[15 + inpos]) << 20);
+        @out[6 + outpos] = (@in[16 + inpos] & 4095)
+                           | ((@in[17 + inpos] & 4095) << 12)
+                           | ((@in[18 + inpos]) << 24);
+        @out[7 + outpos] = (int)(((uint)@in[18 + inpos] & 4095) >> (12 - 4))
+                           | ((@in[19 + inpos] & 4095) << 4)
+                           | ((@in[20 + inpos] & 4095) << 16)
+                           | ((@in[21 + inpos]) << 28);
+        @out[8 + outpos] = (int)(((uint)@in[21 + inpos] & 4095) >> (12 - 8))
+                           | ((@in[22 + inpos] & 4095) << 8)
+                           | ((@in[23 + inpos]) << 20);
+        @out[9 + outpos] = (@in[24 + inpos] & 4095)
+                           | ((@in[25 + inpos] & 4095) << 12)
+                           | ((@in[26 + inpos]) << 24);
+        @out[10 + outpos] = (int)(((uint)@in[26 + inpos] & 4095) >> (12 - 4))
+                            | ((@in[27 + inpos] & 4095) << 4)
+                            | ((@in[28 + inpos] & 4095) << 16)
+                            | ((@in[29 + inpos]) << 28);
+        @out[11 + outpos] = (int)(((uint)@in[29 + inpos] & 4095) >> (12 - 8))
+                            | ((@in[30 + inpos] & 4095) << 8)
+                            | ((@in[31 + inpos]) << 20);
+    }
+
+    protected static void fastpack13(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 8191)
+                           | ((@in[1 + inpos] & 8191) << 13)
+                           | ((@in[2 + inpos]) << 26);
+        @out[1 + outpos] = (int)(((uint)@in[2 + inpos] & 8191) >> (13 - 7))
+                           | ((@in[3 + inpos] & 8191) << 7)
+                           | ((@in[4 + inpos]) << 20);
+        @out[2 + outpos] = (int)(((uint)@in[4 + inpos] & 8191) >> (13 - 1))
+                           | ((@in[5 + inpos] & 8191) << 1)
+                           | ((@in[6 + inpos] & 8191) << 14)
+                           | ((@in[7 + inpos]) << 27);
+        @out[3 + outpos] = (int)(((uint)@in[7 + inpos] & 8191) >> (13 - 8))
+                           | ((@in[8 + inpos] & 8191) << 8)
+                           | ((@in[9 + inpos]) << 21);
+        @out[4 + outpos] = (int)(((uint)@in[9 + inpos] & 8191) >> (13 - 2))
+                           | ((@in[10 + inpos] & 8191) << 2)
+                           | ((@in[11 + inpos] & 8191) << 15)
+                           | ((@in[12 + inpos]) << 28);
+        @out[5 + outpos] = (int)(((uint)@in[12 + inpos] & 8191) >> (13 - 9))
+                           | ((@in[13 + inpos] & 8191) << 9)
+                           | ((@in[14 + inpos]) << 22);
+        @out[6 + outpos] = (int)(((uint)@in[14 + inpos] & 8191) >> (13 - 3))
+                           | ((@in[15 + inpos] & 8191) << 3)
+                           | ((@in[16 + inpos] & 8191) << 16)
+                           | ((@in[17 + inpos]) << 29);
+        @out[7 + outpos] = (int)(((uint)@in[17 + inpos] & 8191) >> (13 - 10))
+                           | ((@in[18 + inpos] & 8191) << 10)
+                           | ((@in[19 + inpos]) << 23);
+        @out[8 + outpos] = (int)(((uint)@in[19 + inpos] & 8191) >> (13 - 4))
+                           | ((@in[20 + inpos] & 8191) << 4)
+                           | ((@in[21 + inpos] & 8191) << 17)
+                           | ((@in[22 + inpos]) << 30);
+        @out[9 + outpos] = (int)(((uint)@in[22 + inpos] & 8191) >> (13 - 11))
+                           | ((@in[23 + inpos] & 8191) << 11)
+                           | ((@in[24 + inpos]) << 24);
+        @out[10 + outpos] = (int)(((uint)@in[24 + inpos] & 8191) >> (13 - 5))
+                            | ((@in[25 + inpos] & 8191) << 5)
+                            | ((@in[26 + inpos] & 8191) << 18)
+                            | ((@in[27 + inpos]) << 31);
+        @out[11 + outpos] = (int)(((uint)@in[27 + inpos] & 8191) >> (13 - 12))
+                            | ((@in[28 + inpos] & 8191) << 12)
+                            | ((@in[29 + inpos]) << 25);
+        @out[12 + outpos] = (int)(((uint)@in[29 + inpos] & 8191) >> (13 - 6))
+                            | ((@in[30 + inpos] & 8191) << 6)
+                            | ((@in[31 + inpos]) << 19);
+    }
+
+    protected static void fastpack14(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 16383)
+                           | ((@in[1 + inpos] & 16383) << 14)
+                           | ((@in[2 + inpos]) << 28);
+        @out[1 + outpos] = (int)(((uint)@in[2 + inpos] & 16383) >> (14 - 10))
+                           | ((@in[3 + inpos] & 16383) << 10)
+                           | ((@in[4 + inpos]) << 24);
+        @out[2 + outpos] = (int)(((uint)@in[4 + inpos] & 16383) >> (14 - 6))
+                           | ((@in[5 + inpos] & 16383) << 6)
+                           | ((@in[6 + inpos]) << 20);
+        @out[3 + outpos] = (int)(((uint)@in[6 + inpos] & 16383) >> (14 - 2))
+                           | ((@in[7 + inpos] & 16383) << 2)
+                           | ((@in[8 + inpos] & 16383) << 16)
+                           | ((@in[9 + inpos]) << 30);
+        @out[4 + outpos] = (int)(((uint)@in[9 + inpos] & 16383) >> (14 - 12))
+                           | ((@in[10 + inpos] & 16383) << 12)
+                           | ((@in[11 + inpos]) << 26);
+        @out[5 + outpos] = (int)(((uint)@in[11 + inpos] & 16383) >> (14 - 8))
+                           | ((@in[12 + inpos] & 16383) << 8)
+                           | ((@in[13 + inpos]) << 22);
+        @out[6 + outpos] = (int)(((uint)@in[13 + inpos] & 16383) >> (14 - 4))
+                           | ((@in[14 + inpos] & 16383) << 4)
+                           | ((@in[15 + inpos]) << 18);
+        @out[7 + outpos] = (@in[16 + inpos] & 16383)
+                           | ((@in[17 + inpos] & 16383) << 14)
+                           | ((@in[18 + inpos]) << 28);
+        @out[8 + outpos] = (int)(((uint)@in[18 + inpos] & 16383) >> (14 - 10))
+                           | ((@in[19 + inpos] & 16383) << 10)
+                           | ((@in[20 + inpos]) << 24);
+        @out[9 + outpos] = (int)(((uint)@in[20 + inpos] & 16383) >> (14 - 6))
+                           | ((@in[21 + inpos] & 16383) << 6)
+                           | ((@in[22 + inpos]) << 20);
+        @out[10 + outpos] = (int)(((uint)@in[22 + inpos] & 16383) >> (14 - 2))
+                            | ((@in[23 + inpos] & 16383) << 2)
+                            | ((@in[24 + inpos] & 16383) << 16)
+                            | ((@in[25 + inpos]) << 30);
+        @out[11 + outpos] = (int)(((uint)@in[25 + inpos] & 16383) >> (14 - 12))
+                            | ((@in[26 + inpos] & 16383) << 12)
+                            | ((@in[27 + inpos]) << 26);
+        @out[12 + outpos] = (int)(((uint)@in[27 + inpos] & 16383) >> (14 - 8))
+                            | ((@in[28 + inpos] & 16383) << 8)
+                            | ((@in[29 + inpos]) << 22);
+        @out[13 + outpos] = (int)(((uint)@in[29 + inpos] & 16383) >> (14 - 4))
+                            | ((@in[30 + inpos] & 16383) << 4)
+                            | ((@in[31 + inpos]) << 18);
+    }
+
+    protected static void fastpack15(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 32767)
+                           | ((@in[1 + inpos] & 32767) << 15)
+                           | ((@in[2 + inpos]) << 30);
+        @out[1 + outpos] = (int)(((uint)@in[2 + inpos] & 32767) >> (15 - 13))
+                           | ((@in[3 + inpos] & 32767) << 13)
+                           | ((@in[4 + inpos]) << 28);
+        @out[2 + outpos] = (int)(((uint)@in[4 + inpos] & 32767) >> (15 - 11))
+                           | ((@in[5 + inpos] & 32767) << 11)
+                           | ((@in[6 + inpos]) << 26);
+        @out[3 + outpos] = (int)(((uint)@in[6 + inpos] & 32767) >> (15 - 9))
+                           | ((@in[7 + inpos] & 32767) << 9)
+                           | ((@in[8 + inpos]) << 24);
+        @out[4 + outpos] = (int)(((uint)@in[8 + inpos] & 32767) >> (15 - 7))
+                           | ((@in[9 + inpos] & 32767) << 7)
+                           | ((@in[10 + inpos]) << 22);
+        @out[5 + outpos] = (int)(((uint)@in[10 + inpos] & 32767) >> (15 - 5))
+                           | ((@in[11 + inpos] & 32767) << 5)
+                           | ((@in[12 + inpos]) << 20);
+        @out[6 + outpos] = (int)(((uint)@in[12 + inpos] & 32767) >> (15 - 3))
+                           | ((@in[13 + inpos] & 32767) << 3)
+                           | ((@in[14 + inpos]) << 18);
+        @out[7 + outpos] = (int)(((uint)@in[14 + inpos] & 32767) >> (15 - 1))
+                           | ((@in[15 + inpos] & 32767) << 1)
+                           | ((@in[16 + inpos] & 32767) << 16)
+                           | ((@in[17 + inpos]) << 31);
+        @out[8 + outpos] = (int)(((uint)@in[17 + inpos] & 32767) >> (15 - 14))
+                           | ((@in[18 + inpos] & 32767) << 14)
+                           | ((@in[19 + inpos]) << 29);
+        @out[9 + outpos] = (int)(((uint)@in[19 + inpos] & 32767) >> (15 - 12))
+                           | ((@in[20 + inpos] & 32767) << 12)
+                           | ((@in[21 + inpos]) << 27);
+        @out[10 + outpos] = (int)(((uint)@in[21 + inpos] & 32767) >> (15 - 10))
+                            | ((@in[22 + inpos] & 32767) << 10)
+                            | ((@in[23 + inpos]) << 25);
+        @out[11 + outpos] = (int)(((uint)@in[23 + inpos] & 32767) >> (15 - 8))
+                            | ((@in[24 + inpos] & 32767) << 8)
+                            | ((@in[25 + inpos]) << 23);
+        @out[12 + outpos] = (int)(((uint)@in[25 + inpos] & 32767) >> (15 - 6))
+                            | ((@in[26 + inpos] & 32767) << 6)
+                            | ((@in[27 + inpos]) << 21);
+        @out[13 + outpos] = (int)(((uint)@in[27 + inpos] & 32767) >> (15 - 4))
+                            | ((@in[28 + inpos] & 32767) << 4)
+                            | ((@in[29 + inpos]) << 19);
+        @out[14 + outpos] = (int)(((uint)@in[29 + inpos] & 32767) >> (15 - 2))
+                            | ((@in[30 + inpos] & 32767) << 2)
+                            | ((@in[31 + inpos]) << 17);
+    }
+
+    protected static void fastpack16(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 65535)
+                           | ((@in[1 + inpos]) << 16);
+        @out[1 + outpos] = (@in[2 + inpos] & 65535)
+                           | ((@in[3 + inpos]) << 16);
+        @out[2 + outpos] = (@in[4 + inpos] & 65535)
+                           | ((@in[5 + inpos]) << 16);
+        @out[3 + outpos] = (@in[6 + inpos] & 65535)
+                           | ((@in[7 + inpos]) << 16);
+        @out[4 + outpos] = (@in[8 + inpos] & 65535)
+                           | ((@in[9 + inpos]) << 16);
+        @out[5 + outpos] = (@in[10 + inpos] & 65535)
+                           | ((@in[11 + inpos]) << 16);
+        @out[6 + outpos] = (@in[12 + inpos] & 65535)
+                           | ((@in[13 + inpos]) << 16);
+        @out[7 + outpos] = (@in[14 + inpos] & 65535)
+                           | ((@in[15 + inpos]) << 16);
+        @out[8 + outpos] = (@in[16 + inpos] & 65535)
+                           | ((@in[17 + inpos]) << 16);
+        @out[9 + outpos] = (@in[18 + inpos] & 65535)
+                           | ((@in[19 + inpos]) << 16);
+        @out[10 + outpos] = (@in[20 + inpos] & 65535)
+                            | ((@in[21 + inpos]) << 16);
+        @out[11 + outpos] = (@in[22 + inpos] & 65535)
+                            | ((@in[23 + inpos]) << 16);
+        @out[12 + outpos] = (@in[24 + inpos] & 65535)
+                            | ((@in[25 + inpos]) << 16);
+        @out[13 + outpos] = (@in[26 + inpos] & 65535)
+                            | ((@in[27 + inpos]) << 16);
+        @out[14 + outpos] = (@in[28 + inpos] & 65535)
+                            | ((@in[29 + inpos]) << 16);
+        @out[15 + outpos] = (@in[30 + inpos] & 65535)
+                            | ((@in[31 + inpos]) << 16);
+    }
+
+    protected static void fastpack17(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 131071)
+                           | ((@in[1 + inpos]) << 17);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 131071) >> (17 - 2))
+                           | ((@in[2 + inpos] & 131071) << 2)
+                           | ((@in[3 + inpos]) << 19);
+        @out[2 + outpos] = (int)(((uint)@in[3 + inpos] & 131071) >> (17 - 4))
+                           | ((@in[4 + inpos] & 131071) << 4)
+                           | ((@in[5 + inpos]) << 21);
+        @out[3 + outpos] = (int)(((uint)@in[5 + inpos] & 131071) >> (17 - 6))
+                           | ((@in[6 + inpos] & 131071) << 6)
+                           | ((@in[7 + inpos]) << 23);
+        @out[4 + outpos] = (int)(((uint)@in[7 + inpos] & 131071) >> (17 - 8))
+                           | ((@in[8 + inpos] & 131071) << 8)
+                           | ((@in[9 + inpos]) << 25);
+        @out[5 + outpos] = (int)(((uint)@in[9 + inpos] & 131071) >> (17 - 10))
+                           | ((@in[10 + inpos] & 131071) << 10)
+                           | ((@in[11 + inpos]) << 27);
+        @out[6 + outpos] = (int)(((uint)@in[11 + inpos] & 131071) >> (17 - 12))
+                           | ((@in[12 + inpos] & 131071) << 12)
+                           | ((@in[13 + inpos]) << 29);
+        @out[7 + outpos] = (int)(((uint)@in[13 + inpos] & 131071) >> (17 - 14))
+                           | ((@in[14 + inpos] & 131071) << 14)
+                           | ((@in[15 + inpos]) << 31);
+        @out[8 + outpos] = (int)(((uint)@in[15 + inpos] & 131071) >> (17 - 16))
+                           | ((@in[16 + inpos]) << 16);
+        @out[9 + outpos] = (int)(((uint)@in[16 + inpos] & 131071) >> (17 - 1))
+                           | ((@in[17 + inpos] & 131071) << 1)
+                           | ((@in[18 + inpos]) << 18);
+        @out[10 + outpos] = (int)(((uint)@in[18 + inpos] & 131071) >> (17 - 3))
+                            | ((@in[19 + inpos] & 131071) << 3)
+                            | ((@in[20 + inpos]) << 20);
+        @out[11 + outpos] = (int)(((uint)@in[20 + inpos] & 131071) >> (17 - 5))
+                            | ((@in[21 + inpos] & 131071) << 5)
+                            | ((@in[22 + inpos]) << 22);
+        @out[12 + outpos] = (int)(((uint)@in[22 + inpos] & 131071) >> (17 - 7))
+                            | ((@in[23 + inpos] & 131071) << 7)
+                            | ((@in[24 + inpos]) << 24);
+        @out[13 + outpos] = (int)(((uint)@in[24 + inpos] & 131071) >> (17 - 9))
+                            | ((@in[25 + inpos] & 131071) << 9)
+                            | ((@in[26 + inpos]) << 26);
+        @out[14 + outpos] = (int)(((uint)@in[26 + inpos] & 131071) >> (17 - 11))
+                            | ((@in[27 + inpos] & 131071) << 11)
+                            | ((@in[28 + inpos]) << 28);
+        @out[15 + outpos] = (int)(((uint)@in[28 + inpos] & 131071) >> (17 - 13))
+                            | ((@in[29 + inpos] & 131071) << 13)
+                            | ((@in[30 + inpos]) << 30);
+        @out[16 + outpos] = (int)(((uint)@in[30 + inpos] & 131071) >> (17 - 15))
+                            | ((@in[31 + inpos]) << 15);
+    }
+
+    protected static void fastpack18(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 262143)
+                           | ((@in[1 + inpos]) << 18);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 262143) >> (18 - 4))
+                           | ((@in[2 + inpos] & 262143) << 4)
+                           | ((@in[3 + inpos]) << 22);
+        @out[2 + outpos] = (int)(((uint)@in[3 + inpos] & 262143) >> (18 - 8))
+                           | ((@in[4 + inpos] & 262143) << 8)
+                           | ((@in[5 + inpos]) << 26);
+        @out[3 + outpos] = (int)(((uint)@in[5 + inpos] & 262143) >> (18 - 12))
+                           | ((@in[6 + inpos] & 262143) << 12)
+                           | ((@in[7 + inpos]) << 30);
+        @out[4 + outpos] = (int)(((uint)@in[7 + inpos] & 262143) >> (18 - 16))
+                           | ((@in[8 + inpos]) << 16);
+        @out[5 + outpos] = (int)(((uint)@in[8 + inpos] & 262143) >> (18 - 2))
+                           | ((@in[9 + inpos] & 262143) << 2)
+                           | ((@in[10 + inpos]) << 20);
+        @out[6 + outpos] = (int)(((uint)@in[10 + inpos] & 262143) >> (18 - 6))
+                           | ((@in[11 + inpos] & 262143) << 6)
+                           | ((@in[12 + inpos]) << 24);
+        @out[7 + outpos] = (int)(((uint)@in[12 + inpos] & 262143) >> (18 - 10))
+                           | ((@in[13 + inpos] & 262143) << 10)
+                           | ((@in[14 + inpos]) << 28);
+        @out[8 + outpos] = (int)(((uint)@in[14 + inpos] & 262143) >> (18 - 14))
+                           | ((@in[15 + inpos]) << 14);
+        @out[9 + outpos] = (@in[16 + inpos] & 262143)
+                           | ((@in[17 + inpos]) << 18);
+        @out[10 + outpos] = (int)(((uint)@in[17 + inpos] & 262143) >> (18 - 4))
+                            | ((@in[18 + inpos] & 262143) << 4)
+                            | ((@in[19 + inpos]) << 22);
+        @out[11 + outpos] = (int)(((uint)@in[19 + inpos] & 262143) >> (18 - 8))
+                            | ((@in[20 + inpos] & 262143) << 8)
+                            | ((@in[21 + inpos]) << 26);
+        @out[12 + outpos] = (int)(((uint)@in[21 + inpos] & 262143) >> (18 - 12))
+                            | ((@in[22 + inpos] & 262143) << 12)
+                            | ((@in[23 + inpos]) << 30);
+        @out[13 + outpos] = (int)(((uint)@in[23 + inpos] & 262143) >> (18 - 16))
+                            | ((@in[24 + inpos]) << 16);
+        @out[14 + outpos] = (int)(((uint)@in[24 + inpos] & 262143) >> (18 - 2))
+                            | ((@in[25 + inpos] & 262143) << 2)
+                            | ((@in[26 + inpos]) << 20);
+        @out[15 + outpos] = (int)(((uint)@in[26 + inpos] & 262143) >> (18 - 6))
+                            | ((@in[27 + inpos] & 262143) << 6)
+                            | ((@in[28 + inpos]) << 24);
+        @out[16 + outpos] = (int)(((uint)@in[28 + inpos] & 262143) >> (18 - 10))
+                            | ((@in[29 + inpos] & 262143) << 10)
+                            | ((@in[30 + inpos]) << 28);
+        @out[17 + outpos] = (int)(((uint)@in[30 + inpos] & 262143) >> (18 - 14))
+                            | ((@in[31 + inpos]) << 14);
+    }
+
+    protected static void fastpack19(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 524287)
+                           | ((@in[1 + inpos]) << 19);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 524287) >> (19 - 6))
+                           | ((@in[2 + inpos] & 524287) << 6)
+                           | ((@in[3 + inpos]) << 25);
+        @out[2 + outpos] = (int)(((uint)@in[3 + inpos] & 524287) >> (19 - 12))
+                           | ((@in[4 + inpos] & 524287) << 12)
+                           | ((@in[5 + inpos]) << 31);
+        @out[3 + outpos] = (int)(((uint)@in[5 + inpos] & 524287) >> (19 - 18))
+                           | ((@in[6 + inpos]) << 18);
+        @out[4 + outpos] = (int)(((uint)@in[6 + inpos] & 524287) >> (19 - 5))
+                           | ((@in[7 + inpos] & 524287) << 5)
+                           | ((@in[8 + inpos]) << 24);
+        @out[5 + outpos] = (int)(((uint)@in[8 + inpos] & 524287) >> (19 - 11))
+                           | ((@in[9 + inpos] & 524287) << 11)
+                           | ((@in[10 + inpos]) << 30);
+        @out[6 + outpos] = (int)(((uint)@in[10 + inpos] & 524287) >> (19 - 17))
+                           | ((@in[11 + inpos]) << 17);
+        @out[7 + outpos] = (int)(((uint)@in[11 + inpos] & 524287) >> (19 - 4))
+                           | ((@in[12 + inpos] & 524287) << 4)
+                           | ((@in[13 + inpos]) << 23);
+        @out[8 + outpos] = (int)(((uint)@in[13 + inpos] & 524287) >> (19 - 10))
+                           | ((@in[14 + inpos] & 524287) << 10)
+                           | ((@in[15 + inpos]) << 29);
+        @out[9 + outpos] = (int)(((uint)@in[15 + inpos] & 524287) >> (19 - 16))
+                           | ((@in[16 + inpos]) << 16);
+        @out[10 + outpos] = (int)(((uint)@in[16 + inpos] & 524287) >> (19 - 3))
+                            | ((@in[17 + inpos] & 524287) << 3)
+                            | ((@in[18 + inpos]) << 22);
+        @out[11 + outpos] = (int)(((uint)@in[18 + inpos] & 524287) >> (19 - 9))
+                            | ((@in[19 + inpos] & 524287) << 9)
+                            | ((@in[20 + inpos]) << 28);
+        @out[12 + outpos] = (int)(((uint)@in[20 + inpos] & 524287) >> (19 - 15))
+                            | ((@in[21 + inpos]) << 15);
+        @out[13 + outpos] = (int)(((uint)@in[21 + inpos] & 524287) >> (19 - 2))
+                            | ((@in[22 + inpos] & 524287) << 2)
+                            | ((@in[23 + inpos]) << 21);
+        @out[14 + outpos] = (int)(((uint)@in[23 + inpos] & 524287) >> (19 - 8))
+                            | ((@in[24 + inpos] & 524287) << 8)
+                            | ((@in[25 + inpos]) << 27);
+        @out[15 + outpos] = (int)(((uint)@in[25 + inpos] & 524287) >> (19 - 14))
+                            | ((@in[26 + inpos]) << 14);
+        @out[16 + outpos] = (int)(((uint)@in[26 + inpos] & 524287) >> (19 - 1))
+                            | ((@in[27 + inpos] & 524287) << 1)
+                            | ((@in[28 + inpos]) << 20);
+        @out[17 + outpos] = (int)(((uint)@in[28 + inpos] & 524287) >> (19 - 7))
+                            | ((@in[29 + inpos] & 524287) << 7)
+                            | ((@in[30 + inpos]) << 26);
+        @out[18 + outpos] = (int)(((uint)@in[30 + inpos] & 524287) >> (19 - 13))
+                            | ((@in[31 + inpos]) << 13);
+    }
+
+    protected static void fastpack2(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 3)
+                           | ((@in[1 + inpos] & 3) << 2)
+                           | ((@in[2 + inpos] & 3) << 4)
+                           | ((@in[3 + inpos] & 3) << 6)
+                           | ((@in[4 + inpos] & 3) << 8)
+                           | ((@in[5 + inpos] & 3) << 10)
+                           | ((@in[6 + inpos] & 3) << 12)
+                           | ((@in[7 + inpos] & 3) << 14)
+                           | ((@in[8 + inpos] & 3) << 16)
+                           | ((@in[9 + inpos] & 3) << 18)
+                           | ((@in[10 + inpos] & 3) << 20)
+                           | ((@in[11 + inpos] & 3) << 22)
+                           | ((@in[12 + inpos] & 3) << 24)
+                           | ((@in[13 + inpos] & 3) << 26)
+                           | ((@in[14 + inpos] & 3) << 28)
+                           | ((@in[15 + inpos]) << 30);
+        @out[1 + outpos] = (@in[16 + inpos] & 3)
+                           | ((@in[17 + inpos] & 3) << 2)
+                           | ((@in[18 + inpos] & 3) << 4)
+                           | ((@in[19 + inpos] & 3) << 6)
+                           | ((@in[20 + inpos] & 3) << 8)
+                           | ((@in[21 + inpos] & 3) << 10)
+                           | ((@in[22 + inpos] & 3) << 12)
+                           | ((@in[23 + inpos] & 3) << 14)
+                           | ((@in[24 + inpos] & 3) << 16)
+                           | ((@in[25 + inpos] & 3) << 18)
+                           | ((@in[26 + inpos] & 3) << 20)
+                           | ((@in[27 + inpos] & 3) << 22)
+                           | ((@in[28 + inpos] & 3) << 24)
+                           | ((@in[29 + inpos] & 3) << 26)
+                           | ((@in[30 + inpos] & 3) << 28)
+                           | ((@in[31 + inpos]) << 30);
+    }
+
+    protected static void fastpack20(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 1048575)
+                           | ((@in[1 + inpos]) << 20);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 1048575) >> (20 - 8))
+                           | ((@in[2 + inpos] & 1048575) << 8)
+                           | ((@in[3 + inpos]) << 28);
+        @out[2 + outpos] = (int)(((uint)@in[3 + inpos] & 1048575) >> (20 - 16))
+                           | ((@in[4 + inpos]) << 16);
+        @out[3 + outpos] = (int)(((uint)@in[4 + inpos] & 1048575) >> (20 - 4))
+                           | ((@in[5 + inpos] & 1048575) << 4)
+                           | ((@in[6 + inpos]) << 24);
+        @out[4 + outpos] = (int)(((uint)@in[6 + inpos] & 1048575) >> (20 - 12))
+                           | ((@in[7 + inpos]) << 12);
+        @out[5 + outpos] = (@in[8 + inpos] & 1048575)
+                           | ((@in[9 + inpos]) << 20);
+        @out[6 + outpos] = (int)(((uint)@in[9 + inpos] & 1048575) >> (20 - 8))
+                           | ((@in[10 + inpos] & 1048575) << 8)
+                           | ((@in[11 + inpos]) << 28);
+        @out[7 + outpos] = (int)(((uint)@in[11 + inpos] & 1048575) >> (20 - 16))
+                           | ((@in[12 + inpos]) << 16);
+        @out[8 + outpos] = (int)(((uint)@in[12 + inpos] & 1048575) >> (20 - 4))
+                           | ((@in[13 + inpos] & 1048575) << 4)
+                           | ((@in[14 + inpos]) << 24);
+        @out[9 + outpos] = (int)(((uint)@in[14 + inpos] & 1048575) >> (20 - 12))
+                           | ((@in[15 + inpos]) << 12);
+        @out[10 + outpos] = (@in[16 + inpos] & 1048575)
+                            | ((@in[17 + inpos]) << 20);
+        @out[11 + outpos] = (int)(((uint)@in[17 + inpos] & 1048575) >> (20 - 8))
+                            | ((@in[18 + inpos] & 1048575) << 8)
+                            | ((@in[19 + inpos]) << 28);
+        @out[12 + outpos] = (int)(((uint)@in[19 + inpos] & 1048575) >> (20 - 16))
+                            | ((@in[20 + inpos]) << 16);
+        @out[13 + outpos] = (int)(((uint)@in[20 + inpos] & 1048575) >> (20 - 4))
+                            | ((@in[21 + inpos] & 1048575) << 4)
+                            | ((@in[22 + inpos]) << 24);
+        @out[14 + outpos] = (int)(((uint)@in[22 + inpos] & 1048575) >> (20 - 12))
+                            | ((@in[23 + inpos]) << 12);
+        @out[15 + outpos] = (@in[24 + inpos] & 1048575)
+                            | ((@in[25 + inpos]) << 20);
+        @out[16 + outpos] = (int)(((uint)@in[25 + inpos] & 1048575) >> (20 - 8))
+                            | ((@in[26 + inpos] & 1048575) << 8)
+                            | ((@in[27 + inpos]) << 28);
+        @out[17 + outpos] = (int)(((uint)@in[27 + inpos] & 1048575) >> (20 - 16))
+                            | ((@in[28 + inpos]) << 16);
+        @out[18 + outpos] = (int)(((uint)@in[28 + inpos] & 1048575) >> (20 - 4))
+                            | ((@in[29 + inpos] & 1048575) << 4)
+                            | ((@in[30 + inpos]) << 24);
+        @out[19 + outpos] = (int)(((uint)@in[30 + inpos] & 1048575) >> (20 - 12))
+                            | ((@in[31 + inpos]) << 12);
+    }
+
+    protected static void fastpack21(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 2097151)
+                           | ((@in[1 + inpos]) << 21);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 2097151) >> (21 - 10))
+                           | ((@in[2 + inpos] & 2097151) << 10)
+                           | ((@in[3 + inpos]) << 31);
+        @out[2 + outpos] = (int)(((uint)@in[3 + inpos] & 2097151) >> (21 - 20))
+                           | ((@in[4 + inpos]) << 20);
+        @out[3 + outpos] = (int)(((uint)@in[4 + inpos] & 2097151) >> (21 - 9))
+                           | ((@in[5 + inpos] & 2097151) << 9)
+                           | ((@in[6 + inpos]) << 30);
+        @out[4 + outpos] = (int)(((uint)@in[6 + inpos] & 2097151) >> (21 - 19))
+                           | ((@in[7 + inpos]) << 19);
+        @out[5 + outpos] = (int)(((uint)@in[7 + inpos] & 2097151) >> (21 - 8))
+                           | ((@in[8 + inpos] & 2097151) << 8)
+                           | ((@in[9 + inpos]) << 29);
+        @out[6 + outpos] = (int)(((uint)@in[9 + inpos] & 2097151) >> (21 - 18))
+                           | ((@in[10 + inpos]) << 18);
+        @out[7 + outpos] = (int)(((uint)@in[10 + inpos] & 2097151) >> (21 - 7))
+                           | ((@in[11 + inpos] & 2097151) << 7)
+                           | ((@in[12 + inpos]) << 28);
+        @out[8 + outpos] = (int)(((uint)@in[12 + inpos] & 2097151) >> (21 - 17))
+                           | ((@in[13 + inpos]) << 17);
+        @out[9 + outpos] = (int)(((uint)@in[13 + inpos] & 2097151) >> (21 - 6))
+                           | ((@in[14 + inpos] & 2097151) << 6)
+                           | ((@in[15 + inpos]) << 27);
+        @out[10 + outpos] = (int)(((uint)@in[15 + inpos] & 2097151) >> (21 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[11 + outpos] = (int)(((uint)@in[16 + inpos] & 2097151) >> (21 - 5))
+                            | ((@in[17 + inpos] & 2097151) << 5)
+                            | ((@in[18 + inpos]) << 26);
+        @out[12 + outpos] = (int)(((uint)@in[18 + inpos] & 2097151) >> (21 - 15))
+                            | ((@in[19 + inpos]) << 15);
+        @out[13 + outpos] = (int)(((uint)@in[19 + inpos] & 2097151) >> (21 - 4))
+                            | ((@in[20 + inpos] & 2097151) << 4)
+                            | ((@in[21 + inpos]) << 25);
+        @out[14 + outpos] = (int)(((uint)@in[21 + inpos] & 2097151) >> (21 - 14))
+                            | ((@in[22 + inpos]) << 14);
+        @out[15 + outpos] = (int)(((uint)@in[22 + inpos] & 2097151) >> (21 - 3))
+                            | ((@in[23 + inpos] & 2097151) << 3)
+                            | ((@in[24 + inpos]) << 24);
+        @out[16 + outpos] = (int)(((uint)@in[24 + inpos] & 2097151) >> (21 - 13))
+                            | ((@in[25 + inpos]) << 13);
+        @out[17 + outpos] = (int)(((uint)@in[25 + inpos] & 2097151) >> (21 - 2))
+                            | ((@in[26 + inpos] & 2097151) << 2)
+                            | ((@in[27 + inpos]) << 23);
+        @out[18 + outpos] = (int)(((uint)@in[27 + inpos] & 2097151) >> (21 - 12))
+                            | ((@in[28 + inpos]) << 12);
+        @out[19 + outpos] = (int)(((uint)@in[28 + inpos] & 2097151) >> (21 - 1))
+                            | ((@in[29 + inpos] & 2097151) << 1)
+                            | ((@in[30 + inpos]) << 22);
+        @out[20 + outpos] = (int)(((uint)@in[30 + inpos] & 2097151) >> (21 - 11))
+                            | ((@in[31 + inpos]) << 11);
+    }
+
+    protected static void fastpack22(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 4194303)
+                           | ((@in[1 + inpos]) << 22);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 4194303) >> (22 - 12))
+                           | ((@in[2 + inpos]) << 12);
+        @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 4194303) >> (22 - 2))
+                           | ((@in[3 + inpos] & 4194303) << 2)
+                           | ((@in[4 + inpos]) << 24);
+        @out[3 + outpos] = (int)(((uint)@in[4 + inpos] & 4194303) >> (22 - 14))
+                           | ((@in[5 + inpos]) << 14);
+        @out[4 + outpos] = (int)(((uint)@in[5 + inpos] & 4194303) >> (22 - 4))
+                           | ((@in[6 + inpos] & 4194303) << 4)
+                           | ((@in[7 + inpos]) << 26);
+        @out[5 + outpos] = (int)(((uint)@in[7 + inpos] & 4194303) >> (22 - 16))
+                           | ((@in[8 + inpos]) << 16);
+        @out[6 + outpos] = (int)(((uint)@in[8 + inpos] & 4194303) >> (22 - 6))
+                           | ((@in[9 + inpos] & 4194303) << 6)
+                           | ((@in[10 + inpos]) << 28);
+        @out[7 + outpos] = (int)(((uint)@in[10 + inpos] & 4194303) >> (22 - 18))
+                           | ((@in[11 + inpos]) << 18);
+        @out[8 + outpos] = (int)(((uint)@in[11 + inpos] & 4194303) >> (22 - 8))
+                           | ((@in[12 + inpos] & 4194303) << 8)
+                           | ((@in[13 + inpos]) << 30);
+        @out[9 + outpos] = (int)(((uint)@in[13 + inpos] & 4194303) >> (22 - 20))
+                           | ((@in[14 + inpos]) << 20);
+        @out[10 + outpos] = (int)(((uint)@in[14 + inpos] & 4194303) >> (22 - 10))
+                            | ((@in[15 + inpos]) << 10);
+        @out[11 + outpos] = (@in[16 + inpos] & 4194303)
+                            | ((@in[17 + inpos]) << 22);
+        @out[12 + outpos] = (int)(((uint)@in[17 + inpos] & 4194303) >> (22 - 12))
+                            | ((@in[18 + inpos]) << 12);
+        @out[13 + outpos] = (int)(((uint)@in[18 + inpos] & 4194303) >> (22 - 2))
+                            | ((@in[19 + inpos] & 4194303) << 2)
+                            | ((@in[20 + inpos]) << 24);
+        @out[14 + outpos] = (int)(((uint)@in[20 + inpos] & 4194303) >> (22 - 14))
+                            | ((@in[21 + inpos]) << 14);
+        @out[15 + outpos] = (int)(((uint)@in[21 + inpos] & 4194303) >> (22 - 4))
+                            | ((@in[22 + inpos] & 4194303) << 4)
+                            | ((@in[23 + inpos]) << 26);
+        @out[16 + outpos] = (int)(((uint)@in[23 + inpos] & 4194303) >> (22 - 16))
+                            | ((@in[24 + inpos]) << 16);
+        @out[17 + outpos] = (int)(((uint)@in[24 + inpos] & 4194303) >> (22 - 6))
+                            | ((@in[25 + inpos] & 4194303) << 6)
+                            | ((@in[26 + inpos]) << 28);
+        @out[18 + outpos] = (int)(((uint)@in[26 + inpos] & 4194303) >> (22 - 18))
+                            | ((@in[27 + inpos]) << 18);
+        @out[19 + outpos] = (int)(((uint)@in[27 + inpos] & 4194303) >> (22 - 8))
+                            | ((@in[28 + inpos] & 4194303) << 8)
+                            | ((@in[29 + inpos]) << 30);
+        @out[20 + outpos] = (int)(((uint)@in[29 + inpos] & 4194303) >> (22 - 20))
+                            | ((@in[30 + inpos]) << 20);
+        @out[21 + outpos] = (int)(((uint)@in[30 + inpos] & 4194303) >> (22 - 10))
+                            | ((@in[31 + inpos]) << 10);
+    }
+
+    protected static void fastpack23(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 8388607)
+                           | ((@in[1 + inpos]) << 23);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 8388607) >> (23 - 14))
+                           | ((@in[2 + inpos]) << 14);
+        @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 8388607) >> (23 - 5))
+                           | ((@in[3 + inpos] & 8388607) << 5)
+                           | ((@in[4 + inpos]) << 28);
+        @out[3 + outpos] = (int)(((uint)@in[4 + inpos] & 8388607) >> (23 - 19))
+                           | ((@in[5 + inpos]) << 19);
+        @out[4 + outpos] = (int)(((uint)@in[5 + inpos] & 8388607) >> (23 - 10))
+                           | ((@in[6 + inpos]) << 10);
+        @out[5 + outpos] = (int)(((uint)@in[6 + inpos] & 8388607) >> (23 - 1))
+                           | ((@in[7 + inpos] & 8388607) << 1)
+                           | ((@in[8 + inpos]) << 24);
+        @out[6 + outpos] = (int)(((uint)@in[8 + inpos] & 8388607) >> (23 - 15))
+                           | ((@in[9 + inpos]) << 15);
+        @out[7 + outpos] = (int)(((uint)@in[9 + inpos] & 8388607) >> (23 - 6))
+                           | ((@in[10 + inpos] & 8388607) << 6)
+                           | ((@in[11 + inpos]) << 29);
+        @out[8 + outpos] = (int)(((uint)@in[11 + inpos] & 8388607) >> (23 - 20))
+                           | ((@in[12 + inpos]) << 20);
+        @out[9 + outpos] = (int)(((uint)@in[12 + inpos] & 8388607) >> (23 - 11))
+                           | ((@in[13 + inpos]) << 11);
+        @out[10 + outpos] = (int)(((uint)@in[13 + inpos] & 8388607) >> (23 - 2))
+                            | ((@in[14 + inpos] & 8388607) << 2)
+                            | ((@in[15 + inpos]) << 25);
+        @out[11 + outpos] = (int)(((uint)@in[15 + inpos] & 8388607) >> (23 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[12 + outpos] = (int)(((uint)@in[16 + inpos] & 8388607) >> (23 - 7))
+                            | ((@in[17 + inpos] & 8388607) << 7)
+                            | ((@in[18 + inpos]) << 30);
+        @out[13 + outpos] = (int)(((uint)@in[18 + inpos] & 8388607) >> (23 - 21))
+                            | ((@in[19 + inpos]) << 21);
+        @out[14 + outpos] = (int)(((uint)@in[19 + inpos] & 8388607) >> (23 - 12))
+                            | ((@in[20 + inpos]) << 12);
+        @out[15 + outpos] = (int)(((uint)@in[20 + inpos] & 8388607) >> (23 - 3))
+                            | ((@in[21 + inpos] & 8388607) << 3)
+                            | ((@in[22 + inpos]) << 26);
+        @out[16 + outpos] = (int)(((uint)@in[22 + inpos] & 8388607) >> (23 - 17))
+                            | ((@in[23 + inpos]) << 17);
+        @out[17 + outpos] = (int)(((uint)@in[23 + inpos] & 8388607) >> (23 - 8))
+                            | ((@in[24 + inpos] & 8388607) << 8)
+                            | ((@in[25 + inpos]) << 31);
+        @out[18 + outpos] = (int)(((uint)@in[25 + inpos] & 8388607) >> (23 - 22))
+                            | ((@in[26 + inpos]) << 22);
+        @out[19 + outpos] = (int)(((uint)@in[26 + inpos] & 8388607) >> (23 - 13))
+                            | ((@in[27 + inpos]) << 13);
+        @out[20 + outpos] = (int)(((uint)@in[27 + inpos] & 8388607) >> (23 - 4))
+                            | ((@in[28 + inpos] & 8388607) << 4)
+                            | ((@in[29 + inpos]) << 27);
+        @out[21 + outpos] = (int)(((uint)@in[29 + inpos] & 8388607) >> (23 - 18))
+                            | ((@in[30 + inpos]) << 18);
+        @out[22 + outpos] = (int)(((uint)@in[30 + inpos] & 8388607) >> (23 - 9))
+                            | ((@in[31 + inpos]) << 9);
+    }
+
+    protected static void fastpack24(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 16777215)
+                           | ((@in[1 + inpos]) << 24);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 16777215) >> (24 - 16))
+                           | ((@in[2 + inpos]) << 16);
+        @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 16777215) >> (24 - 8))
+                           | ((@in[3 + inpos]) << 8);
+        @out[3 + outpos] = (@in[4 + inpos] & 16777215)
+                           | ((@in[5 + inpos]) << 24);
+        @out[4 + outpos] = (int)(((uint)@in[5 + inpos] & 16777215) >> (24 - 16))
+                           | ((@in[6 + inpos]) << 16);
+        @out[5 + outpos] = (int)(((uint)@in[6 + inpos] & 16777215) >> (24 - 8))
+                           | ((@in[7 + inpos]) << 8);
+        @out[6 + outpos] = (@in[8 + inpos] & 16777215)
+                           | ((@in[9 + inpos]) << 24);
+        @out[7 + outpos] = (int)(((uint)@in[9 + inpos] & 16777215) >> (24 - 16))
+                           | ((@in[10 + inpos]) << 16);
+        @out[8 + outpos] = (int)(((uint)@in[10 + inpos] & 16777215) >> (24 - 8))
+                           | ((@in[11 + inpos]) << 8);
+        @out[9 + outpos] = (@in[12 + inpos] & 16777215)
+                           | ((@in[13 + inpos]) << 24);
+        @out[10 + outpos] = (int)(((uint)@in[13 + inpos] & 16777215) >> (24 - 16))
+                            | ((@in[14 + inpos]) << 16);
+        @out[11 + outpos] = (int)(((uint)@in[14 + inpos] & 16777215) >> (24 - 8))
+                            | ((@in[15 + inpos]) << 8);
+        @out[12 + outpos] = (@in[16 + inpos] & 16777215)
+                            | ((@in[17 + inpos]) << 24);
+        @out[13 + outpos] = (int)(((uint)@in[17 + inpos] & 16777215) >> (24 - 16))
+                            | ((@in[18 + inpos]) << 16);
+        @out[14 + outpos] = (int)(((uint)@in[18 + inpos] & 16777215) >> (24 - 8))
+                            | ((@in[19 + inpos]) << 8);
+        @out[15 + outpos] = (@in[20 + inpos] & 16777215)
+                            | ((@in[21 + inpos]) << 24);
+        @out[16 + outpos] = (int)(((uint)@in[21 + inpos] & 16777215) >> (24 - 16))
+                            | ((@in[22 + inpos]) << 16);
+        @out[17 + outpos] = (int)(((uint)@in[22 + inpos] & 16777215) >> (24 - 8))
+                            | ((@in[23 + inpos]) << 8);
+        @out[18 + outpos] = (@in[24 + inpos] & 16777215)
+                            | ((@in[25 + inpos]) << 24);
+        @out[19 + outpos] = (int)(((uint)@in[25 + inpos] & 16777215) >> (24 - 16))
+                            | ((@in[26 + inpos]) << 16);
+        @out[20 + outpos] = (int)(((uint)@in[26 + inpos] & 16777215) >> (24 - 8))
+                            | ((@in[27 + inpos]) << 8);
+        @out[21 + outpos] = (@in[28 + inpos] & 16777215)
+                            | ((@in[29 + inpos]) << 24);
+        @out[22 + outpos] = (int)(((uint)@in[29 + inpos] & 16777215) >> (24 - 16))
+                            | ((@in[30 + inpos]) << 16);
+        @out[23 + outpos] = (int)(((uint)@in[30 + inpos] & 16777215) >> (24 - 8))
+                            | ((@in[31 + inpos]) << 8);
+    }
+
+    protected static void fastpack25(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 33554431)
+                           | ((@in[1 + inpos]) << 25);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 33554431) >> (25 - 18))
+                           | ((@in[2 + inpos]) << 18);
+        @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 33554431) >> (25 - 11))
+                           | ((@in[3 + inpos]) << 11);
+        @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 33554431) >> (25 - 4))
+                           | ((@in[4 + inpos] & 33554431) << 4)
+                           | ((@in[5 + inpos]) << 29);
+        @out[4 + outpos] = (int)(((uint)@in[5 + inpos] & 33554431) >> (25 - 22))
+                           | ((@in[6 + inpos]) << 22);
+        @out[5 + outpos] = (int)(((uint)@in[6 + inpos] & 33554431) >> (25 - 15))
+                           | ((@in[7 + inpos]) << 15);
+        @out[6 + outpos] = (int)(((uint)@in[7 + inpos] & 33554431) >> (25 - 8))
+                           | ((@in[8 + inpos]) << 8);
+        @out[7 + outpos] = (int)(((uint)@in[8 + inpos] & 33554431) >> (25 - 1))
+                           | ((@in[9 + inpos] & 33554431) << 1)
+                           | ((@in[10 + inpos]) << 26);
+        @out[8 + outpos] = (int)(((uint)@in[10 + inpos] & 33554431) >> (25 - 19))
+                           | ((@in[11 + inpos]) << 19);
+        @out[9 + outpos] = (int)(((uint)@in[11 + inpos] & 33554431) >> (25 - 12))
+                           | ((@in[12 + inpos]) << 12);
+        @out[10 + outpos] = (int)(((uint)@in[12 + inpos] & 33554431) >> (25 - 5))
+                            | ((@in[13 + inpos] & 33554431) << 5)
+                            | ((@in[14 + inpos]) << 30);
+        @out[11 + outpos] = (int)(((uint)@in[14 + inpos] & 33554431) >> (25 - 23))
+                            | ((@in[15 + inpos]) << 23);
+        @out[12 + outpos] = (int)(((uint)@in[15 + inpos] & 33554431) >> (25 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[13 + outpos] = (int)(((uint)@in[16 + inpos] & 33554431) >> (25 - 9))
+                            | ((@in[17 + inpos]) << 9);
+        @out[14 + outpos] = (int)(((uint)@in[17 + inpos] & 33554431) >> (25 - 2))
+                            | ((@in[18 + inpos] & 33554431) << 2)
+                            | ((@in[19 + inpos]) << 27);
+        @out[15 + outpos] = (int)(((uint)@in[19 + inpos] & 33554431) >> (25 - 20))
+                            | ((@in[20 + inpos]) << 20);
+        @out[16 + outpos] = (int)(((uint)@in[20 + inpos] & 33554431) >> (25 - 13))
+                            | ((@in[21 + inpos]) << 13);
+        @out[17 + outpos] = (int)(((uint)@in[21 + inpos] & 33554431) >> (25 - 6))
+                            | ((@in[22 + inpos] & 33554431) << 6)
+                            | ((@in[23 + inpos]) << 31);
+        @out[18 + outpos] = (int)(((uint)@in[23 + inpos] & 33554431) >> (25 - 24))
+                            | ((@in[24 + inpos]) << 24);
+        @out[19 + outpos] = (int)(((uint)@in[24 + inpos] & 33554431) >> (25 - 17))
+                            | ((@in[25 + inpos]) << 17);
+        @out[20 + outpos] = (int)(((uint)@in[25 + inpos] & 33554431) >> (25 - 10))
+                            | ((@in[26 + inpos]) << 10);
+        @out[21 + outpos] = (int)(((uint)@in[26 + inpos] & 33554431) >> (25 - 3))
+                            | ((@in[27 + inpos] & 33554431) << 3)
+                            | ((@in[28 + inpos]) << 28);
+        @out[22 + outpos] = (int)(((uint)@in[28 + inpos] & 33554431) >> (25 - 21))
+                            | ((@in[29 + inpos]) << 21);
+        @out[23 + outpos] = (int)(((uint)@in[29 + inpos] & 33554431) >> (25 - 14))
+                            | ((@in[30 + inpos]) << 14);
+        @out[24 + outpos] = (int)(((uint)@in[30 + inpos] & 33554431) >> (25 - 7))
+                            | ((@in[31 + inpos]) << 7);
+    }
+
+    protected static void fastpack26(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 67108863)
+                           | ((@in[1 + inpos]) << 26);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 67108863) >> (26 - 20))
+                           | ((@in[2 + inpos]) << 20);
+        @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 67108863) >> (26 - 14))
+                           | ((@in[3 + inpos]) << 14);
+        @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 67108863) >> (26 - 8))
+                           | ((@in[4 + inpos]) << 8);
+        @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 67108863) >> (26 - 2))
+                           | ((@in[5 + inpos] & 67108863) << 2)
+                           | ((@in[6 + inpos]) << 28);
+        @out[5 + outpos] = (int)(((uint)@in[6 + inpos] & 67108863) >> (26 - 22))
+                           | ((@in[7 + inpos]) << 22);
+        @out[6 + outpos] = (int)(((uint)@in[7 + inpos] & 67108863) >> (26 - 16))
+                           | ((@in[8 + inpos]) << 16);
+        @out[7 + outpos] = (int)(((uint)@in[8 + inpos] & 67108863) >> (26 - 10))
+                           | ((@in[9 + inpos]) << 10);
+        @out[8 + outpos] = (int)(((uint)@in[9 + inpos] & 67108863) >> (26 - 4))
+                           | ((@in[10 + inpos] & 67108863) << 4)
+                           | ((@in[11 + inpos]) << 30);
+        @out[9 + outpos] = (int)(((uint)@in[11 + inpos] & 67108863) >> (26 - 24))
+                           | ((@in[12 + inpos]) << 24);
+        @out[10 + outpos] = (int)(((uint)@in[12 + inpos] & 67108863) >> (26 - 18))
+                            | ((@in[13 + inpos]) << 18);
+        @out[11 + outpos] = (int)(((uint)@in[13 + inpos] & 67108863) >> (26 - 12))
+                            | ((@in[14 + inpos]) << 12);
+        @out[12 + outpos] = (int)(((uint)@in[14 + inpos] & 67108863) >> (26 - 6))
+                            | ((@in[15 + inpos]) << 6);
+        @out[13 + outpos] = (@in[16 + inpos] & 67108863)
+                            | ((@in[17 + inpos]) << 26);
+        @out[14 + outpos] = (int)(((uint)@in[17 + inpos] & 67108863) >> (26 - 20))
+                            | ((@in[18 + inpos]) << 20);
+        @out[15 + outpos] = (int)(((uint)@in[18 + inpos] & 67108863) >> (26 - 14))
+                            | ((@in[19 + inpos]) << 14);
+        @out[16 + outpos] = (int)(((uint)@in[19 + inpos] & 67108863) >> (26 - 8))
+                            | ((@in[20 + inpos]) << 8);
+        @out[17 + outpos] = (int)(((uint)@in[20 + inpos] & 67108863) >> (26 - 2))
+                            | ((@in[21 + inpos] & 67108863) << 2)
+                            | ((@in[22 + inpos]) << 28);
+        @out[18 + outpos] = (int)(((uint)@in[22 + inpos] & 67108863) >> (26 - 22))
+                            | ((@in[23 + inpos]) << 22);
+        @out[19 + outpos] = (int)(((uint)@in[23 + inpos] & 67108863) >> (26 - 16))
+                            | ((@in[24 + inpos]) << 16);
+        @out[20 + outpos] = (int)(((uint)@in[24 + inpos] & 67108863) >> (26 - 10))
+                            | ((@in[25 + inpos]) << 10);
+        @out[21 + outpos] = (int)(((uint)@in[25 + inpos] & 67108863) >> (26 - 4))
+                            | ((@in[26 + inpos] & 67108863) << 4)
+                            | ((@in[27 + inpos]) << 30);
+        @out[22 + outpos] = (int)(((uint)@in[27 + inpos] & 67108863) >> (26 - 24))
+                            | ((@in[28 + inpos]) << 24);
+        @out[23 + outpos] = (int)(((uint)@in[28 + inpos] & 67108863) >> (26 - 18))
+                            | ((@in[29 + inpos]) << 18);
+        @out[24 + outpos] = (int)(((uint)@in[29 + inpos] & 67108863) >> (26 - 12))
+                            | ((@in[30 + inpos]) << 12);
+        @out[25 + outpos] = (int)(((uint)@in[30 + inpos] & 67108863) >> (26 - 6))
+                            | ((@in[31 + inpos]) << 6);
+    }
+
+    protected static void fastpack27(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 134217727)
+                           | ((@in[1 + inpos]) << 27);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 134217727) >> (27 - 22))
+                           | ((@in[2 + inpos]) << 22);
+        @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 134217727) >> (27 - 17))
+                           | ((@in[3 + inpos]) << 17);
+        @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 134217727) >> (27 - 12))
+                           | ((@in[4 + inpos]) << 12);
+        @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 134217727) >> (27 - 7))
+                           | ((@in[5 + inpos]) << 7);
+        @out[5 + outpos] = (int)(((uint)@in[5 + inpos] & 134217727) >> (27 - 2))
+                           | ((@in[6 + inpos] & 134217727) << 2)
+                           | ((@in[7 + inpos]) << 29);
+        @out[6 + outpos] = (int)(((uint)@in[7 + inpos] & 134217727) >> (27 - 24))
+                           | ((@in[8 + inpos]) << 24);
+        @out[7 + outpos] = (int)(((uint)@in[8 + inpos] & 134217727) >> (27 - 19))
+                           | ((@in[9 + inpos]) << 19);
+        @out[8 + outpos] = (int)(((uint)@in[9 + inpos] & 134217727) >> (27 - 14))
+                           | ((@in[10 + inpos]) << 14);
+        @out[9 + outpos] = (int)(((uint)@in[10 + inpos] & 134217727) >> (27 - 9))
+                           | ((@in[11 + inpos]) << 9);
+        @out[10 + outpos] = (int)(((uint)@in[11 + inpos] & 134217727) >> (27 - 4))
+                            | ((@in[12 + inpos] & 134217727) << 4)
+                            | ((@in[13 + inpos]) << 31);
+        @out[11 + outpos] = (int)(((uint)@in[13 + inpos] & 134217727) >> (27 - 26))
+                            | ((@in[14 + inpos]) << 26);
+        @out[12 + outpos] = (int)(((uint)@in[14 + inpos] & 134217727) >> (27 - 21))
+                            | ((@in[15 + inpos]) << 21);
+        @out[13 + outpos] = (int)(((uint)@in[15 + inpos] & 134217727) >> (27 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[14 + outpos] = (int)(((uint)@in[16 + inpos] & 134217727) >> (27 - 11))
+                            | ((@in[17 + inpos]) << 11);
+        @out[15 + outpos] = (int)(((uint)@in[17 + inpos] & 134217727) >> (27 - 6))
+                            | ((@in[18 + inpos]) << 6);
+        @out[16 + outpos] = (int)(((uint)@in[18 + inpos] & 134217727) >> (27 - 1))
+                            | ((@in[19 + inpos] & 134217727) << 1)
+                            | ((@in[20 + inpos]) << 28);
+        @out[17 + outpos] = (int)(((uint)@in[20 + inpos] & 134217727) >> (27 - 23))
+                            | ((@in[21 + inpos]) << 23);
+        @out[18 + outpos] = (int)(((uint)@in[21 + inpos] & 134217727) >> (27 - 18))
+                            | ((@in[22 + inpos]) << 18);
+        @out[19 + outpos] = (int)(((uint)@in[22 + inpos] & 134217727) >> (27 - 13))
+                            | ((@in[23 + inpos]) << 13);
+        @out[20 + outpos] = (int)(((uint)@in[23 + inpos] & 134217727) >> (27 - 8))
+                            | ((@in[24 + inpos]) << 8);
+        @out[21 + outpos] = (int)(((uint)@in[24 + inpos] & 134217727) >> (27 - 3))
+                            | ((@in[25 + inpos] & 134217727) << 3)
+                            | ((@in[26 + inpos]) << 30);
+        @out[22 + outpos] = (int)(((uint)@in[26 + inpos] & 134217727) >> (27 - 25))
+                            | ((@in[27 + inpos]) << 25);
+        @out[23 + outpos] = (int)(((uint)@in[27 + inpos] & 134217727) >> (27 - 20))
+                            | ((@in[28 + inpos]) << 20);
+        @out[24 + outpos] = (int)(((uint)@in[28 + inpos] & 134217727) >> (27 - 15))
+                            | ((@in[29 + inpos]) << 15);
+        @out[25 + outpos] = (int)(((uint)@in[29 + inpos] & 134217727) >> (27 - 10))
+                            | ((@in[30 + inpos]) << 10);
+        @out[26 + outpos] = (int)(((uint)@in[30 + inpos] & 134217727) >> (27 - 5))
+                            | ((@in[31 + inpos]) << 5);
+    }
+
+    protected static void fastpack28(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 268435455)
+                           | ((@in[1 + inpos]) << 28);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 268435455) >> (28 - 24))
+                           | ((@in[2 + inpos]) << 24);
+        @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 268435455) >> (28 - 20))
+                           | ((@in[3 + inpos]) << 20);
+        @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 268435455) >> (28 - 16))
+                           | ((@in[4 + inpos]) << 16);
+        @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 268435455) >> (28 - 12))
+                           | ((@in[5 + inpos]) << 12);
+        @out[5 + outpos] = (int)(((uint)@in[5 + inpos] & 268435455) >> (28 - 8))
+                           | ((@in[6 + inpos]) << 8);
+        @out[6 + outpos] = (int)(((uint)@in[6 + inpos] & 268435455) >> (28 - 4))
+                           | ((@in[7 + inpos]) << 4);
+        @out[7 + outpos] = (@in[8 + inpos] & 268435455)
+                           | ((@in[9 + inpos]) << 28);
+        @out[8 + outpos] = (int)(((uint)@in[9 + inpos] & 268435455) >> (28 - 24))
+                           | ((@in[10 + inpos]) << 24);
+        @out[9 + outpos] = (int)(((uint)@in[10 + inpos] & 268435455) >> (28 - 20))
+                           | ((@in[11 + inpos]) << 20);
+        @out[10 + outpos] = (int)(((uint)@in[11 + inpos] & 268435455) >> (28 - 16))
+                            | ((@in[12 + inpos]) << 16);
+        @out[11 + outpos] = (int)(((uint)@in[12 + inpos] & 268435455) >> (28 - 12))
+                            | ((@in[13 + inpos]) << 12);
+        @out[12 + outpos] = (int)(((uint)@in[13 + inpos] & 268435455) >> (28 - 8))
+                            | ((@in[14 + inpos]) << 8);
+        @out[13 + outpos] = (int)(((uint)@in[14 + inpos] & 268435455) >> (28 - 4))
+                            | ((@in[15 + inpos]) << 4);
+        @out[14 + outpos] = (@in[16 + inpos] & 268435455)
+                            | ((@in[17 + inpos]) << 28);
+        @out[15 + outpos] = (int)(((uint)@in[17 + inpos] & 268435455) >> (28 - 24))
+                            | ((@in[18 + inpos]) << 24);
+        @out[16 + outpos] = (int)(((uint)@in[18 + inpos] & 268435455) >> (28 - 20))
+                            | ((@in[19 + inpos]) << 20);
+        @out[17 + outpos] = (int)(((uint)@in[19 + inpos] & 268435455) >> (28 - 16))
+                            | ((@in[20 + inpos]) << 16);
+        @out[18 + outpos] = (int)(((uint)@in[20 + inpos] & 268435455) >> (28 - 12))
+                            | ((@in[21 + inpos]) << 12);
+        @out[19 + outpos] = (int)(((uint)@in[21 + inpos] & 268435455) >> (28 - 8))
+                            | ((@in[22 + inpos]) << 8);
+        @out[20 + outpos] = (int)(((uint)@in[22 + inpos] & 268435455) >> (28 - 4))
+                            | ((@in[23 + inpos]) << 4);
+        @out[21 + outpos] = (@in[24 + inpos] & 268435455)
+                            | ((@in[25 + inpos]) << 28);
+        @out[22 + outpos] = (int)(((uint)@in[25 + inpos] & 268435455) >> (28 - 24))
+                            | ((@in[26 + inpos]) << 24);
+        @out[23 + outpos] = (int)(((uint)@in[26 + inpos] & 268435455) >> (28 - 20))
+                            | ((@in[27 + inpos]) << 20);
+        @out[24 + outpos] = (int)(((uint)@in[27 + inpos] & 268435455) >> (28 - 16))
+                            | ((@in[28 + inpos]) << 16);
+        @out[25 + outpos] = (int)(((uint)@in[28 + inpos] & 268435455) >> (28 - 12))
+                            | ((@in[29 + inpos]) << 12);
+        @out[26 + outpos] = (int)(((uint)@in[29 + inpos] & 268435455) >> (28 - 8))
+                            | ((@in[30 + inpos]) << 8);
+        @out[27 + outpos] = (int)(((uint)@in[30 + inpos] & 268435455) >> (28 - 4))
+                            | ((@in[31 + inpos]) << 4);
+    }
+
+    protected static void fastpack29(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 536870911)
+                           | ((@in[1 + inpos]) << 29);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 536870911) >> (29 - 26))
+                           | ((@in[2 + inpos]) << 26);
+        @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 536870911) >> (29 - 23))
+                           | ((@in[3 + inpos]) << 23);
+        @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 536870911) >> (29 - 20))
+                           | ((@in[4 + inpos]) << 20);
+        @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 536870911) >> (29 - 17))
+                           | ((@in[5 + inpos]) << 17);
+        @out[5 + outpos] = (int)(((uint)@in[5 + inpos] & 536870911) >> (29 - 14))
+                           | ((@in[6 + inpos]) << 14);
+        @out[6 + outpos] = (int)(((uint)@in[6 + inpos] & 536870911) >> (29 - 11))
+                           | ((@in[7 + inpos]) << 11);
+        @out[7 + outpos] = (int)(((uint)@in[7 + inpos] & 536870911) >> (29 - 8))
+                           | ((@in[8 + inpos]) << 8);
+        @out[8 + outpos] = (int)(((uint)@in[8 + inpos] & 536870911) >> (29 - 5))
+                           | ((@in[9 + inpos]) << 5);
+        @out[9 + outpos] = (int)(((uint)@in[9 + inpos] & 536870911) >> (29 - 2))
+                           | ((@in[10 + inpos] & 536870911) << 2)
+                           | ((@in[11 + inpos]) << 31);
+        @out[10 + outpos] = (int)(((uint)@in[11 + inpos] & 536870911) >> (29 - 28))
+                            | ((@in[12 + inpos]) << 28);
+        @out[11 + outpos] = (int)(((uint)@in[12 + inpos] & 536870911) >> (29 - 25))
+                            | ((@in[13 + inpos]) << 25);
+        @out[12 + outpos] = (int)(((uint)@in[13 + inpos] & 536870911) >> (29 - 22))
+                            | ((@in[14 + inpos]) << 22);
+        @out[13 + outpos] = (int)(((uint)@in[14 + inpos] & 536870911) >> (29 - 19))
+                            | ((@in[15 + inpos]) << 19);
+        @out[14 + outpos] = (int)(((uint)@in[15 + inpos] & 536870911) >> (29 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[15 + outpos] = (int)(((uint)@in[16 + inpos] & 536870911) >> (29 - 13))
+                            | ((@in[17 + inpos]) << 13);
+        @out[16 + outpos] = (int)(((uint)@in[17 + inpos] & 536870911) >> (29 - 10))
+                            | ((@in[18 + inpos]) << 10);
+        @out[17 + outpos] = (int)(((uint)@in[18 + inpos] & 536870911) >> (29 - 7))
+                            | ((@in[19 + inpos]) << 7);
+        @out[18 + outpos] = (int)(((uint)@in[19 + inpos] & 536870911) >> (29 - 4))
+                            | ((@in[20 + inpos]) << 4);
+        @out[19 + outpos] = (int)(((uint)@in[20 + inpos] & 536870911) >> (29 - 1))
+                            | ((@in[21 + inpos] & 536870911) << 1)
+                            | ((@in[22 + inpos]) << 30);
+        @out[20 + outpos] = (int)(((uint)@in[22 + inpos] & 536870911) >> (29 - 27))
+                            | ((@in[23 + inpos]) << 27);
+        @out[21 + outpos] = (int)(((uint)@in[23 + inpos] & 536870911) >> (29 - 24))
+                            | ((@in[24 + inpos]) << 24);
+        @out[22 + outpos] = (int)(((uint)@in[24 + inpos] & 536870911) >> (29 - 21))
+                            | ((@in[25 + inpos]) << 21);
+        @out[23 + outpos] = (int)(((uint)@in[25 + inpos] & 536870911) >> (29 - 18))
+                            | ((@in[26 + inpos]) << 18);
+        @out[24 + outpos] = (int)(((uint)@in[26 + inpos] & 536870911) >> (29 - 15))
+                            | ((@in[27 + inpos]) << 15);
+        @out[25 + outpos] = (int)(((uint)@in[27 + inpos] & 536870911) >> (29 - 12))
+                            | ((@in[28 + inpos]) << 12);
+        @out[26 + outpos] = (int)(((uint)@in[28 + inpos] & 536870911) >> (29 - 9))
+                            | ((@in[29 + inpos]) << 9);
+        @out[27 + outpos] = (int)(((uint)@in[29 + inpos] & 536870911) >> (29 - 6))
+                            | ((@in[30 + inpos]) << 6);
+        @out[28 + outpos] = (int)(((uint)@in[30 + inpos] & 536870911) >> (29 - 3))
+                            | ((@in[31 + inpos]) << 3);
+    }
+
+    protected static void fastpack3(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 7)
+                           | ((@in[1 + inpos] & 7) << 3)
+                           | ((@in[2 + inpos] & 7) << 6)
+                           | ((@in[3 + inpos] & 7) << 9)
+                           | ((@in[4 + inpos] & 7) << 12)
+                           | ((@in[5 + inpos] & 7) << 15)
+                           | ((@in[6 + inpos] & 7) << 18)
+                           | ((@in[7 + inpos] & 7) << 21)
+                           | ((@in[8 + inpos] & 7) << 24)
+                           | ((@in[9 + inpos] & 7) << 27)
+                           | ((@in[10 + inpos]) << 30);
+        @out[1 + outpos] = (int)(((uint)@in[10 + inpos] & 7) >> (3 - 1))
+                           | ((@in[11 + inpos] & 7) << 1)
+                           | ((@in[12 + inpos] & 7) << 4)
+                           | ((@in[13 + inpos] & 7) << 7)
+                           | ((@in[14 + inpos] & 7) << 10)
+                           | ((@in[15 + inpos] & 7) << 13)
+                           | ((@in[16 + inpos] & 7) << 16)
+                           | ((@in[17 + inpos] & 7) << 19)
+                           | ((@in[18 + inpos] & 7) << 22)
+                           | ((@in[19 + inpos] & 7) << 25)
+                           | ((@in[20 + inpos] & 7) << 28)
+                           | ((@in[21 + inpos]) << 31);
+        @out[2 + outpos] = (int)(((uint)@in[21 + inpos] & 7) >> (3 - 2))
+                           | ((@in[22 + inpos] & 7) << 2)
+                           | ((@in[23 + inpos] & 7) << 5)
+                           | ((@in[24 + inpos] & 7) << 8)
+                           | ((@in[25 + inpos] & 7) << 11)
+                           | ((@in[26 + inpos] & 7) << 14)
+                           | ((@in[27 + inpos] & 7) << 17)
+                           | ((@in[28 + inpos] & 7) << 20)
+                           | ((@in[29 + inpos] & 7) << 23)
+                           | ((@in[30 + inpos] & 7) << 26)
+                           | ((@in[31 + inpos]) << 29);
+    }
+
+    protected static void fastpack30(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 1073741823)
+                           | ((@in[1 + inpos]) << 30);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 1073741823) >> (30 - 28))
+                           | ((@in[2 + inpos]) << 28);
+        @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 1073741823) >> (30 - 26))
+                           | ((@in[3 + inpos]) << 26);
+        @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 1073741823) >> (30 - 24))
+                           | ((@in[4 + inpos]) << 24);
+        @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 1073741823) >> (30 - 22))
+                           | ((@in[5 + inpos]) << 22);
+        @out[5 + outpos] = (int)(((uint)@in[5 + inpos] & 1073741823) >> (30 - 20))
+                           | ((@in[6 + inpos]) << 20);
+        @out[6 + outpos] = (int)(((uint)@in[6 + inpos] & 1073741823) >> (30 - 18))
+                           | ((@in[7 + inpos]) << 18);
+        @out[7 + outpos] = (int)(((uint)@in[7 + inpos] & 1073741823) >> (30 - 16))
+                           | ((@in[8 + inpos]) << 16);
+        @out[8 + outpos] = (int)(((uint)@in[8 + inpos] & 1073741823) >> (30 - 14))
+                           | ((@in[9 + inpos]) << 14);
+        @out[9 + outpos] = (int)(((uint)@in[9 + inpos] & 1073741823) >> (30 - 12))
+                           | ((@in[10 + inpos]) << 12);
+        @out[10 + outpos] = (int)(((uint)@in[10 + inpos] & 1073741823) >> (30 - 10))
+                            | ((@in[11 + inpos]) << 10);
+        @out[11 + outpos] = (int)(((uint)@in[11 + inpos] & 1073741823) >> (30 - 8))
+                            | ((@in[12 + inpos]) << 8);
+        @out[12 + outpos] = (int)(((uint)@in[12 + inpos] & 1073741823) >> (30 - 6))
+                            | ((@in[13 + inpos]) << 6);
+        @out[13 + outpos] = (int)(((uint)@in[13 + inpos] & 1073741823) >> (30 - 4))
+                            | ((@in[14 + inpos]) << 4);
+        @out[14 + outpos] = (int)(((uint)@in[14 + inpos] & 1073741823) >> (30 - 2))
+                            | ((@in[15 + inpos]) << 2);
+        @out[15 + outpos] = (@in[16 + inpos] & 1073741823)
+                            | ((@in[17 + inpos]) << 30);
+        @out[16 + outpos] = (int)(((uint)@in[17 + inpos] & 1073741823) >> (30 - 28))
+                            | ((@in[18 + inpos]) << 28);
+        @out[17 + outpos] = (int)(((uint)@in[18 + inpos] & 1073741823) >> (30 - 26))
+                            | ((@in[19 + inpos]) << 26);
+        @out[18 + outpos] = (int)(((uint)@in[19 + inpos] & 1073741823) >> (30 - 24))
+                            | ((@in[20 + inpos]) << 24);
+        @out[19 + outpos] = (int)(((uint)@in[20 + inpos] & 1073741823) >> (30 - 22))
+                            | ((@in[21 + inpos]) << 22);
+        @out[20 + outpos] = (int)(((uint)@in[21 + inpos] & 1073741823) >> (30 - 20))
+                            | ((@in[22 + inpos]) << 20);
+        @out[21 + outpos] = (int)(((uint)@in[22 + inpos] & 1073741823) >> (30 - 18))
+                            | ((@in[23 + inpos]) << 18);
+        @out[22 + outpos] = (int)(((uint)@in[23 + inpos] & 1073741823) >> (30 - 16))
+                            | ((@in[24 + inpos]) << 16);
+        @out[23 + outpos] = (int)(((uint)@in[24 + inpos] & 1073741823) >> (30 - 14))
+                            | ((@in[25 + inpos]) << 14);
+        @out[24 + outpos] = (int)(((uint)@in[25 + inpos] & 1073741823) >> (30 - 12))
+                            | ((@in[26 + inpos]) << 12);
+        @out[25 + outpos] = (int)(((uint)@in[26 + inpos] & 1073741823) >> (30 - 10))
+                            | ((@in[27 + inpos]) << 10);
+        @out[26 + outpos] = (int)(((uint)@in[27 + inpos] & 1073741823) >> (30 - 8))
+                            | ((@in[28 + inpos]) << 8);
+        @out[27 + outpos] = (int)(((uint)@in[28 + inpos] & 1073741823) >> (30 - 6))
+                            | ((@in[29 + inpos]) << 6);
+        @out[28 + outpos] = (int)(((uint)@in[29 + inpos] & 1073741823) >> (30 - 4))
+                            | ((@in[30 + inpos]) << 4);
+        @out[29 + outpos] = (int)(((uint)@in[30 + inpos] & 1073741823) >> (30 - 2))
+                            | ((@in[31 + inpos]) << 2);
+    }
+
+    protected static void fastpack31(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 2147483647)
+                           | ((@in[1 + inpos]) << 31);
+        @out[1 + outpos] = (int)(((uint)@in[1 + inpos] & 2147483647) >> (31 - 30))
+                           | ((@in[2 + inpos]) << 30);
+        @out[2 + outpos] = (int)(((uint)@in[2 + inpos] & 2147483647) >> (31 - 29))
+                           | ((@in[3 + inpos]) << 29);
+        @out[3 + outpos] = (int)(((uint)@in[3 + inpos] & 2147483647) >> (31 - 28))
+                           | ((@in[4 + inpos]) << 28);
+        @out[4 + outpos] = (int)(((uint)@in[4 + inpos] & 2147483647) >> (31 - 27))
+                           | ((@in[5 + inpos]) << 27);
+        @out[5 + outpos] = (int)(((uint)@in[5 + inpos] & 2147483647) >> (31 - 26))
+                           | ((@in[6 + inpos]) << 26);
+        @out[6 + outpos] = (int)(((uint)@in[6 + inpos] & 2147483647) >> (31 - 25))
+                           | ((@in[7 + inpos]) << 25);
+        @out[7 + outpos] = (int)(((uint)@in[7 + inpos] & 2147483647) >> (31 - 24))
+                           | ((@in[8 + inpos]) << 24);
+        @out[8 + outpos] = (int)(((uint)@in[8 + inpos] & 2147483647) >> (31 - 23))
+                           | ((@in[9 + inpos]) << 23);
+        @out[9 + outpos] = (int)(((uint)@in[9 + inpos] & 2147483647) >> (31 - 22))
+                           | ((@in[10 + inpos]) << 22);
+        @out[10 + outpos] = (int)(((uint)@in[10 + inpos] & 2147483647) >> (31 - 21))
+                            | ((@in[11 + inpos]) << 21);
+        @out[11 + outpos] = (int)(((uint)@in[11 + inpos] & 2147483647) >> (31 - 20))
+                            | ((@in[12 + inpos]) << 20);
+        @out[12 + outpos] = (int)(((uint)@in[12 + inpos] & 2147483647) >> (31 - 19))
+                            | ((@in[13 + inpos]) << 19);
+        @out[13 + outpos] = (int)(((uint)@in[13 + inpos] & 2147483647) >> (31 - 18))
+                            | ((@in[14 + inpos]) << 18);
+        @out[14 + outpos] = (int)(((uint)@in[14 + inpos] & 2147483647) >> (31 - 17))
+                            | ((@in[15 + inpos]) << 17);
+        @out[15 + outpos] = (int)(((uint)@in[15 + inpos] & 2147483647) >> (31 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[16 + outpos] = (int)(((uint)@in[16 + inpos] & 2147483647) >> (31 - 15))
+                            | ((@in[17 + inpos]) << 15);
+        @out[17 + outpos] = (int)(((uint)@in[17 + inpos] & 2147483647) >> (31 - 14))
+                            | ((@in[18 + inpos]) << 14);
+        @out[18 + outpos] = (int)(((uint)@in[18 + inpos] & 2147483647) >> (31 - 13))
+                            | ((@in[19 + inpos]) << 13);
+        @out[19 + outpos] = (int)(((uint)@in[19 + inpos] & 2147483647) >> (31 - 12))
+                            | ((@in[20 + inpos]) << 12);
+        @out[20 + outpos] = (int)(((uint)@in[20 + inpos] & 2147483647) >> (31 - 11))
+                            | ((@in[21 + inpos]) << 11);
+        @out[21 + outpos] = (int)(((uint)@in[21 + inpos] & 2147483647) >> (31 - 10))
+                            | ((@in[22 + inpos]) << 10);
+        @out[22 + outpos] = (int)(((uint)@in[22 + inpos] & 2147483647) >> (31 - 9))
+                            | ((@in[23 + inpos]) << 9);
+        @out[23 + outpos] = (int)(((uint)@in[23 + inpos] & 2147483647) >> (31 - 8))
+                            | ((@in[24 + inpos]) << 8);
+        @out[24 + outpos] = (int)(((uint)@in[24 + inpos] & 2147483647) >> (31 - 7))
+                            | ((@in[25 + inpos]) << 7);
+        @out[25 + outpos] = (int)(((uint)@in[25 + inpos] & 2147483647) >> (31 - 6))
+                            | ((@in[26 + inpos]) << 6);
+        @out[26 + outpos] = (int)(((uint)@in[26 + inpos] & 2147483647) >> (31 - 5))
+                            | ((@in[27 + inpos]) << 5);
+        @out[27 + outpos] = (int)(((uint)@in[27 + inpos] & 2147483647) >> (31 - 4))
+                            | ((@in[28 + inpos]) << 4);
+        @out[28 + outpos] = (int)(((uint)@in[28 + inpos] & 2147483647) >> (31 - 3))
+                            | ((@in[29 + inpos]) << 3);
+        @out[29 + outpos] = (int)(((uint)@in[29 + inpos] & 2147483647) >> (31 - 2))
+                            | ((@in[30 + inpos]) << 2);
+        @out[30 + outpos] = (int)(((uint)@in[30 + inpos] & 2147483647) >> (31 - 1))
+                            | ((@in[31 + inpos]) << 1);
+    }
+
+    protected static void fastpack32(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        Array.Copy(@in, inpos, @out, outpos, 32);
+    }
+
+    protected static void fastpack4(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 15)
+                           | ((@in[1 + inpos] & 15) << 4)
+                           | ((@in[2 + inpos] & 15) << 8)
+                           | ((@in[3 + inpos] & 15) << 12)
+                           | ((@in[4 + inpos] & 15) << 16)
+                           | ((@in[5 + inpos] & 15) << 20)
+                           | ((@in[6 + inpos] & 15) << 24)
+                           | ((@in[7 + inpos]) << 28);
+        @out[1 + outpos] = (@in[8 + inpos] & 15)
+                           | ((@in[9 + inpos] & 15) << 4)
+                           | ((@in[10 + inpos] & 15) << 8)
+                           | ((@in[11 + inpos] & 15) << 12)
+                           | ((@in[12 + inpos] & 15) << 16)
+                           | ((@in[13 + inpos] & 15) << 20)
+                           | ((@in[14 + inpos] & 15) << 24)
+                           | ((@in[15 + inpos]) << 28);
+        @out[2 + outpos] = (@in[16 + inpos] & 15)
+                           | ((@in[17 + inpos] & 15) << 4)
+                           | ((@in[18 + inpos] & 15) << 8)
+                           | ((@in[19 + inpos] & 15) << 12)
+                           | ((@in[20 + inpos] & 15) << 16)
+                           | ((@in[21 + inpos] & 15) << 20)
+                           | ((@in[22 + inpos] & 15) << 24)
+                           | ((@in[23 + inpos]) << 28);
+        @out[3 + outpos] = (@in[24 + inpos] & 15)
+                           | ((@in[25 + inpos] & 15) << 4)
+                           | ((@in[26 + inpos] & 15) << 8)
+                           | ((@in[27 + inpos] & 15) << 12)
+                           | ((@in[28 + inpos] & 15) << 16)
+                           | ((@in[29 + inpos] & 15) << 20)
+                           | ((@in[30 + inpos] & 15) << 24)
+                           | ((@in[31 + inpos]) << 28);
+    }
+
+    protected static void fastpack5(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 31)
+                           | ((@in[1 + inpos] & 31) << 5)
+                           | ((@in[2 + inpos] & 31) << 10)
+                           | ((@in[3 + inpos] & 31) << 15)
+                           | ((@in[4 + inpos] & 31) << 20)
+                           | ((@in[5 + inpos] & 31) << 25)
+                           | ((@in[6 + inpos]) << 30);
+        @out[1 + outpos] = (int)(((uint)@in[6 + inpos] & 31) >> (5 - 3))
+                           | ((@in[7 + inpos] & 31) << 3)
+                           | ((@in[8 + inpos] & 31) << 8)
+                           | ((@in[9 + inpos] & 31) << 13)
+                           | ((@in[10 + inpos] & 31) << 18)
+                           | ((@in[11 + inpos] & 31) << 23)
+                           | ((@in[12 + inpos]) << 28);
+        @out[2 + outpos] = (int)(((uint)@in[12 + inpos] & 31) >> (5 - 1))
+                           | ((@in[13 + inpos] & 31) << 1)
+                           | ((@in[14 + inpos] & 31) << 6)
+                           | ((@in[15 + inpos] & 31) << 11)
+                           | ((@in[16 + inpos] & 31) << 16)
+                           | ((@in[17 + inpos] & 31) << 21)
+                           | ((@in[18 + inpos] & 31) << 26)
+                           | ((@in[19 + inpos]) << 31);
+        @out[3 + outpos] = (int)(((uint)@in[19 + inpos] & 31) >> (5 - 4))
+                           | ((@in[20 + inpos] & 31) << 4)
+                           | ((@in[21 + inpos] & 31) << 9)
+                           | ((@in[22 + inpos] & 31) << 14)
+                           | ((@in[23 + inpos] & 31) << 19)
+                           | ((@in[24 + inpos] & 31) << 24)
+                           | ((@in[25 + inpos]) << 29);
+        @out[4 + outpos] = (int)(((uint)@in[25 + inpos] & 31) >> (5 - 2))
+                           | ((@in[26 + inpos] & 31) << 2)
+                           | ((@in[27 + inpos] & 31) << 7)
+                           | ((@in[28 + inpos] & 31) << 12)
+                           | ((@in[29 + inpos] & 31) << 17)
+                           | ((@in[30 + inpos] & 31) << 22)
+                           | ((@in[31 + inpos]) << 27);
+    }
+
+    protected static void fastpack6(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 63)
+                           | ((@in[1 + inpos] & 63) << 6)
+                           | ((@in[2 + inpos] & 63) << 12)
+                           | ((@in[3 + inpos] & 63) << 18)
+                           | ((@in[4 + inpos] & 63) << 24)
+                           | ((@in[5 + inpos]) << 30);
+        @out[1 + outpos] = (int)(((uint)@in[5 + inpos] & 63) >> (6 - 4))
+                           | ((@in[6 + inpos] & 63) << 4)
+                           | ((@in[7 + inpos] & 63) << 10)
+                           | ((@in[8 + inpos] & 63) << 16)
+                           | ((@in[9 + inpos] & 63) << 22)
+                           | ((@in[10 + inpos]) << 28);
+        @out[2 + outpos] = (int)(((uint)@in[10 + inpos] & 63) >> (6 - 2))
+                           | ((@in[11 + inpos] & 63) << 2)
+                           | ((@in[12 + inpos] & 63) << 8)
+                           | ((@in[13 + inpos] & 63) << 14)
+                           | ((@in[14 + inpos] & 63) << 20)
+                           | ((@in[15 + inpos]) << 26);
+        @out[3 + outpos] = (@in[16 + inpos] & 63)
+                           | ((@in[17 + inpos] & 63) << 6)
+                           | ((@in[18 + inpos] & 63) << 12)
+                           | ((@in[19 + inpos] & 63) << 18)
+                           | ((@in[20 + inpos] & 63) << 24)
+                           | ((@in[21 + inpos]) << 30);
+        @out[4 + outpos] = (int)(((uint)@in[21 + inpos] & 63) >> (6 - 4))
+                           | ((@in[22 + inpos] & 63) << 4)
+                           | ((@in[23 + inpos] & 63) << 10)
+                           | ((@in[24 + inpos] & 63) << 16)
+                           | ((@in[25 + inpos] & 63) << 22)
+                           | ((@in[26 + inpos]) << 28);
+        @out[5 + outpos] = (int)(((uint)@in[26 + inpos] & 63) >> (6 - 2))
+                           | ((@in[27 + inpos] & 63) << 2)
+                           | ((@in[28 + inpos] & 63) << 8)
+                           | ((@in[29 + inpos] & 63) << 14)
+                           | ((@in[30 + inpos] & 63) << 20)
+                           | ((@in[31 + inpos]) << 26);
+    }
+
+    protected static void fastpack7(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 127)
+                           | ((@in[1 + inpos] & 127) << 7)
+                           | ((@in[2 + inpos] & 127) << 14)
+                           | ((@in[3 + inpos] & 127) << 21)
+                           | ((@in[4 + inpos]) << 28);
+        @out[1 + outpos] = (int)(((uint)@in[4 + inpos] & 127) >> (7 - 3))
+                           | ((@in[5 + inpos] & 127) << 3)
+                           | ((@in[6 + inpos] & 127) << 10)
+                           | ((@in[7 + inpos] & 127) << 17)
+                           | ((@in[8 + inpos] & 127) << 24)
+                           | ((@in[9 + inpos]) << 31);
+        @out[2 + outpos] = (int)(((uint)@in[9 + inpos] & 127) >> (7 - 6))
+                           | ((@in[10 + inpos] & 127) << 6)
+                           | ((@in[11 + inpos] & 127) << 13)
+                           | ((@in[12 + inpos] & 127) << 20)
+                           | ((@in[13 + inpos]) << 27);
+        @out[3 + outpos] = (int)(((uint)@in[13 + inpos] & 127) >> (7 - 2))
+                           | ((@in[14 + inpos] & 127) << 2)
+                           | ((@in[15 + inpos] & 127) << 9)
+                           | ((@in[16 + inpos] & 127) << 16)
+                           | ((@in[17 + inpos] & 127) << 23)
+                           | ((@in[18 + inpos]) << 30);
+        @out[4 + outpos] = (int)(((uint)@in[18 + inpos] & 127) >> (7 - 5))
+                           | ((@in[19 + inpos] & 127) << 5)
+                           | ((@in[20 + inpos] & 127) << 12)
+                           | ((@in[21 + inpos] & 127) << 19)
+                           | ((@in[22 + inpos]) << 26);
+        @out[5 + outpos] = (int)(((uint)@in[22 + inpos] & 127) >> (7 - 1))
+                           | ((@in[23 + inpos] & 127) << 1)
+                           | ((@in[24 + inpos] & 127) << 8)
+                           | ((@in[25 + inpos] & 127) << 15)
+                           | ((@in[26 + inpos] & 127) << 22)
+                           | ((@in[27 + inpos]) << 29);
+        @out[6 + outpos] = (int)(((uint)@in[27 + inpos] & 127) >> (7 - 4))
+                           | ((@in[28 + inpos] & 127) << 4)
+                           | ((@in[29 + inpos] & 127) << 11)
+                           | ((@in[30 + inpos] & 127) << 18)
+                           | ((@in[31 + inpos]) << 25);
+    }
+
+    protected static void fastpack8(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 255)
+                           | ((@in[1 + inpos] & 255) << 8)
+                           | ((@in[2 + inpos] & 255) << 16)
+                           | ((@in[3 + inpos]) << 24);
+        @out[1 + outpos] = (@in[4 + inpos] & 255)
+                           | ((@in[5 + inpos] & 255) << 8)
+                           | ((@in[6 + inpos] & 255) << 16)
+                           | ((@in[7 + inpos]) << 24);
+        @out[2 + outpos] = (@in[8 + inpos] & 255)
+                           | ((@in[9 + inpos] & 255) << 8)
+                           | ((@in[10 + inpos] & 255) << 16)
+                           | ((@in[11 + inpos]) << 24);
+        @out[3 + outpos] = (@in[12 + inpos] & 255)
+                           | ((@in[13 + inpos] & 255) << 8)
+                           | ((@in[14 + inpos] & 255) << 16)
+                           | ((@in[15 + inpos]) << 24);
+        @out[4 + outpos] = (@in[16 + inpos] & 255)
+                           | ((@in[17 + inpos] & 255) << 8)
+                           | ((@in[18 + inpos] & 255) << 16)
+                           | ((@in[19 + inpos]) << 24);
+        @out[5 + outpos] = (@in[20 + inpos] & 255)
+                           | ((@in[21 + inpos] & 255) << 8)
+                           | ((@in[22 + inpos] & 255) << 16)
+                           | ((@in[23 + inpos]) << 24);
+        @out[6 + outpos] = (@in[24 + inpos] & 255)
+                           | ((@in[25 + inpos] & 255) << 8)
+                           | ((@in[26 + inpos] & 255) << 16)
+                           | ((@in[27 + inpos]) << 24);
+        @out[7 + outpos] = (@in[28 + inpos] & 255)
+                           | ((@in[29 + inpos] & 255) << 8)
+                           | ((@in[30 + inpos] & 255) << 16)
+                           | ((@in[31 + inpos]) << 24);
+    }
+
+    protected static void fastpack9(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] & 511)
+                           | ((@in[1 + inpos] & 511) << 9)
+                           | ((@in[2 + inpos] & 511) << 18)
+                           | ((@in[3 + inpos]) << 27);
+        @out[1 + outpos] = (int)(((uint)@in[3 + inpos] & 511) >> (9 - 4))
+                           | ((@in[4 + inpos] & 511) << 4)
+                           | ((@in[5 + inpos] & 511) << 13)
+                           | ((@in[6 + inpos] & 511) << 22)
+                           | ((@in[7 + inpos]) << 31);
+        @out[2 + outpos] = (int)(((uint)@in[7 + inpos] & 511) >> (9 - 8))
+                           | ((@in[8 + inpos] & 511) << 8)
+                           | ((@in[9 + inpos] & 511) << 17)
+                           | ((@in[10 + inpos]) << 26);
+        @out[3 + outpos] = (int)(((uint)@in[10 + inpos] & 511) >> (9 - 3))
+                           | ((@in[11 + inpos] & 511) << 3)
+                           | ((@in[12 + inpos] & 511) << 12)
+                           | ((@in[13 + inpos] & 511) << 21)
+                           | ((@in[14 + inpos]) << 30);
+        @out[4 + outpos] = (int)(((uint)@in[14 + inpos] & 511) >> (9 - 7))
+                           | ((@in[15 + inpos] & 511) << 7)
+                           | ((@in[16 + inpos] & 511) << 16)
+                           | ((@in[17 + inpos]) << 25);
+        @out[5 + outpos] = (int)(((uint)@in[17 + inpos] & 511) >> (9 - 2))
+                           | ((@in[18 + inpos] & 511) << 2)
+                           | ((@in[19 + inpos] & 511) << 11)
+                           | ((@in[20 + inpos] & 511) << 20)
+                           | ((@in[21 + inpos]) << 29);
+        @out[6 + outpos] = (int)(((uint)@in[21 + inpos] & 511) >> (9 - 6))
+                           | ((@in[22 + inpos] & 511) << 6)
+                           | ((@in[23 + inpos] & 511) << 15)
+                           | ((@in[24 + inpos]) << 24);
+        @out[7 + outpos] = (int)(((uint)@in[24 + inpos] & 511) >> (9 - 1))
+                           | ((@in[25 + inpos] & 511) << 1)
+                           | ((@in[26 + inpos] & 511) << 10)
+                           | ((@in[27 + inpos] & 511) << 19)
+                           | ((@in[28 + inpos]) << 28);
+        @out[8 + outpos] = (int)(((uint)@in[28 + inpos] & 511) >> (9 - 5))
+                           | ((@in[29 + inpos] & 511) << 5)
+                           | ((@in[30 + inpos] & 511) << 14)
+                           | ((@in[31 + inpos]) << 23);
+    }
+
+    /**
+     * Unpack 32 integers
+     * 
+     * @param in
+     *                source array
+     * @param inpos
+     *                position in source array
+     * @param out
+     *                output array
+     * @param outpos
+     *                position in output array
+     * @param bit
+     *                number of bits to use per integer
+     */
+    public static void fastpackwithoutmask(int[] @in, int inpos, int[] @out, int outpos, int bit)
+    {
+        switch (bit)
+        {
+            case 0:
+                fastpackwithoutmask0(@in, inpos, @out, outpos);
+                break;
+            case 1:
+                fastpackwithoutmask1(@in, inpos, @out, outpos);
+                break;
+            case 2:
+                fastpackwithoutmask2(@in, inpos, @out, outpos);
+                break;
+            case 3:
+                fastpackwithoutmask3(@in, inpos, @out, outpos);
+                break;
+            case 4:
+                fastpackwithoutmask4(@in, inpos, @out, outpos);
+                break;
+            case 5:
+                fastpackwithoutmask5(@in, inpos, @out, outpos);
+                break;
+            case 6:
+                fastpackwithoutmask6(@in, inpos, @out, outpos);
+                break;
+            case 7:
+                fastpackwithoutmask7(@in, inpos, @out, outpos);
+                break;
+            case 8:
+                fastpackwithoutmask8(@in, inpos, @out, outpos);
+                break;
+            case 9:
+                fastpackwithoutmask9(@in, inpos, @out, outpos);
+                break;
+            case 10:
+                fastpackwithoutmask10(@in, inpos, @out, outpos);
+                break;
+            case 11:
+                fastpackwithoutmask11(@in, inpos, @out, outpos);
+                break;
+            case 12:
+                fastpackwithoutmask12(@in, inpos, @out, outpos);
+                break;
+            case 13:
+                fastpackwithoutmask13(@in, inpos, @out, outpos);
+                break;
+            case 14:
+                fastpackwithoutmask14(@in, inpos, @out, outpos);
+                break;
+            case 15:
+                fastpackwithoutmask15(@in, inpos, @out, outpos);
+                break;
+            case 16:
+                fastpackwithoutmask16(@in, inpos, @out, outpos);
+                break;
+            case 17:
+                fastpackwithoutmask17(@in, inpos, @out, outpos);
+                break;
+            case 18:
+                fastpackwithoutmask18(@in, inpos, @out, outpos);
+                break;
+            case 19:
+                fastpackwithoutmask19(@in, inpos, @out, outpos);
+                break;
+            case 20:
+                fastpackwithoutmask20(@in, inpos, @out, outpos);
+                break;
+            case 21:
+                fastpackwithoutmask21(@in, inpos, @out, outpos);
+                break;
+            case 22:
+                fastpackwithoutmask22(@in, inpos, @out, outpos);
+                break;
+            case 23:
+                fastpackwithoutmask23(@in, inpos, @out, outpos);
+                break;
+            case 24:
+                fastpackwithoutmask24(@in, inpos, @out, outpos);
+                break;
+            case 25:
+                fastpackwithoutmask25(@in, inpos, @out, outpos);
+                break;
+            case 26:
+                fastpackwithoutmask26(@in, inpos, @out, outpos);
+                break;
+            case 27:
+                fastpackwithoutmask27(@in, inpos, @out, outpos);
+                break;
+            case 28:
+                fastpackwithoutmask28(@in, inpos, @out, outpos);
+                break;
+            case 29:
+                fastpackwithoutmask29(@in, inpos, @out, outpos);
+                break;
+            case 30:
+                fastpackwithoutmask30(@in, inpos, @out, outpos);
+                break;
+            case 31:
+                fastpackwithoutmask31(@in, inpos, @out, outpos);
+                break;
+            case 32:
+                fastpackwithoutmask32(@in, inpos, @out, outpos);
+                break;
+            default:
+                throw new ArgumentException(
+                    "Unsupported bit width.");
+        }
+    }
+
+    protected static void fastpackwithoutmask0(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        // nothing
+    }
+
+    protected static void fastpackwithoutmask1(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 1)
+                           | ((@in[2 + inpos]) << 2) | ((@in[3 + inpos]) << 3)
+                           | ((@in[4 + inpos]) << 4) | ((@in[5 + inpos]) << 5)
+                           | ((@in[6 + inpos]) << 6) | ((@in[7 + inpos]) << 7)
+                           | ((@in[8 + inpos]) << 8) | ((@in[9 + inpos]) << 9)
+                           | ((@in[10 + inpos]) << 10) | ((@in[11 + inpos]) << 11)
+                           | ((@in[12 + inpos]) << 12) | ((@in[13 + inpos]) << 13)
+                           | ((@in[14 + inpos]) << 14) | ((@in[15 + inpos]) << 15)
+                           | ((@in[16 + inpos]) << 16) | ((@in[17 + inpos]) << 17)
+                           | ((@in[18 + inpos]) << 18) | ((@in[19 + inpos]) << 19)
+                           | ((@in[20 + inpos]) << 20) | ((@in[21 + inpos]) << 21)
+                           | ((@in[22 + inpos]) << 22) | ((@in[23 + inpos]) << 23)
+                           | ((@in[24 + inpos]) << 24) | ((@in[25 + inpos]) << 25)
+                           | ((@in[26 + inpos]) << 26) | ((@in[27 + inpos]) << 27)
+                           | ((@in[28 + inpos]) << 28) | ((@in[29 + inpos]) << 29)
+                           | ((@in[30 + inpos]) << 30) | ((@in[31 + inpos]) << 31);
+    }
+
+    protected static void fastpackwithoutmask10(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 10)
+                           | ((@in[2 + inpos]) << 20) | ((@in[3 + inpos]) << 30);
+        @out[1 + outpos] = (int)((uint)(@in[3 + inpos]) >> (10 - 8))
+                           | ((@in[4 + inpos]) << 8) | ((@in[5 + inpos]) << 18)
+                           | ((@in[6 + inpos]) << 28);
+        @out[2 + outpos] = (int)((uint)(@in[6 + inpos]) >> (10 - 6))
+                           | ((@in[7 + inpos]) << 6) | ((@in[8 + inpos]) << 16)
+                           | ((@in[9 + inpos]) << 26);
+        @out[3 + outpos] = (int)((uint)(@in[9 + inpos]) >> (10 - 4))
+                           | ((@in[10 + inpos]) << 4) | ((@in[11 + inpos]) << 14)
+                           | ((@in[12 + inpos]) << 24);
+        @out[4 + outpos] = (int)((uint)(@in[12 + inpos]) >> (10 - 2))
+                           | ((@in[13 + inpos]) << 2) | ((@in[14 + inpos]) << 12)
+                           | ((@in[15 + inpos]) << 22);
+        @out[5 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 10)
+                           | ((@in[18 + inpos]) << 20) | ((@in[19 + inpos]) << 30);
+        @out[6 + outpos] = (int)((uint)(@in[19 + inpos]) >> (10 - 8))
+                           | ((@in[20 + inpos]) << 8) | ((@in[21 + inpos]) << 18)
+                           | ((@in[22 + inpos]) << 28);
+        @out[7 + outpos] = (int)((uint)(@in[22 + inpos]) >> (10 - 6))
+                           | ((@in[23 + inpos]) << 6) | ((@in[24 + inpos]) << 16)
+                           | ((@in[25 + inpos]) << 26);
+        @out[8 + outpos] = (int)((uint)(@in[25 + inpos]) >> (10 - 4))
+                           | ((@in[26 + inpos]) << 4) | ((@in[27 + inpos]) << 14)
+                           | ((@in[28 + inpos]) << 24);
+        @out[9 + outpos] = (int)((uint)(@in[28 + inpos]) >> (10 - 2))
+                           | ((@in[29 + inpos]) << 2) | ((@in[30 + inpos]) << 12)
+                           | ((@in[31 + inpos]) << 22);
+    }
+
+    protected static void fastpackwithoutmask11(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 11)
+                           | ((@in[2 + inpos]) << 22);
+        @out[1 + outpos] = (int)((uint)(@in[2 + inpos]) >> (11 - 1))
+                           | ((@in[3 + inpos]) << 1) | ((@in[4 + inpos]) << 12)
+                           | ((@in[5 + inpos]) << 23);
+        @out[2 + outpos] = (int)((uint)(@in[5 + inpos]) >> (11 - 2))
+                           | ((@in[6 + inpos]) << 2) | ((@in[7 + inpos]) << 13)
+                           | ((@in[8 + inpos]) << 24);
+        @out[3 + outpos] = (int)((uint)(@in[8 + inpos]) >> (11 - 3))
+                           | ((@in[9 + inpos]) << 3) | ((@in[10 + inpos]) << 14)
+                           | ((@in[11 + inpos]) << 25);
+        @out[4 + outpos] = (int)((uint)(@in[11 + inpos]) >> (11 - 4))
+                           | ((@in[12 + inpos]) << 4) | ((@in[13 + inpos]) << 15)
+                           | ((@in[14 + inpos]) << 26);
+        @out[5 + outpos] = (int)((uint)(@in[14 + inpos]) >> (11 - 5))
+                           | ((@in[15 + inpos]) << 5) | ((@in[16 + inpos]) << 16)
+                           | ((@in[17 + inpos]) << 27);
+        @out[6 + outpos] = (int)((uint)(@in[17 + inpos]) >> (11 - 6))
+                           | ((@in[18 + inpos]) << 6) | ((@in[19 + inpos]) << 17)
+                           | ((@in[20 + inpos]) << 28);
+        @out[7 + outpos] = (int)((uint)(@in[20 + inpos]) >> (11 - 7))
+                           | ((@in[21 + inpos]) << 7) | ((@in[22 + inpos]) << 18)
+                           | ((@in[23 + inpos]) << 29);
+        @out[8 + outpos] = (int)((uint)(@in[23 + inpos]) >> (11 - 8))
+                           | ((@in[24 + inpos]) << 8) | ((@in[25 + inpos]) << 19)
+                           | ((@in[26 + inpos]) << 30);
+        @out[9 + outpos] = (int)((uint)(@in[26 + inpos]) >> (11 - 9))
+                           | ((@in[27 + inpos]) << 9) | ((@in[28 + inpos]) << 20)
+                           | ((@in[29 + inpos]) << 31);
+        @out[10 + outpos] = (int)((uint)(@in[29 + inpos]) >> (11 - 10))
+                            | ((@in[30 + inpos]) << 10) | ((@in[31 + inpos]) << 21);
+    }
+
+    protected static void fastpackwithoutmask12(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 12)
+                           | ((@in[2 + inpos]) << 24);
+        @out[1 + outpos] = (int)((uint)(@in[2 + inpos]) >> (12 - 4))
+                           | ((@in[3 + inpos]) << 4) | ((@in[4 + inpos]) << 16)
+                           | ((@in[5 + inpos]) << 28);
+        @out[2 + outpos] = (int)((uint)(@in[5 + inpos]) >> (12 - 8))
+                           | ((@in[6 + inpos]) << 8) | ((@in[7 + inpos]) << 20);
+        @out[3 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 12)
+                           | ((@in[10 + inpos]) << 24);
+        @out[4 + outpos] = (int)((uint)(@in[10 + inpos]) >> (12 - 4))
+                           | ((@in[11 + inpos]) << 4) | ((@in[12 + inpos]) << 16)
+                           | ((@in[13 + inpos]) << 28);
+        @out[5 + outpos] = (int)((uint)(@in[13 + inpos]) >> (12 - 8))
+                           | ((@in[14 + inpos]) << 8) | ((@in[15 + inpos]) << 20);
+        @out[6 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 12)
+                           | ((@in[18 + inpos]) << 24);
+        @out[7 + outpos] = (int)((uint)(@in[18 + inpos]) >> (12 - 4))
+                           | ((@in[19 + inpos]) << 4) | ((@in[20 + inpos]) << 16)
+                           | ((@in[21 + inpos]) << 28);
+        @out[8 + outpos] = (int)((uint)(@in[21 + inpos]) >> (12 - 8))
+                           | ((@in[22 + inpos]) << 8) | ((@in[23 + inpos]) << 20);
+        @out[9 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 12)
+                           | ((@in[26 + inpos]) << 24);
+        @out[10 + outpos] = (int)((uint)(@in[26 + inpos]) >> (12 - 4))
+                            | ((@in[27 + inpos]) << 4) | ((@in[28 + inpos]) << 16)
+                            | ((@in[29 + inpos]) << 28);
+        @out[11 + outpos] = (int)((uint)(@in[29 + inpos]) >> (12 - 8))
+                            | ((@in[30 + inpos]) << 8) | ((@in[31 + inpos]) << 20);
+    }
+
+    protected static void fastpackwithoutmask13(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 13)
+                           | ((@in[2 + inpos]) << 26);
+        @out[1 + outpos] = (int)((uint)(@in[2 + inpos]) >> (13 - 7))
+                           | ((@in[3 + inpos]) << 7) | ((@in[4 + inpos]) << 20);
+        @out[2 + outpos] = (int)((uint)(@in[4 + inpos]) >> (13 - 1))
+                           | ((@in[5 + inpos]) << 1) | ((@in[6 + inpos]) << 14)
+                           | ((@in[7 + inpos]) << 27);
+        @out[3 + outpos] = (int)((uint)(@in[7 + inpos]) >> (13 - 8))
+                           | ((@in[8 + inpos]) << 8) | ((@in[9 + inpos]) << 21);
+        @out[4 + outpos] = (int)((uint)(@in[9 + inpos]) >> (13 - 2))
+                           | ((@in[10 + inpos]) << 2) | ((@in[11 + inpos]) << 15)
+                           | ((@in[12 + inpos]) << 28);
+        @out[5 + outpos] = (int)((uint)(@in[12 + inpos]) >> (13 - 9))
+                           | ((@in[13 + inpos]) << 9) | ((@in[14 + inpos]) << 22);
+        @out[6 + outpos] = (int)((uint)(@in[14 + inpos]) >> (13 - 3))
+                           | ((@in[15 + inpos]) << 3) | ((@in[16 + inpos]) << 16)
+                           | ((@in[17 + inpos]) << 29);
+        @out[7 + outpos] = (int)((uint)(@in[17 + inpos]) >> (13 - 10))
+                           | ((@in[18 + inpos]) << 10) | ((@in[19 + inpos]) << 23);
+        @out[8 + outpos] = (int)((uint)(@in[19 + inpos]) >> (13 - 4))
+                           | ((@in[20 + inpos]) << 4) | ((@in[21 + inpos]) << 17)
+                           | ((@in[22 + inpos]) << 30);
+        @out[9 + outpos] = (int)((uint)(@in[22 + inpos]) >> (13 - 11))
+                           | ((@in[23 + inpos]) << 11) | ((@in[24 + inpos]) << 24);
+        @out[10 + outpos] = (int)((uint)(@in[24 + inpos]) >> (13 - 5))
+                            | ((@in[25 + inpos]) << 5) | ((@in[26 + inpos]) << 18)
+                            | ((@in[27 + inpos]) << 31);
+        @out[11 + outpos] = (int)((uint)(@in[27 + inpos]) >> (13 - 12))
+                            | ((@in[28 + inpos]) << 12) | ((@in[29 + inpos]) << 25);
+        @out[12 + outpos] = (int)((uint)(@in[29 + inpos]) >> (13 - 6))
+                            | ((@in[30 + inpos]) << 6) | ((@in[31 + inpos]) << 19);
+    }
+
+    protected static void fastpackwithoutmask14(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 14)
+                           | ((@in[2 + inpos]) << 28);
+        @out[1 + outpos] = (int)((uint)(@in[2 + inpos]) >> (14 - 10))
+                           | ((@in[3 + inpos]) << 10) | ((@in[4 + inpos]) << 24);
+        @out[2 + outpos] = (int)((uint)(@in[4 + inpos]) >> (14 - 6))
+                           | ((@in[5 + inpos]) << 6) | ((@in[6 + inpos]) << 20);
+        @out[3 + outpos] = (int)((uint)(@in[6 + inpos]) >> (14 - 2))
+                           | ((@in[7 + inpos]) << 2) | ((@in[8 + inpos]) << 16)
+                           | ((@in[9 + inpos]) << 30);
+        @out[4 + outpos] = (int)((uint)(@in[9 + inpos]) >> (14 - 12))
+                           | ((@in[10 + inpos]) << 12) | ((@in[11 + inpos]) << 26);
+        @out[5 + outpos] = (int)((uint)(@in[11 + inpos]) >> (14 - 8))
+                           | ((@in[12 + inpos]) << 8) | ((@in[13 + inpos]) << 22);
+        @out[6 + outpos] = (int)((uint)(@in[13 + inpos]) >> (14 - 4))
+                           | ((@in[14 + inpos]) << 4) | ((@in[15 + inpos]) << 18);
+        @out[7 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 14)
+                           | ((@in[18 + inpos]) << 28);
+        @out[8 + outpos] = (int)((uint)(@in[18 + inpos]) >> (14 - 10))
+                           | ((@in[19 + inpos]) << 10) | ((@in[20 + inpos]) << 24);
+        @out[9 + outpos] = (int)((uint)(@in[20 + inpos]) >> (14 - 6))
+                           | ((@in[21 + inpos]) << 6) | ((@in[22 + inpos]) << 20);
+        @out[10 + outpos] = (int)((uint)(@in[22 + inpos]) >> (14 - 2))
+                            | ((@in[23 + inpos]) << 2) | ((@in[24 + inpos]) << 16)
+                            | ((@in[25 + inpos]) << 30);
+        @out[11 + outpos] = (int)((uint)(@in[25 + inpos]) >> (14 - 12))
+                            | ((@in[26 + inpos]) << 12) | ((@in[27 + inpos]) << 26);
+        @out[12 + outpos] = (int)((uint)(@in[27 + inpos]) >> (14 - 8))
+                            | ((@in[28 + inpos]) << 8) | ((@in[29 + inpos]) << 22);
+        @out[13 + outpos] = (int)((uint)(@in[29 + inpos]) >> (14 - 4))
+                            | ((@in[30 + inpos]) << 4) | ((@in[31 + inpos]) << 18);
+    }
+
+    protected static void fastpackwithoutmask15(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 15)
+                           | ((@in[2 + inpos]) << 30);
+        @out[1 + outpos] = (int)((uint)(@in[2 + inpos]) >> (15 - 13))
+                           | ((@in[3 + inpos]) << 13) | ((@in[4 + inpos]) << 28);
+        @out[2 + outpos] = (int)((uint)(@in[4 + inpos]) >> (15 - 11))
+                           | ((@in[5 + inpos]) << 11) | ((@in[6 + inpos]) << 26);
+        @out[3 + outpos] = (int)((uint)(@in[6 + inpos]) >> (15 - 9))
+                           | ((@in[7 + inpos]) << 9) | ((@in[8 + inpos]) << 24);
+        @out[4 + outpos] = (int)((uint)(@in[8 + inpos]) >> (15 - 7))
+                           | ((@in[9 + inpos]) << 7) | ((@in[10 + inpos]) << 22);
+        @out[5 + outpos] = (int)((uint)(@in[10 + inpos]) >> (15 - 5))
+                           | ((@in[11 + inpos]) << 5) | ((@in[12 + inpos]) << 20);
+        @out[6 + outpos] = (int)((uint)(@in[12 + inpos]) >> (15 - 3))
+                           | ((@in[13 + inpos]) << 3) | ((@in[14 + inpos]) << 18);
+        @out[7 + outpos] = (int)((uint)(@in[14 + inpos]) >> (15 - 1))
+                           | ((@in[15 + inpos]) << 1) | ((@in[16 + inpos]) << 16)
+                           | ((@in[17 + inpos]) << 31);
+        @out[8 + outpos] = (int)((uint)(@in[17 + inpos]) >> (15 - 14))
+                           | ((@in[18 + inpos]) << 14) | ((@in[19 + inpos]) << 29);
+        @out[9 + outpos] = (int)((uint)(@in[19 + inpos]) >> (15 - 12))
+                           | ((@in[20 + inpos]) << 12) | ((@in[21 + inpos]) << 27);
+        @out[10 + outpos] = (int)((uint)(@in[21 + inpos]) >> (15 - 10))
+                            | ((@in[22 + inpos]) << 10) | ((@in[23 + inpos]) << 25);
+        @out[11 + outpos] = (int)((uint)(@in[23 + inpos]) >> (15 - 8))
+                            | ((@in[24 + inpos]) << 8) | ((@in[25 + inpos]) << 23);
+        @out[12 + outpos] = (int)((uint)(@in[25 + inpos]) >> (15 - 6))
+                            | ((@in[26 + inpos]) << 6) | ((@in[27 + inpos]) << 21);
+        @out[13 + outpos] = (int)((uint)(@in[27 + inpos]) >> (15 - 4))
+                            | ((@in[28 + inpos]) << 4) | ((@in[29 + inpos]) << 19);
+        @out[14 + outpos] = (int)((uint)(@in[29 + inpos]) >> (15 - 2))
+                            | ((@in[30 + inpos]) << 2) | ((@in[31 + inpos]) << 17);
+    }
+
+    protected static void fastpackwithoutmask16(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 16);
+        @out[1 + outpos] = @in[2 + inpos] | ((@in[3 + inpos]) << 16);
+        @out[2 + outpos] = @in[4 + inpos] | ((@in[5 + inpos]) << 16);
+        @out[3 + outpos] = @in[6 + inpos] | ((@in[7 + inpos]) << 16);
+        @out[4 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 16);
+        @out[5 + outpos] = @in[10 + inpos] | ((@in[11 + inpos]) << 16);
+        @out[6 + outpos] = @in[12 + inpos] | ((@in[13 + inpos]) << 16);
+        @out[7 + outpos] = @in[14 + inpos] | ((@in[15 + inpos]) << 16);
+        @out[8 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 16);
+        @out[9 + outpos] = @in[18 + inpos] | ((@in[19 + inpos]) << 16);
+        @out[10 + outpos] = @in[20 + inpos] | ((@in[21 + inpos]) << 16);
+        @out[11 + outpos] = @in[22 + inpos] | ((@in[23 + inpos]) << 16);
+        @out[12 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 16);
+        @out[13 + outpos] = @in[26 + inpos] | ((@in[27 + inpos]) << 16);
+        @out[14 + outpos] = @in[28 + inpos] | ((@in[29 + inpos]) << 16);
+        @out[15 + outpos] = @in[30 + inpos] | ((@in[31 + inpos]) << 16);
+    }
+
+    protected static void fastpackwithoutmask17(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 17);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (17 - 2))
+                           | ((@in[2 + inpos]) << 2) | ((@in[3 + inpos]) << 19);
+        @out[2 + outpos] = (int)((uint)(@in[3 + inpos]) >> (17 - 4))
+                           | ((@in[4 + inpos]) << 4) | ((@in[5 + inpos]) << 21);
+        @out[3 + outpos] = (int)((uint)(@in[5 + inpos]) >> (17 - 6))
+                           | ((@in[6 + inpos]) << 6) | ((@in[7 + inpos]) << 23);
+        @out[4 + outpos] = (int)((uint)(@in[7 + inpos]) >> (17 - 8))
+                           | ((@in[8 + inpos]) << 8) | ((@in[9 + inpos]) << 25);
+        @out[5 + outpos] = (int)((uint)(@in[9 + inpos]) >> (17 - 10))
+                           | ((@in[10 + inpos]) << 10) | ((@in[11 + inpos]) << 27);
+        @out[6 + outpos] = (int)((uint)(@in[11 + inpos]) >> (17 - 12))
+                           | ((@in[12 + inpos]) << 12) | ((@in[13 + inpos]) << 29);
+        @out[7 + outpos] = (int)((uint)(@in[13 + inpos]) >> (17 - 14))
+                           | ((@in[14 + inpos]) << 14) | ((@in[15 + inpos]) << 31);
+        @out[8 + outpos] = (int)((uint)(@in[15 + inpos]) >> (17 - 16))
+                           | ((@in[16 + inpos]) << 16);
+        @out[9 + outpos] = (int)((uint)(@in[16 + inpos]) >> (17 - 1))
+                           | ((@in[17 + inpos]) << 1) | ((@in[18 + inpos]) << 18);
+        @out[10 + outpos] = (int)((uint)(@in[18 + inpos]) >> (17 - 3))
+                            | ((@in[19 + inpos]) << 3) | ((@in[20 + inpos]) << 20);
+        @out[11 + outpos] = (int)((uint)(@in[20 + inpos]) >> (17 - 5))
+                            | ((@in[21 + inpos]) << 5) | ((@in[22 + inpos]) << 22);
+        @out[12 + outpos] = (int)((uint)(@in[22 + inpos]) >> (17 - 7))
+                            | ((@in[23 + inpos]) << 7) | ((@in[24 + inpos]) << 24);
+        @out[13 + outpos] = (int)((uint)(@in[24 + inpos]) >> (17 - 9))
+                            | ((@in[25 + inpos]) << 9) | ((@in[26 + inpos]) << 26);
+        @out[14 + outpos] = (int)((uint)(@in[26 + inpos]) >> (17 - 11))
+                            | ((@in[27 + inpos]) << 11) | ((@in[28 + inpos]) << 28);
+        @out[15 + outpos] = (int)((uint)(@in[28 + inpos]) >> (17 - 13))
+                            | ((@in[29 + inpos]) << 13) | ((@in[30 + inpos]) << 30);
+        @out[16 + outpos] = (int)((uint)(@in[30 + inpos]) >> (17 - 15))
+                            | ((@in[31 + inpos]) << 15);
+    }
+
+    protected static void fastpackwithoutmask18(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 18);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (18 - 4))
+                           | ((@in[2 + inpos]) << 4) | ((@in[3 + inpos]) << 22);
+        @out[2 + outpos] = (int)((uint)(@in[3 + inpos]) >> (18 - 8))
+                           | ((@in[4 + inpos]) << 8) | ((@in[5 + inpos]) << 26);
+        @out[3 + outpos] = (int)((uint)(@in[5 + inpos]) >> (18 - 12))
+                           | ((@in[6 + inpos]) << 12) | ((@in[7 + inpos]) << 30);
+        @out[4 + outpos] = (int)((uint)(@in[7 + inpos]) >> (18 - 16))
+                           | ((@in[8 + inpos]) << 16);
+        @out[5 + outpos] = (int)((uint)(@in[8 + inpos]) >> (18 - 2))
+                           | ((@in[9 + inpos]) << 2) | ((@in[10 + inpos]) << 20);
+        @out[6 + outpos] = (int)((uint)(@in[10 + inpos]) >> (18 - 6))
+                           | ((@in[11 + inpos]) << 6) | ((@in[12 + inpos]) << 24);
+        @out[7 + outpos] = (int)((uint)(@in[12 + inpos]) >> (18 - 10))
+                           | ((@in[13 + inpos]) << 10) | ((@in[14 + inpos]) << 28);
+        @out[8 + outpos] = (int)((uint)(@in[14 + inpos]) >> (18 - 14))
+                           | ((@in[15 + inpos]) << 14);
+        @out[9 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 18);
+        @out[10 + outpos] = (int)((uint)(@in[17 + inpos]) >> (18 - 4))
+                            | ((@in[18 + inpos]) << 4) | ((@in[19 + inpos]) << 22);
+        @out[11 + outpos] = (int)((uint)(@in[19 + inpos]) >> (18 - 8))
+                            | ((@in[20 + inpos]) << 8) | ((@in[21 + inpos]) << 26);
+        @out[12 + outpos] = (int)((uint)(@in[21 + inpos]) >> (18 - 12))
+                            | ((@in[22 + inpos]) << 12) | ((@in[23 + inpos]) << 30);
+        @out[13 + outpos] = (int)((uint)(@in[23 + inpos]) >> (18 - 16))
+                            | ((@in[24 + inpos]) << 16);
+        @out[14 + outpos] = (int)((uint)(@in[24 + inpos]) >> (18 - 2))
+                            | ((@in[25 + inpos]) << 2) | ((@in[26 + inpos]) << 20);
+        @out[15 + outpos] = (int)((uint)(@in[26 + inpos]) >> (18 - 6))
+                            | ((@in[27 + inpos]) << 6) | ((@in[28 + inpos]) << 24);
+        @out[16 + outpos] = (int)((uint)(@in[28 + inpos]) >> (18 - 10))
+                            | ((@in[29 + inpos]) << 10) | ((@in[30 + inpos]) << 28);
+        @out[17 + outpos] = (int)((uint)(@in[30 + inpos]) >> (18 - 14))
+                            | ((@in[31 + inpos]) << 14);
+    }
+
+    protected static void fastpackwithoutmask19(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 19);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (19 - 6))
+                           | ((@in[2 + inpos]) << 6) | ((@in[3 + inpos]) << 25);
+        @out[2 + outpos] = (int)((uint)(@in[3 + inpos]) >> (19 - 12))
+                           | ((@in[4 + inpos]) << 12) | ((@in[5 + inpos]) << 31);
+        @out[3 + outpos] = (int)((uint)(@in[5 + inpos]) >> (19 - 18))
+                           | ((@in[6 + inpos]) << 18);
+        @out[4 + outpos] = (int)((uint)(@in[6 + inpos]) >> (19 - 5))
+                           | ((@in[7 + inpos]) << 5) | ((@in[8 + inpos]) << 24);
+        @out[5 + outpos] = (int)((uint)(@in[8 + inpos]) >> (19 - 11))
+                           | ((@in[9 + inpos]) << 11) | ((@in[10 + inpos]) << 30);
+        @out[6 + outpos] = (int)((uint)(@in[10 + inpos]) >> (19 - 17))
+                           | ((@in[11 + inpos]) << 17);
+        @out[7 + outpos] = (int)((uint)(@in[11 + inpos]) >> (19 - 4))
+                           | ((@in[12 + inpos]) << 4) | ((@in[13 + inpos]) << 23);
+        @out[8 + outpos] = (int)((uint)(@in[13 + inpos]) >> (19 - 10))
+                           | ((@in[14 + inpos]) << 10) | ((@in[15 + inpos]) << 29);
+        @out[9 + outpos] = (int)((uint)(@in[15 + inpos]) >> (19 - 16))
+                           | ((@in[16 + inpos]) << 16);
+        @out[10 + outpos] = (int)((uint)(@in[16 + inpos]) >> (19 - 3))
+                            | ((@in[17 + inpos]) << 3) | ((@in[18 + inpos]) << 22);
+        @out[11 + outpos] = (int)((uint)(@in[18 + inpos]) >> (19 - 9))
+                            | ((@in[19 + inpos]) << 9) | ((@in[20 + inpos]) << 28);
+        @out[12 + outpos] = (int)((uint)(@in[20 + inpos]) >> (19 - 15))
+                            | ((@in[21 + inpos]) << 15);
+        @out[13 + outpos] = (int)((uint)(@in[21 + inpos]) >> (19 - 2))
+                            | ((@in[22 + inpos]) << 2) | ((@in[23 + inpos]) << 21);
+        @out[14 + outpos] = (int)((uint)(@in[23 + inpos]) >> (19 - 8))
+                            | ((@in[24 + inpos]) << 8) | ((@in[25 + inpos]) << 27);
+        @out[15 + outpos] = (int)((uint)(@in[25 + inpos]) >> (19 - 14))
+                            | ((@in[26 + inpos]) << 14);
+        @out[16 + outpos] = (int)((uint)(@in[26 + inpos]) >> (19 - 1))
+                            | ((@in[27 + inpos]) << 1) | ((@in[28 + inpos]) << 20);
+        @out[17 + outpos] = (int)((uint)(@in[28 + inpos]) >> (19 - 7))
+                            | ((@in[29 + inpos]) << 7) | ((@in[30 + inpos]) << 26);
+        @out[18 + outpos] = (int)((uint)(@in[30 + inpos]) >> (19 - 13))
+                            | ((@in[31 + inpos]) << 13);
+    }
+
+    protected static void fastpackwithoutmask2(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 2)
+                           | ((@in[2 + inpos]) << 4) | ((@in[3 + inpos]) << 6)
+                           | ((@in[4 + inpos]) << 8) | ((@in[5 + inpos]) << 10)
+                           | ((@in[6 + inpos]) << 12) | ((@in[7 + inpos]) << 14)
+                           | ((@in[8 + inpos]) << 16) | ((@in[9 + inpos]) << 18)
+                           | ((@in[10 + inpos]) << 20) | ((@in[11 + inpos]) << 22)
+                           | ((@in[12 + inpos]) << 24) | ((@in[13 + inpos]) << 26)
+                           | ((@in[14 + inpos]) << 28) | ((@in[15 + inpos]) << 30);
+        @out[1 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 2)
+                           | ((@in[18 + inpos]) << 4) | ((@in[19 + inpos]) << 6)
+                           | ((@in[20 + inpos]) << 8) | ((@in[21 + inpos]) << 10)
+                           | ((@in[22 + inpos]) << 12) | ((@in[23 + inpos]) << 14)
+                           | ((@in[24 + inpos]) << 16) | ((@in[25 + inpos]) << 18)
+                           | ((@in[26 + inpos]) << 20) | ((@in[27 + inpos]) << 22)
+                           | ((@in[28 + inpos]) << 24) | ((@in[29 + inpos]) << 26)
+                           | ((@in[30 + inpos]) << 28) | ((@in[31 + inpos]) << 30);
+    }
+
+    protected static void fastpackwithoutmask20(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 20);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (20 - 8))
+                           | ((@in[2 + inpos]) << 8) | ((@in[3 + inpos]) << 28);
+        @out[2 + outpos] = (int)((uint)(@in[3 + inpos]) >> (20 - 16))
+                           | ((@in[4 + inpos]) << 16);
+        @out[3 + outpos] = (int)((uint)(@in[4 + inpos]) >> (20 - 4))
+                           | ((@in[5 + inpos]) << 4) | ((@in[6 + inpos]) << 24);
+        @out[4 + outpos] = (int)((uint)(@in[6 + inpos]) >> (20 - 12))
+                           | ((@in[7 + inpos]) << 12);
+        @out[5 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 20);
+        @out[6 + outpos] = (int)((uint)(@in[9 + inpos]) >> (20 - 8))
+                           | ((@in[10 + inpos]) << 8) | ((@in[11 + inpos]) << 28);
+        @out[7 + outpos] = (int)((uint)(@in[11 + inpos]) >> (20 - 16))
+                           | ((@in[12 + inpos]) << 16);
+        @out[8 + outpos] = (int)((uint)(@in[12 + inpos]) >> (20 - 4))
+                           | ((@in[13 + inpos]) << 4) | ((@in[14 + inpos]) << 24);
+        @out[9 + outpos] = (int)((uint)(@in[14 + inpos]) >> (20 - 12))
+                           | ((@in[15 + inpos]) << 12);
+        @out[10 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 20);
+        @out[11 + outpos] = (int)((uint)(@in[17 + inpos]) >> (20 - 8))
+                            | ((@in[18 + inpos]) << 8) | ((@in[19 + inpos]) << 28);
+        @out[12 + outpos] = (int)((uint)(@in[19 + inpos]) >> (20 - 16))
+                            | ((@in[20 + inpos]) << 16);
+        @out[13 + outpos] = (int)((uint)(@in[20 + inpos]) >> (20 - 4))
+                            | ((@in[21 + inpos]) << 4) | ((@in[22 + inpos]) << 24);
+        @out[14 + outpos] = (int)((uint)(@in[22 + inpos]) >> (20 - 12))
+                            | ((@in[23 + inpos]) << 12);
+        @out[15 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 20);
+        @out[16 + outpos] = (int)((uint)(@in[25 + inpos]) >> (20 - 8))
+                            | ((@in[26 + inpos]) << 8) | ((@in[27 + inpos]) << 28);
+        @out[17 + outpos] = (int)((uint)(@in[27 + inpos]) >> (20 - 16))
+                            | ((@in[28 + inpos]) << 16);
+        @out[18 + outpos] = (int)((uint)(@in[28 + inpos]) >> (20 - 4))
+                            | ((@in[29 + inpos]) << 4) | ((@in[30 + inpos]) << 24);
+        @out[19 + outpos] = (int)((uint)(@in[30 + inpos]) >> (20 - 12))
+                            | ((@in[31 + inpos]) << 12);
+    }
+
+    protected static void fastpackwithoutmask21(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 21);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (21 - 10))
+                           | ((@in[2 + inpos]) << 10) | ((@in[3 + inpos]) << 31);
+        @out[2 + outpos] = (int)((uint)(@in[3 + inpos]) >> (21 - 20))
+                           | ((@in[4 + inpos]) << 20);
+        @out[3 + outpos] = (int)((uint)(@in[4 + inpos]) >> (21 - 9))
+                           | ((@in[5 + inpos]) << 9) | ((@in[6 + inpos]) << 30);
+        @out[4 + outpos] = (int)((uint)(@in[6 + inpos]) >> (21 - 19))
+                           | ((@in[7 + inpos]) << 19);
+        @out[5 + outpos] = (int)((uint)(@in[7 + inpos]) >> (21 - 8))
+                           | ((@in[8 + inpos]) << 8) | ((@in[9 + inpos]) << 29);
+        @out[6 + outpos] = (int)((uint)(@in[9 + inpos]) >> (21 - 18))
+                           | ((@in[10 + inpos]) << 18);
+        @out[7 + outpos] = (int)((uint)(@in[10 + inpos]) >> (21 - 7))
+                           | ((@in[11 + inpos]) << 7) | ((@in[12 + inpos]) << 28);
+        @out[8 + outpos] = (int)((uint)(@in[12 + inpos]) >> (21 - 17))
+                           | ((@in[13 + inpos]) << 17);
+        @out[9 + outpos] = (int)((uint)(@in[13 + inpos]) >> (21 - 6))
+                           | ((@in[14 + inpos]) << 6) | ((@in[15 + inpos]) << 27);
+        @out[10 + outpos] = (int)((uint)(@in[15 + inpos]) >> (21 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[11 + outpos] = (int)((uint)(@in[16 + inpos]) >> (21 - 5))
+                            | ((@in[17 + inpos]) << 5) | ((@in[18 + inpos]) << 26);
+        @out[12 + outpos] = (int)((uint)(@in[18 + inpos]) >> (21 - 15))
+                            | ((@in[19 + inpos]) << 15);
+        @out[13 + outpos] = (int)((uint)(@in[19 + inpos]) >> (21 - 4))
+                            | ((@in[20 + inpos]) << 4) | ((@in[21 + inpos]) << 25);
+        @out[14 + outpos] = (int)((uint)(@in[21 + inpos]) >> (21 - 14))
+                            | ((@in[22 + inpos]) << 14);
+        @out[15 + outpos] = (int)((uint)(@in[22 + inpos]) >> (21 - 3))
+                            | ((@in[23 + inpos]) << 3) | ((@in[24 + inpos]) << 24);
+        @out[16 + outpos] = (int)((uint)(@in[24 + inpos]) >> (21 - 13))
+                            | ((@in[25 + inpos]) << 13);
+        @out[17 + outpos] = (int)((uint)(@in[25 + inpos]) >> (21 - 2))
+                            | ((@in[26 + inpos]) << 2) | ((@in[27 + inpos]) << 23);
+        @out[18 + outpos] = (int)((uint)(@in[27 + inpos]) >> (21 - 12))
+                            | ((@in[28 + inpos]) << 12);
+        @out[19 + outpos] = (int)((uint)(@in[28 + inpos]) >> (21 - 1))
+                            | ((@in[29 + inpos]) << 1) | ((@in[30 + inpos]) << 22);
+        @out[20 + outpos] = (int)((uint)(@in[30 + inpos]) >> (21 - 11))
+                            | ((@in[31 + inpos]) << 11);
+    }
+
+    protected static void fastpackwithoutmask22(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 22);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (22 - 12))
+                           | ((@in[2 + inpos]) << 12);
+        @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (22 - 2))
+                           | ((@in[3 + inpos]) << 2) | ((@in[4 + inpos]) << 24);
+        @out[3 + outpos] = (int)((uint)(@in[4 + inpos]) >> (22 - 14))
+                           | ((@in[5 + inpos]) << 14);
+        @out[4 + outpos] = (int)((uint)(@in[5 + inpos]) >> (22 - 4))
+                           | ((@in[6 + inpos]) << 4) | ((@in[7 + inpos]) << 26);
+        @out[5 + outpos] = (int)((uint)(@in[7 + inpos]) >> (22 - 16))
+                           | ((@in[8 + inpos]) << 16);
+        @out[6 + outpos] = (int)((uint)(@in[8 + inpos]) >> (22 - 6))
+                           | ((@in[9 + inpos]) << 6) | ((@in[10 + inpos]) << 28);
+        @out[7 + outpos] = (int)((uint)(@in[10 + inpos]) >> (22 - 18))
+                           | ((@in[11 + inpos]) << 18);
+        @out[8 + outpos] = (int)((uint)(@in[11 + inpos]) >> (22 - 8))
+                           | ((@in[12 + inpos]) << 8) | ((@in[13 + inpos]) << 30);
+        @out[9 + outpos] = (int)((uint)(@in[13 + inpos]) >> (22 - 20))
+                           | ((@in[14 + inpos]) << 20);
+        @out[10 + outpos] = (int)((uint)(@in[14 + inpos]) >> (22 - 10))
+                            | ((@in[15 + inpos]) << 10);
+        @out[11 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 22);
+        @out[12 + outpos] = (int)((uint)(@in[17 + inpos]) >> (22 - 12))
+                            | ((@in[18 + inpos]) << 12);
+        @out[13 + outpos] = (int)((uint)(@in[18 + inpos]) >> (22 - 2))
+                            | ((@in[19 + inpos]) << 2) | ((@in[20 + inpos]) << 24);
+        @out[14 + outpos] = (int)((uint)(@in[20 + inpos]) >> (22 - 14))
+                            | ((@in[21 + inpos]) << 14);
+        @out[15 + outpos] = (int)((uint)(@in[21 + inpos]) >> (22 - 4))
+                            | ((@in[22 + inpos]) << 4) | ((@in[23 + inpos]) << 26);
+        @out[16 + outpos] = (int)((uint)(@in[23 + inpos]) >> (22 - 16))
+                            | ((@in[24 + inpos]) << 16);
+        @out[17 + outpos] = (int)((uint)(@in[24 + inpos]) >> (22 - 6))
+                            | ((@in[25 + inpos]) << 6) | ((@in[26 + inpos]) << 28);
+        @out[18 + outpos] = (int)((uint)(@in[26 + inpos]) >> (22 - 18))
+                            | ((@in[27 + inpos]) << 18);
+        @out[19 + outpos] = (int)((uint)(@in[27 + inpos]) >> (22 - 8))
+                            | ((@in[28 + inpos]) << 8) | ((@in[29 + inpos]) << 30);
+        @out[20 + outpos] = (int)((uint)(@in[29 + inpos]) >> (22 - 20))
+                            | ((@in[30 + inpos]) << 20);
+        @out[21 + outpos] = (int)((uint)(@in[30 + inpos]) >> (22 - 10))
+                            | ((@in[31 + inpos]) << 10);
+    }
+
+    protected static void fastpackwithoutmask23(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 23);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (23 - 14))
+                           | ((@in[2 + inpos]) << 14);
+        @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (23 - 5))
+                           | ((@in[3 + inpos]) << 5) | ((@in[4 + inpos]) << 28);
+        @out[3 + outpos] = (int)((uint)(@in[4 + inpos]) >> (23 - 19))
+                           | ((@in[5 + inpos]) << 19);
+        @out[4 + outpos] = (int)((uint)(@in[5 + inpos]) >> (23 - 10))
+                           | ((@in[6 + inpos]) << 10);
+        @out[5 + outpos] = (int)((uint)(@in[6 + inpos]) >> (23 - 1))
+                           | ((@in[7 + inpos]) << 1) | ((@in[8 + inpos]) << 24);
+        @out[6 + outpos] = (int)((uint)(@in[8 + inpos]) >> (23 - 15))
+                           | ((@in[9 + inpos]) << 15);
+        @out[7 + outpos] = (int)((uint)(@in[9 + inpos]) >> (23 - 6))
+                           | ((@in[10 + inpos]) << 6) | ((@in[11 + inpos]) << 29);
+        @out[8 + outpos] = (int)((uint)(@in[11 + inpos]) >> (23 - 20))
+                           | ((@in[12 + inpos]) << 20);
+        @out[9 + outpos] = (int)((uint)(@in[12 + inpos]) >> (23 - 11))
+                           | ((@in[13 + inpos]) << 11);
+        @out[10 + outpos] = (int)((uint)(@in[13 + inpos]) >> (23 - 2))
+                            | ((@in[14 + inpos]) << 2) | ((@in[15 + inpos]) << 25);
+        @out[11 + outpos] = (int)((uint)(@in[15 + inpos]) >> (23 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[12 + outpos] = (int)((uint)(@in[16 + inpos]) >> (23 - 7))
+                            | ((@in[17 + inpos]) << 7) | ((@in[18 + inpos]) << 30);
+        @out[13 + outpos] = (int)((uint)(@in[18 + inpos]) >> (23 - 21))
+                            | ((@in[19 + inpos]) << 21);
+        @out[14 + outpos] = (int)((uint)(@in[19 + inpos]) >> (23 - 12))
+                            | ((@in[20 + inpos]) << 12);
+        @out[15 + outpos] = (int)((uint)(@in[20 + inpos]) >> (23 - 3))
+                            | ((@in[21 + inpos]) << 3) | ((@in[22 + inpos]) << 26);
+        @out[16 + outpos] = (int)((uint)(@in[22 + inpos]) >> (23 - 17))
+                            | ((@in[23 + inpos]) << 17);
+        @out[17 + outpos] = (int)((uint)(@in[23 + inpos]) >> (23 - 8))
+                            | ((@in[24 + inpos]) << 8) | ((@in[25 + inpos]) << 31);
+        @out[18 + outpos] = (int)((uint)(@in[25 + inpos]) >> (23 - 22))
+                            | ((@in[26 + inpos]) << 22);
+        @out[19 + outpos] = (int)((uint)(@in[26 + inpos]) >> (23 - 13))
+                            | ((@in[27 + inpos]) << 13);
+        @out[20 + outpos] = (int)((uint)(@in[27 + inpos]) >> (23 - 4))
+                            | ((@in[28 + inpos]) << 4) | ((@in[29 + inpos]) << 27);
+        @out[21 + outpos] = (int)((uint)(@in[29 + inpos]) >> (23 - 18))
+                            | ((@in[30 + inpos]) << 18);
+        @out[22 + outpos] = (int)((uint)(@in[30 + inpos]) >> (23 - 9))
+                            | ((@in[31 + inpos]) << 9);
+    }
+
+    protected static void fastpackwithoutmask24(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 24);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (24 - 16))
+                           | ((@in[2 + inpos]) << 16);
+        @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (24 - 8))
+                           | ((@in[3 + inpos]) << 8);
+        @out[3 + outpos] = @in[4 + inpos] | ((@in[5 + inpos]) << 24);
+        @out[4 + outpos] = (int)((uint)(@in[5 + inpos]) >> (24 - 16))
+                           | ((@in[6 + inpos]) << 16);
+        @out[5 + outpos] = (int)((uint)(@in[6 + inpos]) >> (24 - 8))
+                           | ((@in[7 + inpos]) << 8);
+        @out[6 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 24);
+        @out[7 + outpos] = (int)((uint)(@in[9 + inpos]) >> (24 - 16))
+                           | ((@in[10 + inpos]) << 16);
+        @out[8 + outpos] = (int)((uint)(@in[10 + inpos]) >> (24 - 8))
+                           | ((@in[11 + inpos]) << 8);
+        @out[9 + outpos] = @in[12 + inpos] | ((@in[13 + inpos]) << 24);
+        @out[10 + outpos] = (int)((uint)(@in[13 + inpos]) >> (24 - 16))
+                            | ((@in[14 + inpos]) << 16);
+        @out[11 + outpos] = (int)((uint)(@in[14 + inpos]) >> (24 - 8))
+                            | ((@in[15 + inpos]) << 8);
+        @out[12 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 24);
+        @out[13 + outpos] = (int)((uint)(@in[17 + inpos]) >> (24 - 16))
+                            | ((@in[18 + inpos]) << 16);
+        @out[14 + outpos] = (int)((uint)(@in[18 + inpos]) >> (24 - 8))
+                            | ((@in[19 + inpos]) << 8);
+        @out[15 + outpos] = @in[20 + inpos] | ((@in[21 + inpos]) << 24);
+        @out[16 + outpos] = (int)((uint)(@in[21 + inpos]) >> (24 - 16))
+                            | ((@in[22 + inpos]) << 16);
+        @out[17 + outpos] = (int)((uint)(@in[22 + inpos]) >> (24 - 8))
+                            | ((@in[23 + inpos]) << 8);
+        @out[18 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 24);
+        @out[19 + outpos] = (int)((uint)(@in[25 + inpos]) >> (24 - 16))
+                            | ((@in[26 + inpos]) << 16);
+        @out[20 + outpos] = (int)((uint)(@in[26 + inpos]) >> (24 - 8))
+                            | ((@in[27 + inpos]) << 8);
+        @out[21 + outpos] = @in[28 + inpos] | ((@in[29 + inpos]) << 24);
+        @out[22 + outpos] = (int)((uint)(@in[29 + inpos]) >> (24 - 16))
+                            | ((@in[30 + inpos]) << 16);
+        @out[23 + outpos] = (int)((uint)(@in[30 + inpos]) >> (24 - 8))
+                            | ((@in[31 + inpos]) << 8);
+    }
+
+    protected static void fastpackwithoutmask25(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 25);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (25 - 18))
+                           | ((@in[2 + inpos]) << 18);
+        @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (25 - 11))
+                           | ((@in[3 + inpos]) << 11);
+        @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (25 - 4))
+                           | ((@in[4 + inpos]) << 4) | ((@in[5 + inpos]) << 29);
+        @out[4 + outpos] = (int)((uint)(@in[5 + inpos]) >> (25 - 22))
+                           | ((@in[6 + inpos]) << 22);
+        @out[5 + outpos] = (int)((uint)(@in[6 + inpos]) >> (25 - 15))
+                           | ((@in[7 + inpos]) << 15);
+        @out[6 + outpos] = (int)((uint)(@in[7 + inpos]) >> (25 - 8))
+                           | ((@in[8 + inpos]) << 8);
+        @out[7 + outpos] = (int)((uint)(@in[8 + inpos]) >> (25 - 1))
+                           | ((@in[9 + inpos]) << 1) | ((@in[10 + inpos]) << 26);
+        @out[8 + outpos] = (int)((uint)(@in[10 + inpos]) >> (25 - 19))
+                           | ((@in[11 + inpos]) << 19);
+        @out[9 + outpos] = (int)((uint)(@in[11 + inpos]) >> (25 - 12))
+                           | ((@in[12 + inpos]) << 12);
+        @out[10 + outpos] = (int)((uint)(@in[12 + inpos]) >> (25 - 5))
+                            | ((@in[13 + inpos]) << 5) | ((@in[14 + inpos]) << 30);
+        @out[11 + outpos] = (int)((uint)(@in[14 + inpos]) >> (25 - 23))
+                            | ((@in[15 + inpos]) << 23);
+        @out[12 + outpos] = (int)((uint)(@in[15 + inpos]) >> (25 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[13 + outpos] = (int)((uint)(@in[16 + inpos]) >> (25 - 9))
+                            | ((@in[17 + inpos]) << 9);
+        @out[14 + outpos] = (int)((uint)(@in[17 + inpos]) >> (25 - 2))
+                            | ((@in[18 + inpos]) << 2) | ((@in[19 + inpos]) << 27);
+        @out[15 + outpos] = (int)((uint)(@in[19 + inpos]) >> (25 - 20))
+                            | ((@in[20 + inpos]) << 20);
+        @out[16 + outpos] = (int)((uint)(@in[20 + inpos]) >> (25 - 13))
+                            | ((@in[21 + inpos]) << 13);
+        @out[17 + outpos] = (int)((uint)(@in[21 + inpos]) >> (25 - 6))
+                            | ((@in[22 + inpos]) << 6) | ((@in[23 + inpos]) << 31);
+        @out[18 + outpos] = (int)((uint)(@in[23 + inpos]) >> (25 - 24))
+                            | ((@in[24 + inpos]) << 24);
+        @out[19 + outpos] = (int)((uint)(@in[24 + inpos]) >> (25 - 17))
+                            | ((@in[25 + inpos]) << 17);
+        @out[20 + outpos] = (int)((uint)(@in[25 + inpos]) >> (25 - 10))
+                            | ((@in[26 + inpos]) << 10);
+        @out[21 + outpos] = (int)((uint)(@in[26 + inpos]) >> (25 - 3))
+                            | ((@in[27 + inpos]) << 3) | ((@in[28 + inpos]) << 28);
+        @out[22 + outpos] = (int)((uint)(@in[28 + inpos]) >> (25 - 21))
+                            | ((@in[29 + inpos]) << 21);
+        @out[23 + outpos] = (int)((uint)(@in[29 + inpos]) >> (25 - 14))
+                            | ((@in[30 + inpos]) << 14);
+        @out[24 + outpos] = (int)((uint)(@in[30 + inpos]) >> (25 - 7))
+                            | ((@in[31 + inpos]) << 7);
+    }
+
+    protected static void fastpackwithoutmask26(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 26);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (26 - 20))
+                           | ((@in[2 + inpos]) << 20);
+        @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (26 - 14))
+                           | ((@in[3 + inpos]) << 14);
+        @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (26 - 8))
+                           | ((@in[4 + inpos]) << 8);
+        @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (26 - 2))
+                           | ((@in[5 + inpos]) << 2) | ((@in[6 + inpos]) << 28);
+        @out[5 + outpos] = (int)((uint)(@in[6 + inpos]) >> (26 - 22))
+                           | ((@in[7 + inpos]) << 22);
+        @out[6 + outpos] = (int)((uint)(@in[7 + inpos]) >> (26 - 16))
+                           | ((@in[8 + inpos]) << 16);
+        @out[7 + outpos] = (int)((uint)(@in[8 + inpos]) >> (26 - 10))
+                           | ((@in[9 + inpos]) << 10);
+        @out[8 + outpos] = (int)((uint)(@in[9 + inpos]) >> (26 - 4))
+                           | ((@in[10 + inpos]) << 4) | ((@in[11 + inpos]) << 30);
+        @out[9 + outpos] = (int)((uint)(@in[11 + inpos]) >> (26 - 24))
+                           | ((@in[12 + inpos]) << 24);
+        @out[10 + outpos] = (int)((uint)(@in[12 + inpos]) >> (26 - 18))
+                            | ((@in[13 + inpos]) << 18);
+        @out[11 + outpos] = (int)((uint)(@in[13 + inpos]) >> (26 - 12))
+                            | ((@in[14 + inpos]) << 12);
+        @out[12 + outpos] = (int)((uint)(@in[14 + inpos]) >> (26 - 6))
+                            | ((@in[15 + inpos]) << 6);
+        @out[13 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 26);
+        @out[14 + outpos] = (int)((uint)(@in[17 + inpos]) >> (26 - 20))
+                            | ((@in[18 + inpos]) << 20);
+        @out[15 + outpos] = (int)((uint)(@in[18 + inpos]) >> (26 - 14))
+                            | ((@in[19 + inpos]) << 14);
+        @out[16 + outpos] = (int)((uint)(@in[19 + inpos]) >> (26 - 8))
+                            | ((@in[20 + inpos]) << 8);
+        @out[17 + outpos] = (int)((uint)(@in[20 + inpos]) >> (26 - 2))
+                            | ((@in[21 + inpos]) << 2) | ((@in[22 + inpos]) << 28);
+        @out[18 + outpos] = (int)((uint)(@in[22 + inpos]) >> (26 - 22))
+                            | ((@in[23 + inpos]) << 22);
+        @out[19 + outpos] = (int)((uint)(@in[23 + inpos]) >> (26 - 16))
+                            | ((@in[24 + inpos]) << 16);
+        @out[20 + outpos] = (int)((uint)(@in[24 + inpos]) >> (26 - 10))
+                            | ((@in[25 + inpos]) << 10);
+        @out[21 + outpos] = (int)((uint)(@in[25 + inpos]) >> (26 - 4))
+                            | ((@in[26 + inpos]) << 4) | ((@in[27 + inpos]) << 30);
+        @out[22 + outpos] = (int)((uint)(@in[27 + inpos]) >> (26 - 24))
+                            | ((@in[28 + inpos]) << 24);
+        @out[23 + outpos] = (int)((uint)(@in[28 + inpos]) >> (26 - 18))
+                            | ((@in[29 + inpos]) << 18);
+        @out[24 + outpos] = (int)((uint)(@in[29 + inpos]) >> (26 - 12))
+                            | ((@in[30 + inpos]) << 12);
+        @out[25 + outpos] = (int)((uint)(@in[30 + inpos]) >> (26 - 6))
+                            | ((@in[31 + inpos]) << 6);
+    }
+
+    protected static void fastpackwithoutmask27(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 27);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (27 - 22))
+                           | ((@in[2 + inpos]) << 22);
+        @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (27 - 17))
+                           | ((@in[3 + inpos]) << 17);
+        @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (27 - 12))
+                           | ((@in[4 + inpos]) << 12);
+        @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (27 - 7))
+                           | ((@in[5 + inpos]) << 7);
+        @out[5 + outpos] = (int)((uint)(@in[5 + inpos]) >> (27 - 2))
+                           | ((@in[6 + inpos]) << 2) | ((@in[7 + inpos]) << 29);
+        @out[6 + outpos] = (int)((uint)(@in[7 + inpos]) >> (27 - 24))
+                           | ((@in[8 + inpos]) << 24);
+        @out[7 + outpos] = (int)((uint)(@in[8 + inpos]) >> (27 - 19))
+                           | ((@in[9 + inpos]) << 19);
+        @out[8 + outpos] = (int)((uint)(@in[9 + inpos]) >> (27 - 14))
+                           | ((@in[10 + inpos]) << 14);
+        @out[9 + outpos] = (int)((uint)(@in[10 + inpos]) >> (27 - 9))
+                           | ((@in[11 + inpos]) << 9);
+        @out[10 + outpos] = (int)((uint)(@in[11 + inpos]) >> (27 - 4))
+                            | ((@in[12 + inpos]) << 4) | ((@in[13 + inpos]) << 31);
+        @out[11 + outpos] = (int)((uint)(@in[13 + inpos]) >> (27 - 26))
+                            | ((@in[14 + inpos]) << 26);
+        @out[12 + outpos] = (int)((uint)(@in[14 + inpos]) >> (27 - 21))
+                            | ((@in[15 + inpos]) << 21);
+        @out[13 + outpos] = (int)((uint)(@in[15 + inpos]) >> (27 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[14 + outpos] = (int)((uint)(@in[16 + inpos]) >> (27 - 11))
+                            | ((@in[17 + inpos]) << 11);
+        @out[15 + outpos] = (int)((uint)(@in[17 + inpos]) >> (27 - 6))
+                            | ((@in[18 + inpos]) << 6);
+        @out[16 + outpos] = (int)((uint)(@in[18 + inpos]) >> (27 - 1))
+                            | ((@in[19 + inpos]) << 1) | ((@in[20 + inpos]) << 28);
+        @out[17 + outpos] = (int)((uint)(@in[20 + inpos]) >> (27 - 23))
+                            | ((@in[21 + inpos]) << 23);
+        @out[18 + outpos] = (int)((uint)(@in[21 + inpos]) >> (27 - 18))
+                            | ((@in[22 + inpos]) << 18);
+        @out[19 + outpos] = (int)((uint)(@in[22 + inpos]) >> (27 - 13))
+                            | ((@in[23 + inpos]) << 13);
+        @out[20 + outpos] = (int)((uint)(@in[23 + inpos]) >> (27 - 8))
+                            | ((@in[24 + inpos]) << 8);
+        @out[21 + outpos] = (int)((uint)(@in[24 + inpos]) >> (27 - 3))
+                            | ((@in[25 + inpos]) << 3) | ((@in[26 + inpos]) << 30);
+        @out[22 + outpos] = (int)((uint)(@in[26 + inpos]) >> (27 - 25))
+                            | ((@in[27 + inpos]) << 25);
+        @out[23 + outpos] = (int)((uint)(@in[27 + inpos]) >> (27 - 20))
+                            | ((@in[28 + inpos]) << 20);
+        @out[24 + outpos] = (int)((uint)(@in[28 + inpos]) >> (27 - 15))
+                            | ((@in[29 + inpos]) << 15);
+        @out[25 + outpos] = (int)((uint)(@in[29 + inpos]) >> (27 - 10))
+                            | ((@in[30 + inpos]) << 10);
+        @out[26 + outpos] = (int)((uint)(@in[30 + inpos]) >> (27 - 5))
+                            | ((@in[31 + inpos]) << 5);
+    }
+
+    protected static void fastpackwithoutmask28(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 28);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (28 - 24))
+                           | ((@in[2 + inpos]) << 24);
+        @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (28 - 20))
+                           | ((@in[3 + inpos]) << 20);
+        @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (28 - 16))
+                           | ((@in[4 + inpos]) << 16);
+        @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (28 - 12))
+                           | ((@in[5 + inpos]) << 12);
+        @out[5 + outpos] = (int)((uint)(@in[5 + inpos]) >> (28 - 8))
+                           | ((@in[6 + inpos]) << 8);
+        @out[6 + outpos] = (int)((uint)(@in[6 + inpos]) >> (28 - 4))
+                           | ((@in[7 + inpos]) << 4);
+        @out[7 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 28);
+        @out[8 + outpos] = (int)((uint)(@in[9 + inpos]) >> (28 - 24))
+                           | ((@in[10 + inpos]) << 24);
+        @out[9 + outpos] = (int)((uint)(@in[10 + inpos]) >> (28 - 20))
+                           | ((@in[11 + inpos]) << 20);
+        @out[10 + outpos] = (int)((uint)(@in[11 + inpos]) >> (28 - 16))
+                            | ((@in[12 + inpos]) << 16);
+        @out[11 + outpos] = (int)((uint)(@in[12 + inpos]) >> (28 - 12))
+                            | ((@in[13 + inpos]) << 12);
+        @out[12 + outpos] = (int)((uint)(@in[13 + inpos]) >> (28 - 8))
+                            | ((@in[14 + inpos]) << 8);
+        @out[13 + outpos] = (int)((uint)(@in[14 + inpos]) >> (28 - 4))
+                            | ((@in[15 + inpos]) << 4);
+        @out[14 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 28);
+        @out[15 + outpos] = (int)((uint)(@in[17 + inpos]) >> (28 - 24))
+                            | ((@in[18 + inpos]) << 24);
+        @out[16 + outpos] = (int)((uint)(@in[18 + inpos]) >> (28 - 20))
+                            | ((@in[19 + inpos]) << 20);
+        @out[17 + outpos] = (int)((uint)(@in[19 + inpos]) >> (28 - 16))
+                            | ((@in[20 + inpos]) << 16);
+        @out[18 + outpos] = (int)((uint)(@in[20 + inpos]) >> (28 - 12))
+                            | ((@in[21 + inpos]) << 12);
+        @out[19 + outpos] = (int)((uint)(@in[21 + inpos]) >> (28 - 8))
+                            | ((@in[22 + inpos]) << 8);
+        @out[20 + outpos] = (int)((uint)(@in[22 + inpos]) >> (28 - 4))
+                            | ((@in[23 + inpos]) << 4);
+        @out[21 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 28);
+        @out[22 + outpos] = (int)((uint)(@in[25 + inpos]) >> (28 - 24))
+                            | ((@in[26 + inpos]) << 24);
+        @out[23 + outpos] = (int)((uint)(@in[26 + inpos]) >> (28 - 20))
+                            | ((@in[27 + inpos]) << 20);
+        @out[24 + outpos] = (int)((uint)(@in[27 + inpos]) >> (28 - 16))
+                            | ((@in[28 + inpos]) << 16);
+        @out[25 + outpos] = (int)((uint)(@in[28 + inpos]) >> (28 - 12))
+                            | ((@in[29 + inpos]) << 12);
+        @out[26 + outpos] = (int)((uint)(@in[29 + inpos]) >> (28 - 8))
+                            | ((@in[30 + inpos]) << 8);
+        @out[27 + outpos] = (int)((uint)(@in[30 + inpos]) >> (28 - 4))
+                            | ((@in[31 + inpos]) << 4);
+    }
+
+    protected static void fastpackwithoutmask29(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 29);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (29 - 26))
+                           | ((@in[2 + inpos]) << 26);
+        @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (29 - 23))
+                           | ((@in[3 + inpos]) << 23);
+        @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (29 - 20))
+                           | ((@in[4 + inpos]) << 20);
+        @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (29 - 17))
+                           | ((@in[5 + inpos]) << 17);
+        @out[5 + outpos] = (int)((uint)(@in[5 + inpos]) >> (29 - 14))
+                           | ((@in[6 + inpos]) << 14);
+        @out[6 + outpos] = (int)((uint)(@in[6 + inpos]) >> (29 - 11))
+                           | ((@in[7 + inpos]) << 11);
+        @out[7 + outpos] = (int)((uint)(@in[7 + inpos]) >> (29 - 8))
+                           | ((@in[8 + inpos]) << 8);
+        @out[8 + outpos] = (int)((uint)(@in[8 + inpos]) >> (29 - 5))
+                           | ((@in[9 + inpos]) << 5);
+        @out[9 + outpos] = (int)((uint)(@in[9 + inpos]) >> (29 - 2))
+                           | ((@in[10 + inpos]) << 2) | ((@in[11 + inpos]) << 31);
+        @out[10 + outpos] = (int)((uint)(@in[11 + inpos]) >> (29 - 28))
+                            | ((@in[12 + inpos]) << 28);
+        @out[11 + outpos] = (int)((uint)(@in[12 + inpos]) >> (29 - 25))
+                            | ((@in[13 + inpos]) << 25);
+        @out[12 + outpos] = (int)((uint)(@in[13 + inpos]) >> (29 - 22))
+                            | ((@in[14 + inpos]) << 22);
+        @out[13 + outpos] = (int)((uint)(@in[14 + inpos]) >> (29 - 19))
+                            | ((@in[15 + inpos]) << 19);
+        @out[14 + outpos] = (int)((uint)(@in[15 + inpos]) >> (29 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[15 + outpos] = (int)((uint)(@in[16 + inpos]) >> (29 - 13))
+                            | ((@in[17 + inpos]) << 13);
+        @out[16 + outpos] = (int)((uint)(@in[17 + inpos]) >> (29 - 10))
+                            | ((@in[18 + inpos]) << 10);
+        @out[17 + outpos] = (int)((uint)(@in[18 + inpos]) >> (29 - 7))
+                            | ((@in[19 + inpos]) << 7);
+        @out[18 + outpos] = (int)((uint)(@in[19 + inpos]) >> (29 - 4))
+                            | ((@in[20 + inpos]) << 4);
+        @out[19 + outpos] = (int)((uint)(@in[20 + inpos]) >> (29 - 1))
+                            | ((@in[21 + inpos]) << 1) | ((@in[22 + inpos]) << 30);
+        @out[20 + outpos] = (int)((uint)(@in[22 + inpos]) >> (29 - 27))
+                            | ((@in[23 + inpos]) << 27);
+        @out[21 + outpos] = (int)((uint)(@in[23 + inpos]) >> (29 - 24))
+                            | ((@in[24 + inpos]) << 24);
+        @out[22 + outpos] = (int)((uint)(@in[24 + inpos]) >> (29 - 21))
+                            | ((@in[25 + inpos]) << 21);
+        @out[23 + outpos] = (int)((uint)(@in[25 + inpos]) >> (29 - 18))
+                            | ((@in[26 + inpos]) << 18);
+        @out[24 + outpos] = (int)((uint)(@in[26 + inpos]) >> (29 - 15))
+                            | ((@in[27 + inpos]) << 15);
+        @out[25 + outpos] = (int)((uint)(@in[27 + inpos]) >> (29 - 12))
+                            | ((@in[28 + inpos]) << 12);
+        @out[26 + outpos] = (int)((uint)(@in[28 + inpos]) >> (29 - 9))
+                            | ((@in[29 + inpos]) << 9);
+        @out[27 + outpos] = (int)((uint)(@in[29 + inpos]) >> (29 - 6))
+                            | ((@in[30 + inpos]) << 6);
+        @out[28 + outpos] = (int)((uint)(@in[30 + inpos]) >> (29 - 3))
+                            | ((@in[31 + inpos]) << 3);
+    }
+
+    protected static void fastpackwithoutmask3(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 3)
+                           | ((@in[2 + inpos]) << 6) | ((@in[3 + inpos]) << 9)
+                           | ((@in[4 + inpos]) << 12) | ((@in[5 + inpos]) << 15)
+                           | ((@in[6 + inpos]) << 18) | ((@in[7 + inpos]) << 21)
+                           | ((@in[8 + inpos]) << 24) | ((@in[9 + inpos]) << 27)
+                           | ((@in[10 + inpos]) << 30);
+        @out[1 + outpos] = (int)((uint)(@in[10 + inpos]) >> (3 - 1))
+                           | ((@in[11 + inpos]) << 1) | ((@in[12 + inpos]) << 4)
+                           | ((@in[13 + inpos]) << 7) | ((@in[14 + inpos]) << 10)
+                           | ((@in[15 + inpos]) << 13) | ((@in[16 + inpos]) << 16)
+                           | ((@in[17 + inpos]) << 19) | ((@in[18 + inpos]) << 22)
+                           | ((@in[19 + inpos]) << 25) | ((@in[20 + inpos]) << 28)
+                           | ((@in[21 + inpos]) << 31);
+        @out[2 + outpos] = (int)((uint)(@in[21 + inpos]) >> (3 - 2))
+                           | ((@in[22 + inpos]) << 2) | ((@in[23 + inpos]) << 5)
+                           | ((@in[24 + inpos]) << 8) | ((@in[25 + inpos]) << 11)
+                           | ((@in[26 + inpos]) << 14) | ((@in[27 + inpos]) << 17)
+                           | ((@in[28 + inpos]) << 20) | ((@in[29 + inpos]) << 23)
+                           | ((@in[30 + inpos]) << 26) | ((@in[31 + inpos]) << 29);
+    }
+
+    protected static void fastpackwithoutmask30(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 30);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (30 - 28))
+                           | ((@in[2 + inpos]) << 28);
+        @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (30 - 26))
+                           | ((@in[3 + inpos]) << 26);
+        @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (30 - 24))
+                           | ((@in[4 + inpos]) << 24);
+        @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (30 - 22))
+                           | ((@in[5 + inpos]) << 22);
+        @out[5 + outpos] = (int)((uint)(@in[5 + inpos]) >> (30 - 20))
+                           | ((@in[6 + inpos]) << 20);
+        @out[6 + outpos] = (int)((uint)(@in[6 + inpos]) >> (30 - 18))
+                           | ((@in[7 + inpos]) << 18);
+        @out[7 + outpos] = (int)((uint)(@in[7 + inpos]) >> (30 - 16))
+                           | ((@in[8 + inpos]) << 16);
+        @out[8 + outpos] = (int)((uint)(@in[8 + inpos]) >> (30 - 14))
+                           | ((@in[9 + inpos]) << 14);
+        @out[9 + outpos] = (int)((uint)(@in[9 + inpos]) >> (30 - 12))
+                           | ((@in[10 + inpos]) << 12);
+        @out[10 + outpos] = (int)((uint)(@in[10 + inpos]) >> (30 - 10))
+                            | ((@in[11 + inpos]) << 10);
+        @out[11 + outpos] = (int)((uint)(@in[11 + inpos]) >> (30 - 8))
+                            | ((@in[12 + inpos]) << 8);
+        @out[12 + outpos] = (int)((uint)(@in[12 + inpos]) >> (30 - 6))
+                            | ((@in[13 + inpos]) << 6);
+        @out[13 + outpos] = (int)((uint)(@in[13 + inpos]) >> (30 - 4))
+                            | ((@in[14 + inpos]) << 4);
+        @out[14 + outpos] = (int)((uint)(@in[14 + inpos]) >> (30 - 2))
+                            | ((@in[15 + inpos]) << 2);
+        @out[15 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 30);
+        @out[16 + outpos] = (int)((uint)(@in[17 + inpos]) >> (30 - 28))
+                            | ((@in[18 + inpos]) << 28);
+        @out[17 + outpos] = (int)((uint)(@in[18 + inpos]) >> (30 - 26))
+                            | ((@in[19 + inpos]) << 26);
+        @out[18 + outpos] = (int)((uint)(@in[19 + inpos]) >> (30 - 24))
+                            | ((@in[20 + inpos]) << 24);
+        @out[19 + outpos] = (int)((uint)(@in[20 + inpos]) >> (30 - 22))
+                            | ((@in[21 + inpos]) << 22);
+        @out[20 + outpos] = (int)((uint)(@in[21 + inpos]) >> (30 - 20))
+                            | ((@in[22 + inpos]) << 20);
+        @out[21 + outpos] = (int)((uint)(@in[22 + inpos]) >> (30 - 18))
+                            | ((@in[23 + inpos]) << 18);
+        @out[22 + outpos] = (int)((uint)(@in[23 + inpos]) >> (30 - 16))
+                            | ((@in[24 + inpos]) << 16);
+        @out[23 + outpos] = (int)((uint)(@in[24 + inpos]) >> (30 - 14))
+                            | ((@in[25 + inpos]) << 14);
+        @out[24 + outpos] = (int)((uint)(@in[25 + inpos]) >> (30 - 12))
+                            | ((@in[26 + inpos]) << 12);
+        @out[25 + outpos] = (int)((uint)(@in[26 + inpos]) >> (30 - 10))
+                            | ((@in[27 + inpos]) << 10);
+        @out[26 + outpos] = (int)((uint)(@in[27 + inpos]) >> (30 - 8))
+                            | ((@in[28 + inpos]) << 8);
+        @out[27 + outpos] = (int)((uint)(@in[28 + inpos]) >> (30 - 6))
+                            | ((@in[29 + inpos]) << 6);
+        @out[28 + outpos] = (int)((uint)(@in[29 + inpos]) >> (30 - 4))
+                            | ((@in[30 + inpos]) << 4);
+        @out[29 + outpos] = (int)((uint)(@in[30 + inpos]) >> (30 - 2))
+                            | ((@in[31 + inpos]) << 2);
+    }
+
+    protected static void fastpackwithoutmask31(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 31);
+        @out[1 + outpos] = (int)((uint)(@in[1 + inpos]) >> (31 - 30))
+                           | ((@in[2 + inpos]) << 30);
+        @out[2 + outpos] = (int)((uint)(@in[2 + inpos]) >> (31 - 29))
+                           | ((@in[3 + inpos]) << 29);
+        @out[3 + outpos] = (int)((uint)(@in[3 + inpos]) >> (31 - 28))
+                           | ((@in[4 + inpos]) << 28);
+        @out[4 + outpos] = (int)((uint)(@in[4 + inpos]) >> (31 - 27))
+                           | ((@in[5 + inpos]) << 27);
+        @out[5 + outpos] = (int)((uint)(@in[5 + inpos]) >> (31 - 26))
+                           | ((@in[6 + inpos]) << 26);
+        @out[6 + outpos] = (int)((uint)(@in[6 + inpos]) >> (31 - 25))
+                           | ((@in[7 + inpos]) << 25);
+        @out[7 + outpos] = (int)((uint)(@in[7 + inpos]) >> (31 - 24))
+                           | ((@in[8 + inpos]) << 24);
+        @out[8 + outpos] = (int)((uint)(@in[8 + inpos]) >> (31 - 23))
+                           | ((@in[9 + inpos]) << 23);
+        @out[9 + outpos] = (int)((uint)(@in[9 + inpos]) >> (31 - 22))
+                           | ((@in[10 + inpos]) << 22);
+        @out[10 + outpos] = (int)((uint)(@in[10 + inpos]) >> (31 - 21))
+                            | ((@in[11 + inpos]) << 21);
+        @out[11 + outpos] = (int)((uint)(@in[11 + inpos]) >> (31 - 20))
+                            | ((@in[12 + inpos]) << 20);
+        @out[12 + outpos] = (int)((uint)(@in[12 + inpos]) >> (31 - 19))
+                            | ((@in[13 + inpos]) << 19);
+        @out[13 + outpos] = (int)((uint)(@in[13 + inpos]) >> (31 - 18))
+                            | ((@in[14 + inpos]) << 18);
+        @out[14 + outpos] = (int)((uint)(@in[14 + inpos]) >> (31 - 17))
+                            | ((@in[15 + inpos]) << 17);
+        @out[15 + outpos] = (int)((uint)(@in[15 + inpos]) >> (31 - 16))
+                            | ((@in[16 + inpos]) << 16);
+        @out[16 + outpos] = (int)((uint)(@in[16 + inpos]) >> (31 - 15))
+                            | ((@in[17 + inpos]) << 15);
+        @out[17 + outpos] = (int)((uint)(@in[17 + inpos]) >> (31 - 14))
+                            | ((@in[18 + inpos]) << 14);
+        @out[18 + outpos] = (int)((uint)(@in[18 + inpos]) >> (31 - 13))
+                            | ((@in[19 + inpos]) << 13);
+        @out[19 + outpos] = (int)((uint)(@in[19 + inpos]) >> (31 - 12))
+                            | ((@in[20 + inpos]) << 12);
+        @out[20 + outpos] = (int)((uint)(@in[20 + inpos]) >> (31 - 11))
+                            | ((@in[21 + inpos]) << 11);
+        @out[21 + outpos] = (int)((uint)(@in[21 + inpos]) >> (31 - 10))
+                            | ((@in[22 + inpos]) << 10);
+        @out[22 + outpos] = (int)((uint)(@in[22 + inpos]) >> (31 - 9))
+                            | ((@in[23 + inpos]) << 9);
+        @out[23 + outpos] = (int)((uint)(@in[23 + inpos]) >> (31 - 8))
+                            | ((@in[24 + inpos]) << 8);
+        @out[24 + outpos] = (int)((uint)(@in[24 + inpos]) >> (31 - 7))
+                            | ((@in[25 + inpos]) << 7);
+        @out[25 + outpos] = (int)((uint)(@in[25 + inpos]) >> (31 - 6))
+                            | ((@in[26 + inpos]) << 6);
+        @out[26 + outpos] = (int)((uint)(@in[26 + inpos]) >> (31 - 5))
+                            | ((@in[27 + inpos]) << 5);
+        @out[27 + outpos] = (int)((uint)(@in[27 + inpos]) >> (31 - 4))
+                            | ((@in[28 + inpos]) << 4);
+        @out[28 + outpos] = (int)((uint)(@in[28 + inpos]) >> (31 - 3))
+                            | ((@in[29 + inpos]) << 3);
+        @out[29 + outpos] = (int)((uint)(@in[29 + inpos]) >> (31 - 2))
+                            | ((@in[30 + inpos]) << 2);
+        @out[30 + outpos] = (int)((uint)(@in[30 + inpos]) >> (31 - 1))
+                            | ((@in[31 + inpos]) << 1);
+    }
+
+    protected static void fastpackwithoutmask32(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        Array.Copy(@in, inpos, @out, outpos, 32);
+    }
+
+    protected static void fastpackwithoutmask4(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 4)
+                           | ((@in[2 + inpos]) << 8) | ((@in[3 + inpos]) << 12)
+                           | ((@in[4 + inpos]) << 16) | ((@in[5 + inpos]) << 20)
+                           | ((@in[6 + inpos]) << 24) | ((@in[7 + inpos]) << 28);
+        @out[1 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 4)
+                           | ((@in[10 + inpos]) << 8) | ((@in[11 + inpos]) << 12)
+                           | ((@in[12 + inpos]) << 16) | ((@in[13 + inpos]) << 20)
+                           | ((@in[14 + inpos]) << 24) | ((@in[15 + inpos]) << 28);
+        @out[2 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 4)
+                           | ((@in[18 + inpos]) << 8) | ((@in[19 + inpos]) << 12)
+                           | ((@in[20 + inpos]) << 16) | ((@in[21 + inpos]) << 20)
+                           | ((@in[22 + inpos]) << 24) | ((@in[23 + inpos]) << 28);
+        @out[3 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 4)
+                           | ((@in[26 + inpos]) << 8) | ((@in[27 + inpos]) << 12)
+                           | ((@in[28 + inpos]) << 16) | ((@in[29 + inpos]) << 20)
+                           | ((@in[30 + inpos]) << 24) | ((@in[31 + inpos]) << 28);
+    }
+
+    protected static void fastpackwithoutmask5(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 5)
+                           | ((@in[2 + inpos]) << 10) | ((@in[3 + inpos]) << 15)
+                           | ((@in[4 + inpos]) << 20) | ((@in[5 + inpos]) << 25)
+                           | ((@in[6 + inpos]) << 30);
+        @out[1 + outpos] = (int)((uint)(@in[6 + inpos]) >> (5 - 3))
+                           | ((@in[7 + inpos]) << 3) | ((@in[8 + inpos]) << 8)
+                           | ((@in[9 + inpos]) << 13) | ((@in[10 + inpos]) << 18)
+                           | ((@in[11 + inpos]) << 23) | ((@in[12 + inpos]) << 28);
+        @out[2 + outpos] = (int)((uint)(@in[12 + inpos]) >> (5 - 1))
+                           | ((@in[13 + inpos]) << 1) | ((@in[14 + inpos]) << 6)
+                           | ((@in[15 + inpos]) << 11) | ((@in[16 + inpos]) << 16)
+                           | ((@in[17 + inpos]) << 21) | ((@in[18 + inpos]) << 26)
+                           | ((@in[19 + inpos]) << 31);
+        @out[3 + outpos] = (int)((uint)(@in[19 + inpos]) >> (5 - 4))
+                           | ((@in[20 + inpos]) << 4) | ((@in[21 + inpos]) << 9)
+                           | ((@in[22 + inpos]) << 14) | ((@in[23 + inpos]) << 19)
+                           | ((@in[24 + inpos]) << 24) | ((@in[25 + inpos]) << 29);
+        @out[4 + outpos] = (int)((uint)(@in[25 + inpos]) >> (5 - 2))
+                           | ((@in[26 + inpos]) << 2) | ((@in[27 + inpos]) << 7)
+                           | ((@in[28 + inpos]) << 12) | ((@in[29 + inpos]) << 17)
+                           | ((@in[30 + inpos]) << 22) | ((@in[31 + inpos]) << 27);
+    }
+
+    protected static void fastpackwithoutmask6(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 6)
+                           | ((@in[2 + inpos]) << 12) | ((@in[3 + inpos]) << 18)
+                           | ((@in[4 + inpos]) << 24) | ((@in[5 + inpos]) << 30);
+        @out[1 + outpos] = (int)((uint)(@in[5 + inpos]) >> (6 - 4))
+                           | ((@in[6 + inpos]) << 4) | ((@in[7 + inpos]) << 10)
+                           | ((@in[8 + inpos]) << 16) | ((@in[9 + inpos]) << 22)
+                           | ((@in[10 + inpos]) << 28);
+        @out[2 + outpos] = (int)((uint)(@in[10 + inpos]) >> (6 - 2))
+                           | ((@in[11 + inpos]) << 2) | ((@in[12 + inpos]) << 8)
+                           | ((@in[13 + inpos]) << 14) | ((@in[14 + inpos]) << 20)
+                           | ((@in[15 + inpos]) << 26);
+        @out[3 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 6)
+                           | ((@in[18 + inpos]) << 12) | ((@in[19 + inpos]) << 18)
+                           | ((@in[20 + inpos]) << 24) | ((@in[21 + inpos]) << 30);
+        @out[4 + outpos] = (int)((uint)(@in[21 + inpos]) >> (6 - 4))
+                           | ((@in[22 + inpos]) << 4) | ((@in[23 + inpos]) << 10)
+                           | ((@in[24 + inpos]) << 16) | ((@in[25 + inpos]) << 22)
+                           | ((@in[26 + inpos]) << 28);
+        @out[5 + outpos] = (int)((uint)(@in[26 + inpos]) >> (6 - 2))
+                           | ((@in[27 + inpos]) << 2) | ((@in[28 + inpos]) << 8)
+                           | ((@in[29 + inpos]) << 14) | ((@in[30 + inpos]) << 20)
+                           | ((@in[31 + inpos]) << 26);
+    }
+
+    protected static void fastpackwithoutmask7(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 7)
+                           | ((@in[2 + inpos]) << 14) | ((@in[3 + inpos]) << 21)
+                           | ((@in[4 + inpos]) << 28);
+        @out[1 + outpos] = (int)((uint)(@in[4 + inpos]) >> (7 - 3))
+                           | ((@in[5 + inpos]) << 3) | ((@in[6 + inpos]) << 10)
+                           | ((@in[7 + inpos]) << 17) | ((@in[8 + inpos]) << 24)
+                           | ((@in[9 + inpos]) << 31);
+        @out[2 + outpos] = (int)((uint)(@in[9 + inpos]) >> (7 - 6))
+                           | ((@in[10 + inpos]) << 6) | ((@in[11 + inpos]) << 13)
+                           | ((@in[12 + inpos]) << 20) | ((@in[13 + inpos]) << 27);
+        @out[3 + outpos] = (int)((uint)(@in[13 + inpos]) >> (7 - 2))
+                           | ((@in[14 + inpos]) << 2) | ((@in[15 + inpos]) << 9)
+                           | ((@in[16 + inpos]) << 16) | ((@in[17 + inpos]) << 23)
+                           | ((@in[18 + inpos]) << 30);
+        @out[4 + outpos] = (int)((uint)(@in[18 + inpos]) >> (7 - 5))
+                           | ((@in[19 + inpos]) << 5) | ((@in[20 + inpos]) << 12)
+                           | ((@in[21 + inpos]) << 19) | ((@in[22 + inpos]) << 26);
+        @out[5 + outpos] = (int)((uint)(@in[22 + inpos]) >> (7 - 1))
+                           | ((@in[23 + inpos]) << 1) | ((@in[24 + inpos]) << 8)
+                           | ((@in[25 + inpos]) << 15) | ((@in[26 + inpos]) << 22)
+                           | ((@in[27 + inpos]) << 29);
+        @out[6 + outpos] = (int)((uint)(@in[27 + inpos]) >> (7 - 4))
+                           | ((@in[28 + inpos]) << 4) | ((@in[29 + inpos]) << 11)
+                           | ((@in[30 + inpos]) << 18) | ((@in[31 + inpos]) << 25);
+    }
+
+    protected static void fastpackwithoutmask8(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 8)
+                           | ((@in[2 + inpos]) << 16) | ((@in[3 + inpos]) << 24);
+        @out[1 + outpos] = @in[4 + inpos] | ((@in[5 + inpos]) << 8)
+                           | ((@in[6 + inpos]) << 16) | ((@in[7 + inpos]) << 24);
+        @out[2 + outpos] = @in[8 + inpos] | ((@in[9 + inpos]) << 8)
+                           | ((@in[10 + inpos]) << 16) | ((@in[11 + inpos]) << 24);
+        @out[3 + outpos] = @in[12 + inpos] | ((@in[13 + inpos]) << 8)
+                           | ((@in[14 + inpos]) << 16) | ((@in[15 + inpos]) << 24);
+        @out[4 + outpos] = @in[16 + inpos] | ((@in[17 + inpos]) << 8)
+                           | ((@in[18 + inpos]) << 16) | ((@in[19 + inpos]) << 24);
+        @out[5 + outpos] = @in[20 + inpos] | ((@in[21 + inpos]) << 8)
+                           | ((@in[22 + inpos]) << 16) | ((@in[23 + inpos]) << 24);
+        @out[6 + outpos] = @in[24 + inpos] | ((@in[25 + inpos]) << 8)
+                           | ((@in[26 + inpos]) << 16) | ((@in[27 + inpos]) << 24);
+        @out[7 + outpos] = @in[28 + inpos] | ((@in[29 + inpos]) << 8)
+                           | ((@in[30 + inpos]) << 16) | ((@in[31 + inpos]) << 24);
+    }
+
+    protected static void fastpackwithoutmask9(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = @in[0 + inpos] | ((@in[1 + inpos]) << 9)
+                           | ((@in[2 + inpos]) << 18) | ((@in[3 + inpos]) << 27);
+        @out[1 + outpos] = (int)((uint)(@in[3 + inpos]) >> (9 - 4))
+                           | ((@in[4 + inpos]) << 4) | ((@in[5 + inpos]) << 13)
+                           | ((@in[6 + inpos]) << 22) | ((@in[7 + inpos]) << 31);
+        @out[2 + outpos] = (int)((uint)(@in[7 + inpos]) >> (9 - 8))
+                           | ((@in[8 + inpos]) << 8) | ((@in[9 + inpos]) << 17)
+                           | ((@in[10 + inpos]) << 26);
+        @out[3 + outpos] = (int)((uint)(@in[10 + inpos]) >> (9 - 3))
+                           | ((@in[11 + inpos]) << 3) | ((@in[12 + inpos]) << 12)
+                           | ((@in[13 + inpos]) << 21) | ((@in[14 + inpos]) << 30);
+        @out[4 + outpos] = (int)((uint)(@in[14 + inpos]) >> (9 - 7))
+                           | ((@in[15 + inpos]) << 7) | ((@in[16 + inpos]) << 16)
+                           | ((@in[17 + inpos]) << 25);
+        @out[5 + outpos] = (int)((uint)(@in[17 + inpos]) >> (9 - 2))
+                           | ((@in[18 + inpos]) << 2) | ((@in[19 + inpos]) << 11)
+                           | ((@in[20 + inpos]) << 20) | ((@in[21 + inpos]) << 29);
+        @out[6 + outpos] = (int)((uint)(@in[21 + inpos]) >> (9 - 6))
+                           | ((@in[22 + inpos]) << 6) | ((@in[23 + inpos]) << 15)
+                           | ((@in[24 + inpos]) << 24);
+        @out[7 + outpos] = (int)((uint)(@in[24 + inpos]) >> (9 - 1))
+                           | ((@in[25 + inpos]) << 1) | ((@in[26 + inpos]) << 10)
+                           | ((@in[27 + inpos]) << 19) | ((@in[28 + inpos]) << 28);
+        @out[8 + outpos] = (int)((uint)(@in[28 + inpos]) >> (9 - 5))
+                           | ((@in[29 + inpos]) << 5) | ((@in[30 + inpos]) << 14)
+                           | ((@in[31 + inpos]) << 23);
+    }
+
+    /**
+     * Pack the 32 integers
+     * 
+     * @param in
+     *                source array
+     * @param inpos
+     *                starting point in the source array
+     * @param out
+     *                output array
+     * @param outpos
+     *                starting point in the output array
+     * @param bit
+     *                how many bits to use per integer
+     */
+    public static void fastunpack(int[] @in, int inpos, int[] @out, int outpos, int bit)
+    {
+        switch (bit)
+        {
+            case 0:
+                fastunpack0(@in, inpos, @out, outpos);
+                break;
+            case 1:
+                fastunpack1(@in, inpos, @out, outpos);
+                break;
+            case 2:
+                fastunpack2(@in, inpos, @out, outpos);
+                break;
+            case 3:
+                fastunpack3(@in, inpos, @out, outpos);
+                break;
+            case 4:
+                fastunpack4(@in, inpos, @out, outpos);
+                break;
+            case 5:
+                fastunpack5(@in, inpos, @out, outpos);
+                break;
+            case 6:
+                fastunpack6(@in, inpos, @out, outpos);
+                break;
+            case 7:
+                fastunpack7(@in, inpos, @out, outpos);
+                break;
+            case 8:
+                fastunpack8(@in, inpos, @out, outpos);
+                break;
+            case 9:
+                fastunpack9(@in, inpos, @out, outpos);
+                break;
+            case 10:
+                fastunpack10(@in, inpos, @out, outpos);
+                break;
+            case 11:
+                fastunpack11(@in, inpos, @out, outpos);
+                break;
+            case 12:
+                fastunpack12(@in, inpos, @out, outpos);
+                break;
+            case 13:
+                fastunpack13(@in, inpos, @out, outpos);
+                break;
+            case 14:
+                fastunpack14(@in, inpos, @out, outpos);
+                break;
+            case 15:
+                fastunpack15(@in, inpos, @out, outpos);
+                break;
+            case 16:
+                fastunpack16(@in, inpos, @out, outpos);
+                break;
+            case 17:
+                fastunpack17(@in, inpos, @out, outpos);
+                break;
+            case 18:
+                fastunpack18(@in, inpos, @out, outpos);
+                break;
+            case 19:
+                fastunpack19(@in, inpos, @out, outpos);
+                break;
+            case 20:
+                fastunpack20(@in, inpos, @out, outpos);
+                break;
+            case 21:
+                fastunpack21(@in, inpos, @out, outpos);
+                break;
+            case 22:
+                fastunpack22(@in, inpos, @out, outpos);
+                break;
+            case 23:
+                fastunpack23(@in, inpos, @out, outpos);
+                break;
+            case 24:
+                fastunpack24(@in, inpos, @out, outpos);
+                break;
+            case 25:
+                fastunpack25(@in, inpos, @out, outpos);
+                break;
+            case 26:
+                fastunpack26(@in, inpos, @out, outpos);
+                break;
+            case 27:
+                fastunpack27(@in, inpos, @out, outpos);
+                break;
+            case 28:
+                fastunpack28(@in, inpos, @out, outpos);
+                break;
+            case 29:
+                fastunpack29(@in, inpos, @out, outpos);
+                break;
+            case 30:
+                fastunpack30(@in, inpos, @out, outpos);
+                break;
+            case 31:
+                fastunpack31(@in, inpos, @out, outpos);
+                break;
+            case 32:
+                fastunpack32(@in, inpos, @out, outpos);
+                break;
+            default:
+                throw new ArgumentException(
+                    "Unsupported bit width.");
+        }
+    }
+
+    protected static void fastunpack0(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        Arrays.fill(@out, outpos, outpos + 32, 0);
+    }
+
+    protected static void fastunpack1(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 1);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 1) & 1);
+        @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 2) & 1);
+        @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 3) & 1);
+        @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 4) & 1);
+        @out[5 + outpos] = (int)(((uint)@in[0 + inpos] >> 5) & 1);
+        @out[6 + outpos] = (int)(((uint)@in[0 + inpos] >> 6) & 1);
+        @out[7 + outpos] = (int)(((uint)@in[0 + inpos] >> 7) & 1);
+        @out[8 + outpos] = (int)(((uint)@in[0 + inpos] >> 8) & 1);
+        @out[9 + outpos] = (int)(((uint)@in[0 + inpos] >> 9) & 1);
+        @out[10 + outpos] = (int)(((uint)@in[0 + inpos] >> 10) & 1);
+        @out[11 + outpos] = (int)(((uint)@in[0 + inpos] >> 11) & 1);
+        @out[12 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 1);
+        @out[13 + outpos] = (int)(((uint)@in[0 + inpos] >> 13) & 1);
+        @out[14 + outpos] = (int)(((uint)@in[0 + inpos] >> 14) & 1);
+        @out[15 + outpos] = (int)(((uint)@in[0 + inpos] >> 15) & 1);
+        @out[16 + outpos] = (int)(((uint)@in[0 + inpos] >> 16) & 1);
+        @out[17 + outpos] = (int)(((uint)@in[0 + inpos] >> 17) & 1);
+        @out[18 + outpos] = (int)(((uint)@in[0 + inpos] >> 18) & 1);
+        @out[19 + outpos] = (int)(((uint)@in[0 + inpos] >> 19) & 1);
+        @out[20 + outpos] = (int)(((uint)@in[0 + inpos] >> 20) & 1);
+        @out[21 + outpos] = (int)(((uint)@in[0 + inpos] >> 21) & 1);
+        @out[22 + outpos] = (int)(((uint)@in[0 + inpos] >> 22) & 1);
+        @out[23 + outpos] = (int)(((uint)@in[0 + inpos] >> 23) & 1);
+        @out[24 + outpos] = (int)(((uint)@in[0 + inpos] >> 24) & 1);
+        @out[25 + outpos] = (int)(((uint)@in[0 + inpos] >> 25) & 1);
+        @out[26 + outpos] = (int)(((uint)@in[0 + inpos] >> 26) & 1);
+        @out[27 + outpos] = (int)(((uint)@in[0 + inpos] >> 27) & 1);
+        @out[28 + outpos] = (int)(((uint)@in[0 + inpos] >> 28) & 1);
+        @out[29 + outpos] = (int)(((uint)@in[0 + inpos] >> 29) & 1);
+        @out[30 + outpos] = (int)(((uint)@in[0 + inpos] >> 30) & 1);
+        @out[31 + outpos] = (int)((uint)@in[0 + inpos] >> 31);
+    }
+
+    protected static void fastunpack10(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 1023);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 10) & 1023);
+        @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 20) & 1023);
+        @out[3 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
+                           | ((@in[1 + inpos] & 255) << (10 - 8));
+        @out[4 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 1023);
+        @out[5 + outpos] = (int)(((uint)@in[1 + inpos] >> 18) & 1023);
+        @out[6 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
+                           | ((@in[2 + inpos] & 63) << (10 - 6));
+        @out[7 + outpos] = (int)(((uint)@in[2 + inpos] >> 6) & 1023);
+        @out[8 + outpos] = (int)(((uint)@in[2 + inpos] >> 16) & 1023);
+        @out[9 + outpos] = (int)((uint)@in[2 + inpos] >> 26)
+                           | ((@in[3 + inpos] & 15) << (10 - 4));
+        @out[10 + outpos] = (int)(((uint)@in[3 + inpos] >> 4) & 1023);
+        @out[11 + outpos] = (int)(((uint)@in[3 + inpos] >> 14) & 1023);
+        @out[12 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
+                            | ((@in[4 + inpos] & 3) << (10 - 2));
+        @out[13 + outpos] = (int)(((uint)@in[4 + inpos] >> 2) & 1023);
+        @out[14 + outpos] = (int)(((uint)@in[4 + inpos] >> 12) & 1023);
+        @out[15 + outpos] = (int)((uint)@in[4 + inpos] >> 22);
+        @out[16 + outpos] = (int)(((uint)@in[5 + inpos] >> 0) & 1023);
+        @out[17 + outpos] = (int)(((uint)@in[5 + inpos] >> 10) & 1023);
+        @out[18 + outpos] = (int)(((uint)@in[5 + inpos] >> 20) & 1023);
+        @out[19 + outpos] = (int)((uint)@in[5 + inpos] >> 30)
+                            | ((@in[6 + inpos] & 255) << (10 - 8));
+        @out[20 + outpos] = (int)(((uint)@in[6 + inpos] >> 8) & 1023);
+        @out[21 + outpos] = (int)(((uint)@in[6 + inpos] >> 18) & 1023);
+        @out[22 + outpos] = (int)((uint)@in[6 + inpos] >> 28)
+                            | ((@in[7 + inpos] & 63) << (10 - 6));
+        @out[23 + outpos] = (int)(((uint)@in[7 + inpos] >> 6) & 1023);
+        @out[24 + outpos] = (int)(((uint)@in[7 + inpos] >> 16) & 1023);
+        @out[25 + outpos] = (int)((uint)@in[7 + inpos] >> 26)
+                            | ((@in[8 + inpos] & 15) << (10 - 4));
+        @out[26 + outpos] = (int)(((uint)@in[8 + inpos] >> 4) & 1023);
+        @out[27 + outpos] = (int)(((uint)@in[8 + inpos] >> 14) & 1023);
+        @out[28 + outpos] = (int)((uint)@in[8 + inpos] >> 24)
+                            | ((@in[9 + inpos] & 3) << (10 - 2));
+        @out[29 + outpos] = (int)(((uint)@in[9 + inpos] >> 2) & 1023);
+        @out[30 + outpos] = (int)(((uint)@in[9 + inpos] >> 12) & 1023);
+        @out[31 + outpos] = (int)((uint)@in[9 + inpos] >> 22);
+    }
+
+    protected static void fastunpack11(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 2047);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 11) & 2047);
+        @out[2 + outpos] = (int)((uint)@in[0 + inpos] >> 22)
+                           | ((@in[1 + inpos] & 1) << (11 - 1));
+        @out[3 + outpos] = (int)(((uint)@in[1 + inpos] >> 1) & 2047);
+        @out[4 + outpos] = (int)(((uint)@in[1 + inpos] >> 12) & 2047);
+        @out[5 + outpos] = (int)((uint)@in[1 + inpos] >> 23)
+                           | ((@in[2 + inpos] & 3) << (11 - 2));
+        @out[6 + outpos] = (int)(((uint)@in[2 + inpos] >> 2) & 2047);
+        @out[7 + outpos] = (int)(((uint)@in[2 + inpos] >> 13) & 2047);
+        @out[8 + outpos] = (int)((uint)@in[2 + inpos] >> 24)
+                           | ((@in[3 + inpos] & 7) << (11 - 3));
+        @out[9 + outpos] = (int)(((uint)@in[3 + inpos] >> 3) & 2047);
+        @out[10 + outpos] = (int)(((uint)@in[3 + inpos] >> 14) & 2047);
+        @out[11 + outpos] = (int)((uint)@in[3 + inpos] >> 25)
+                            | ((@in[4 + inpos] & 15) << (11 - 4));
+        @out[12 + outpos] = (int)(((uint)@in[4 + inpos] >> 4) & 2047);
+        @out[13 + outpos] = (int)(((uint)@in[4 + inpos] >> 15) & 2047);
+        @out[14 + outpos] = (int)((uint)@in[4 + inpos] >> 26)
+                            | ((@in[5 + inpos] & 31) << (11 - 5));
+        @out[15 + outpos] = (int)(((uint)@in[5 + inpos] >> 5) & 2047);
+        @out[16 + outpos] = (int)(((uint)@in[5 + inpos] >> 16) & 2047);
+        @out[17 + outpos] = (int)((uint)@in[5 + inpos] >> 27)
+                            | ((@in[6 + inpos] & 63) << (11 - 6));
+        @out[18 + outpos] = (int)(((uint)@in[6 + inpos] >> 6) & 2047);
+        @out[19 + outpos] = (int)(((uint)@in[6 + inpos] >> 17) & 2047);
+        @out[20 + outpos] = (int)((uint)@in[6 + inpos] >> 28)
+                            | ((@in[7 + inpos] & 127) << (11 - 7));
+        @out[21 + outpos] = (int)(((uint)@in[7 + inpos] >> 7) & 2047);
+        @out[22 + outpos] = (int)(((uint)@in[7 + inpos] >> 18) & 2047);
+        @out[23 + outpos] = (int)((uint)@in[7 + inpos] >> 29)
+                            | ((@in[8 + inpos] & 255) << (11 - 8));
+        @out[24 + outpos] = (int)(((uint)@in[8 + inpos] >> 8) & 2047);
+        @out[25 + outpos] = (int)(((uint)@in[8 + inpos] >> 19) & 2047);
+        @out[26 + outpos] = (int)((uint)@in[8 + inpos] >> 30)
+                            | ((@in[9 + inpos] & 511) << (11 - 9));
+        @out[27 + outpos] = (int)(((uint)@in[9 + inpos] >> 9) & 2047);
+        @out[28 + outpos] = (int)(((uint)@in[9 + inpos] >> 20) & 2047);
+        @out[29 + outpos] = (int)((uint)@in[9 + inpos] >> 31)
+                            | ((@in[10 + inpos] & 1023) << (11 - 10));
+        @out[30 + outpos] = (int)(((uint)@in[10 + inpos] >> 10) & 2047);
+        @out[31 + outpos] = (int)((uint)@in[10 + inpos] >> 21);
+    }
+
+    protected static void fastunpack12(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 4095);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 4095);
+        @out[2 + outpos] = (int)((uint)@in[0 + inpos] >> 24)
+                           | ((@in[1 + inpos] & 15) << (12 - 4));
+        @out[3 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 4095);
+        @out[4 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 4095);
+        @out[5 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
+                           | ((@in[2 + inpos] & 255) << (12 - 8));
+        @out[6 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 4095);
+        @out[7 + outpos] = (int)((uint)@in[2 + inpos] >> 20);
+        @out[8 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 4095);
+        @out[9 + outpos] = (int)(((uint)@in[3 + inpos] >> 12) & 4095);
+        @out[10 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
+                            | ((@in[4 + inpos] & 15) << (12 - 4));
+        @out[11 + outpos] = (int)(((uint)@in[4 + inpos] >> 4) & 4095);
+        @out[12 + outpos] = (int)(((uint)@in[4 + inpos] >> 16) & 4095);
+        @out[13 + outpos] = (int)((uint)@in[4 + inpos] >> 28)
+                            | ((@in[5 + inpos] & 255) << (12 - 8));
+        @out[14 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 4095);
+        @out[15 + outpos] = (int)((uint)@in[5 + inpos] >> 20);
+        @out[16 + outpos] = (int)(((uint)@in[6 + inpos] >> 0) & 4095);
+        @out[17 + outpos] = (int)(((uint)@in[6 + inpos] >> 12) & 4095);
+        @out[18 + outpos] = (int)((uint)@in[6 + inpos] >> 24)
+                            | ((@in[7 + inpos] & 15) << (12 - 4));
+        @out[19 + outpos] = (int)(((uint)@in[7 + inpos] >> 4) & 4095);
+        @out[20 + outpos] = (int)(((uint)@in[7 + inpos] >> 16) & 4095);
+        @out[21 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
+                            | ((@in[8 + inpos] & 255) << (12 - 8));
+        @out[22 + outpos] = (int)(((uint)@in[8 + inpos] >> 8) & 4095);
+        @out[23 + outpos] = (int)((uint)@in[8 + inpos] >> 20);
+        @out[24 + outpos] = (int)(((uint)@in[9 + inpos] >> 0) & 4095);
+        @out[25 + outpos] = (int)(((uint)@in[9 + inpos] >> 12) & 4095);
+        @out[26 + outpos] = (int)((uint)@in[9 + inpos] >> 24)
+                            | ((@in[10 + inpos] & 15) << (12 - 4));
+        @out[27 + outpos] = (int)(((uint)@in[10 + inpos] >> 4) & 4095);
+        @out[28 + outpos] = (int)(((uint)@in[10 + inpos] >> 16) & 4095);
+        @out[29 + outpos] = (int)((uint)@in[10 + inpos] >> 28)
+                            | ((@in[11 + inpos] & 255) << (12 - 8));
+        @out[30 + outpos] = (int)(((uint)@in[11 + inpos] >> 8) & 4095);
+        @out[31 + outpos] = (int)((uint)@in[11 + inpos] >> 20);
+    }
+
+    protected static void fastunpack13(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 8191);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 13) & 8191);
+        @out[2 + outpos] = (int)((uint)@in[0 + inpos] >> 26)
+                           | ((@in[1 + inpos] & 127) << (13 - 7));
+        @out[3 + outpos] = (int)(((uint)@in[1 + inpos] >> 7) & 8191);
+        @out[4 + outpos] = (int)((uint)@in[1 + inpos] >> 20)
+                           | ((@in[2 + inpos] & 1) << (13 - 1));
+        @out[5 + outpos] = (int)(((uint)@in[2 + inpos] >> 1) & 8191);
+        @out[6 + outpos] = (int)(((uint)@in[2 + inpos] >> 14) & 8191);
+        @out[7 + outpos] = (int)((uint)@in[2 + inpos] >> 27)
+                           | ((@in[3 + inpos] & 255) << (13 - 8));
+        @out[8 + outpos] = (int)(((uint)@in[3 + inpos] >> 8) & 8191);
+        @out[9 + outpos] = (int)((uint)@in[3 + inpos] >> 21)
+                           | ((@in[4 + inpos] & 3) << (13 - 2));
+        @out[10 + outpos] = (int)(((uint)@in[4 + inpos] >> 2) & 8191);
+        @out[11 + outpos] = (int)(((uint)@in[4 + inpos] >> 15) & 8191);
+        @out[12 + outpos] = (int)((uint)@in[4 + inpos] >> 28)
+                            | ((@in[5 + inpos] & 511) << (13 - 9));
+        @out[13 + outpos] = (int)(((uint)@in[5 + inpos] >> 9) & 8191);
+        @out[14 + outpos] = (int)((uint)@in[5 + inpos] >> 22)
+                            | ((@in[6 + inpos] & 7) << (13 - 3));
+        @out[15 + outpos] = (int)(((uint)@in[6 + inpos] >> 3) & 8191);
+        @out[16 + outpos] = (int)(((uint)@in[6 + inpos] >> 16) & 8191);
+        @out[17 + outpos] = (int)((uint)@in[6 + inpos] >> 29)
+                            | ((@in[7 + inpos] & 1023) << (13 - 10));
+        @out[18 + outpos] = (int)(((uint)@in[7 + inpos] >> 10) & 8191);
+        @out[19 + outpos] = (int)((uint)@in[7 + inpos] >> 23)
+                            | ((@in[8 + inpos] & 15) << (13 - 4));
+        @out[20 + outpos] = (int)(((uint)@in[8 + inpos] >> 4) & 8191);
+        @out[21 + outpos] = (int)(((uint)@in[8 + inpos] >> 17) & 8191);
+        @out[22 + outpos] = (int)((uint)@in[8 + inpos] >> 30)
+                            | ((@in[9 + inpos] & 2047) << (13 - 11));
+        @out[23 + outpos] = (int)(((uint)@in[9 + inpos] >> 11) & 8191);
+        @out[24 + outpos] = (int)((uint)@in[9 + inpos] >> 24)
+                            | ((@in[10 + inpos] & 31) << (13 - 5));
+        @out[25 + outpos] = (int)(((uint)@in[10 + inpos] >> 5) & 8191);
+        @out[26 + outpos] = (int)(((uint)@in[10 + inpos] >> 18) & 8191);
+        @out[27 + outpos] = (int)((uint)@in[10 + inpos] >> 31)
+                            | ((@in[11 + inpos] & 4095) << (13 - 12));
+        @out[28 + outpos] = (int)(((uint)@in[11 + inpos] >> 12) & 8191);
+        @out[29 + outpos] = (int)((uint)@in[11 + inpos] >> 25)
+                            | ((@in[12 + inpos] & 63) << (13 - 6));
+        @out[30 + outpos] = (int)(((uint)@in[12 + inpos] >> 6) & 8191);
+        @out[31 + outpos] = (int)((uint)@in[12 + inpos] >> 19);
+    }
+
+    protected static void fastunpack14(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 16383);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 14) & 16383);
+        @out[2 + outpos] = (int)((uint)@in[0 + inpos] >> 28)
+                           | ((@in[1 + inpos] & 1023) << (14 - 10));
+        @out[3 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 16383);
+        @out[4 + outpos] = (int)((uint)@in[1 + inpos] >> 24)
+                           | ((@in[2 + inpos] & 63) << (14 - 6));
+        @out[5 + outpos] = (int)(((uint)@in[2 + inpos] >> 6) & 16383);
+        @out[6 + outpos] = (int)((uint)@in[2 + inpos] >> 20)
+                           | ((@in[3 + inpos] & 3) << (14 - 2));
+        @out[7 + outpos] = (int)(((uint)@in[3 + inpos] >> 2) & 16383);
+        @out[8 + outpos] = (int)(((uint)@in[3 + inpos] >> 16) & 16383);
+        @out[9 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
+                           | ((@in[4 + inpos] & 4095) << (14 - 12));
+        @out[10 + outpos] = (int)(((uint)@in[4 + inpos] >> 12) & 16383);
+        @out[11 + outpos] = (int)((uint)@in[4 + inpos] >> 26)
+                            | ((@in[5 + inpos] & 255) << (14 - 8));
+        @out[12 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 16383);
+        @out[13 + outpos] = (int)((uint)@in[5 + inpos] >> 22)
+                            | ((@in[6 + inpos] & 15) << (14 - 4));
+        @out[14 + outpos] = (int)(((uint)@in[6 + inpos] >> 4) & 16383);
+        @out[15 + outpos] = (int)((uint)@in[6 + inpos] >> 18);
+        @out[16 + outpos] = (int)(((uint)@in[7 + inpos] >> 0) & 16383);
+        @out[17 + outpos] = (int)(((uint)@in[7 + inpos] >> 14) & 16383);
+        @out[18 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
+                            | ((@in[8 + inpos] & 1023) << (14 - 10));
+        @out[19 + outpos] = (int)(((uint)@in[8 + inpos] >> 10) & 16383);
+        @out[20 + outpos] = (int)((uint)@in[8 + inpos] >> 24)
+                            | ((@in[9 + inpos] & 63) << (14 - 6));
+        @out[21 + outpos] = (int)(((uint)@in[9 + inpos] >> 6) & 16383);
+        @out[22 + outpos] = (int)((uint)@in[9 + inpos] >> 20)
+                            | ((@in[10 + inpos] & 3) << (14 - 2));
+        @out[23 + outpos] = (int)(((uint)@in[10 + inpos] >> 2) & 16383);
+        @out[24 + outpos] = (int)(((uint)@in[10 + inpos] >> 16) & 16383);
+        @out[25 + outpos] = (int)((uint)@in[10 + inpos] >> 30)
+                            | ((@in[11 + inpos] & 4095) << (14 - 12));
+        @out[26 + outpos] = (int)(((uint)@in[11 + inpos] >> 12) & 16383);
+        @out[27 + outpos] = (int)((uint)@in[11 + inpos] >> 26)
+                            | ((@in[12 + inpos] & 255) << (14 - 8));
+        @out[28 + outpos] = (int)(((uint)@in[12 + inpos] >> 8) & 16383);
+        @out[29 + outpos] = (int)((uint)@in[12 + inpos] >> 22)
+                            | ((@in[13 + inpos] & 15) << (14 - 4));
+        @out[30 + outpos] = (int)(((uint)@in[13 + inpos] >> 4) & 16383);
+        @out[31 + outpos] = (int)((uint)@in[13 + inpos] >> 18);
+    }
+
+    protected static void fastunpack15(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 32767);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 15) & 32767);
+        @out[2 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
+                           | ((@in[1 + inpos] & 8191) << (15 - 13));
+        @out[3 + outpos] = (int)(((uint)@in[1 + inpos] >> 13) & 32767);
+        @out[4 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
+                           | ((@in[2 + inpos] & 2047) << (15 - 11));
+        @out[5 + outpos] = (int)(((uint)@in[2 + inpos] >> 11) & 32767);
+        @out[6 + outpos] = (int)((uint)@in[2 + inpos] >> 26)
+                           | ((@in[3 + inpos] & 511) << (15 - 9));
+        @out[7 + outpos] = (int)(((uint)@in[3 + inpos] >> 9) & 32767);
+        @out[8 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
+                           | ((@in[4 + inpos] & 127) << (15 - 7));
+        @out[9 + outpos] = (int)(((uint)@in[4 + inpos] >> 7) & 32767);
+        @out[10 + outpos] = (int)((uint)@in[4 + inpos] >> 22)
+                            | ((@in[5 + inpos] & 31) << (15 - 5));
+        @out[11 + outpos] = (int)(((uint)@in[5 + inpos] >> 5) & 32767);
+        @out[12 + outpos] = (int)((uint)@in[5 + inpos] >> 20)
+                            | ((@in[6 + inpos] & 7) << (15 - 3));
+        @out[13 + outpos] = (int)(((uint)@in[6 + inpos] >> 3) & 32767);
+        @out[14 + outpos] = (int)((uint)@in[6 + inpos] >> 18)
+                            | ((@in[7 + inpos] & 1) << (15 - 1));
+        @out[15 + outpos] = (int)(((uint)@in[7 + inpos] >> 1) & 32767);
+        @out[16 + outpos] = (int)(((uint)@in[7 + inpos] >> 16) & 32767);
+        @out[17 + outpos] = (int)((uint)@in[7 + inpos] >> 31)
+                            | ((@in[8 + inpos] & 16383) << (15 - 14));
+        @out[18 + outpos] = (int)(((uint)@in[8 + inpos] >> 14) & 32767);
+        @out[19 + outpos] = (int)((uint)@in[8 + inpos] >> 29)
+                            | ((@in[9 + inpos] & 4095) << (15 - 12));
+        @out[20 + outpos] = (int)(((uint)@in[9 + inpos] >> 12) & 32767);
+        @out[21 + outpos] = (int)((uint)@in[9 + inpos] >> 27)
+                            | ((@in[10 + inpos] & 1023) << (15 - 10));
+        @out[22 + outpos] = (int)(((uint)@in[10 + inpos] >> 10) & 32767);
+        @out[23 + outpos] = (int)((uint)@in[10 + inpos] >> 25)
+                            | ((@in[11 + inpos] & 255) << (15 - 8));
+        @out[24 + outpos] = (int)(((uint)@in[11 + inpos] >> 8) & 32767);
+        @out[25 + outpos] = (int)((uint)@in[11 + inpos] >> 23)
+                            | ((@in[12 + inpos] & 63) << (15 - 6));
+        @out[26 + outpos] = (int)(((uint)@in[12 + inpos] >> 6) & 32767);
+        @out[27 + outpos] = (int)((uint)@in[12 + inpos] >> 21)
+                            | ((@in[13 + inpos] & 15) << (15 - 4));
+        @out[28 + outpos] = (int)(((uint)@in[13 + inpos] >> 4) & 32767);
+        @out[29 + outpos] = (int)((uint)@in[13 + inpos] >> 19)
+                            | ((@in[14 + inpos] & 3) << (15 - 2));
+        @out[30 + outpos] = (int)(((uint)@in[14 + inpos] >> 2) & 32767);
+        @out[31 + outpos] = (int)((uint)@in[14 + inpos] >> 17);
+    }
+
+    protected static void fastunpack16(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 65535);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 16);
+        @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 0) & 65535);
+        @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 16);
+        @out[4 + outpos] = (int)(((uint)@in[2 + inpos] >> 0) & 65535);
+        @out[5 + outpos] = (int)((uint)@in[2 + inpos] >> 16);
+        @out[6 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 65535);
+        @out[7 + outpos] = (int)((uint)@in[3 + inpos] >> 16);
+        @out[8 + outpos] = (int)(((uint)@in[4 + inpos] >> 0) & 65535);
+        @out[9 + outpos] = (int)((uint)@in[4 + inpos] >> 16);
+        @out[10 + outpos] = (int)(((uint)@in[5 + inpos] >> 0) & 65535);
+        @out[11 + outpos] = (int)((uint)@in[5 + inpos] >> 16);
+        @out[12 + outpos] = (int)(((uint)@in[6 + inpos] >> 0) & 65535);
+        @out[13 + outpos] = (int)((uint)@in[6 + inpos] >> 16);
+        @out[14 + outpos] = (int)(((uint)@in[7 + inpos] >> 0) & 65535);
+        @out[15 + outpos] = (int)((uint)@in[7 + inpos] >> 16);
+        @out[16 + outpos] = (int)(((uint)@in[8 + inpos] >> 0) & 65535);
+        @out[17 + outpos] = (int)((uint)@in[8 + inpos] >> 16);
+        @out[18 + outpos] = (int)(((uint)@in[9 + inpos] >> 0) & 65535);
+        @out[19 + outpos] = (int)((uint)@in[9 + inpos] >> 16);
+        @out[20 + outpos] = (int)(((uint)@in[10 + inpos] >> 0) & 65535);
+        @out[21 + outpos] = (int)((uint)@in[10 + inpos] >> 16);
+        @out[22 + outpos] = (int)(((uint)@in[11 + inpos] >> 0) & 65535);
+        @out[23 + outpos] = (int)((uint)@in[11 + inpos] >> 16);
+        @out[24 + outpos] = (int)(((uint)@in[12 + inpos] >> 0) & 65535);
+        @out[25 + outpos] = (int)((uint)@in[12 + inpos] >> 16);
+        @out[26 + outpos] = (int)(((uint)@in[13 + inpos] >> 0) & 65535);
+        @out[27 + outpos] = (int)((uint)@in[13 + inpos] >> 16);
+        @out[28 + outpos] = (int)(((uint)@in[14 + inpos] >> 0) & 65535);
+        @out[29 + outpos] = (int)((uint)@in[14 + inpos] >> 16);
+        @out[30 + outpos] = (int)(((uint)@in[15 + inpos] >> 0) & 65535);
+        @out[31 + outpos] = (int)((uint)@in[15 + inpos] >> 16);
+    }
+
+    protected static void fastunpack17(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 131071);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 17)
+                           | ((@in[1 + inpos] & 3) << (17 - 2));
+        @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 2) & 131071);
+        @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 19)
+                           | ((@in[2 + inpos] & 15) << (17 - 4));
+        @out[4 + outpos] = (int)(((uint)@in[2 + inpos] >> 4) & 131071);
+        @out[5 + outpos] = (int)((uint)@in[2 + inpos] >> 21)
+                           | ((@in[3 + inpos] & 63) << (17 - 6));
+        @out[6 + outpos] = (int)(((uint)@in[3 + inpos] >> 6) & 131071);
+        @out[7 + outpos] = (int)((uint)@in[3 + inpos] >> 23)
+                           | ((@in[4 + inpos] & 255) << (17 - 8));
+        @out[8 + outpos] = (int)(((uint)@in[4 + inpos] >> 8) & 131071);
+        @out[9 + outpos] = (int)((uint)@in[4 + inpos] >> 25)
+                           | ((@in[5 + inpos] & 1023) << (17 - 10));
+        @out[10 + outpos] = (int)(((uint)@in[5 + inpos] >> 10) & 131071);
+        @out[11 + outpos] = (int)((uint)@in[5 + inpos] >> 27)
+                            | ((@in[6 + inpos] & 4095) << (17 - 12));
+        @out[12 + outpos] = (int)(((uint)@in[6 + inpos] >> 12) & 131071);
+        @out[13 + outpos] = (int)((uint)@in[6 + inpos] >> 29)
+                            | ((@in[7 + inpos] & 16383) << (17 - 14));
+        @out[14 + outpos] = (int)(((uint)@in[7 + inpos] >> 14) & 131071);
+        @out[15 + outpos] = (int)((uint)@in[7 + inpos] >> 31)
+                            | ((@in[8 + inpos] & 65535) << (17 - 16));
+        @out[16 + outpos] = (int)((uint)@in[8 + inpos] >> 16)
+                            | ((@in[9 + inpos] & 1) << (17 - 1));
+        @out[17 + outpos] = (int)(((uint)@in[9 + inpos] >> 1) & 131071);
+        @out[18 + outpos] = (int)((uint)@in[9 + inpos] >> 18)
+                            | ((@in[10 + inpos] & 7) << (17 - 3));
+        @out[19 + outpos] = (int)(((uint)@in[10 + inpos] >> 3) & 131071);
+        @out[20 + outpos] = (int)((uint)@in[10 + inpos] >> 20)
+                            | ((@in[11 + inpos] & 31) << (17 - 5));
+        @out[21 + outpos] = (int)(((uint)@in[11 + inpos] >> 5) & 131071);
+        @out[22 + outpos] = (int)((uint)@in[11 + inpos] >> 22)
+                            | ((@in[12 + inpos] & 127) << (17 - 7));
+        @out[23 + outpos] = (int)(((uint)@in[12 + inpos] >> 7) & 131071);
+        @out[24 + outpos] = (int)((uint)@in[12 + inpos] >> 24)
+                            | ((@in[13 + inpos] & 511) << (17 - 9));
+        @out[25 + outpos] = (int)(((uint)@in[13 + inpos] >> 9) & 131071);
+        @out[26 + outpos] = (int)((uint)@in[13 + inpos] >> 26)
+                            | ((@in[14 + inpos] & 2047) << (17 - 11));
+        @out[27 + outpos] = (int)(((uint)@in[14 + inpos] >> 11) & 131071);
+        @out[28 + outpos] = (int)((uint)@in[14 + inpos] >> 28)
+                            | ((@in[15 + inpos] & 8191) << (17 - 13));
+        @out[29 + outpos] = (int)(((uint)@in[15 + inpos] >> 13) & 131071);
+        @out[30 + outpos] = (int)((uint)@in[15 + inpos] >> 30)
+                            | ((@in[16 + inpos] & 32767) << (17 - 15));
+        @out[31 + outpos] = (int)((uint)@in[16 + inpos] >> 15);
+    }
+
+    protected static void fastunpack18(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 262143);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 18)
+                           | ((@in[1 + inpos] & 15) << (18 - 4));
+        @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 262143);
+        @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 22)
+                           | ((@in[2 + inpos] & 255) << (18 - 8));
+        @out[4 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 262143);
+        @out[5 + outpos] = (int)((uint)@in[2 + inpos] >> 26)
+                           | ((@in[3 + inpos] & 4095) << (18 - 12));
+        @out[6 + outpos] = (int)(((uint)@in[3 + inpos] >> 12) & 262143);
+        @out[7 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
+                           | ((@in[4 + inpos] & 65535) << (18 - 16));
+        @out[8 + outpos] = (int)((uint)@in[4 + inpos] >> 16)
+                           | ((@in[5 + inpos] & 3) << (18 - 2));
+        @out[9 + outpos] = (int)(((uint)@in[5 + inpos] >> 2) & 262143);
+        @out[10 + outpos] = (int)((uint)@in[5 + inpos] >> 20)
+                            | ((@in[6 + inpos] & 63) << (18 - 6));
+        @out[11 + outpos] = (int)(((uint)@in[6 + inpos] >> 6) & 262143);
+        @out[12 + outpos] = (int)((uint)@in[6 + inpos] >> 24)
+                            | ((@in[7 + inpos] & 1023) << (18 - 10));
+        @out[13 + outpos] = (int)(((uint)@in[7 + inpos] >> 10) & 262143);
+        @out[14 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
+                            | ((@in[8 + inpos] & 16383) << (18 - 14));
+        @out[15 + outpos] = (int)((uint)@in[8 + inpos] >> 14);
+        @out[16 + outpos] = (int)(((uint)@in[9 + inpos] >> 0) & 262143);
+        @out[17 + outpos] = (int)((uint)@in[9 + inpos] >> 18)
+                            | ((@in[10 + inpos] & 15) << (18 - 4));
+        @out[18 + outpos] = (int)(((uint)@in[10 + inpos] >> 4) & 262143);
+        @out[19 + outpos] = (int)((uint)@in[10 + inpos] >> 22)
+                            | ((@in[11 + inpos] & 255) << (18 - 8));
+        @out[20 + outpos] = (int)(((uint)@in[11 + inpos] >> 8) & 262143);
+        @out[21 + outpos] = (int)((uint)@in[11 + inpos] >> 26)
+                            | ((@in[12 + inpos] & 4095) << (18 - 12));
+        @out[22 + outpos] = (int)(((uint)@in[12 + inpos] >> 12) & 262143);
+        @out[23 + outpos] = (int)((uint)@in[12 + inpos] >> 30)
+                            | ((@in[13 + inpos] & 65535) << (18 - 16));
+        @out[24 + outpos] = (int)((uint)@in[13 + inpos] >> 16)
+                            | ((@in[14 + inpos] & 3) << (18 - 2));
+        @out[25 + outpos] = (int)(((uint)@in[14 + inpos] >> 2) & 262143);
+        @out[26 + outpos] = (int)((uint)@in[14 + inpos] >> 20)
+                            | ((@in[15 + inpos] & 63) << (18 - 6));
+        @out[27 + outpos] = (int)(((uint)@in[15 + inpos] >> 6) & 262143);
+        @out[28 + outpos] = (int)((uint)@in[15 + inpos] >> 24)
+                            | ((@in[16 + inpos] & 1023) << (18 - 10));
+        @out[29 + outpos] = (int)(((uint)@in[16 + inpos] >> 10) & 262143);
+        @out[30 + outpos] = (int)((uint)@in[16 + inpos] >> 28)
+                            | ((@in[17 + inpos] & 16383) << (18 - 14));
+        @out[31 + outpos] = (int)((uint)@in[17 + inpos] >> 14);
+    }
+
+    protected static void fastunpack19(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 524287);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 19)
+                           | ((@in[1 + inpos] & 63) << (19 - 6));
+        @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 6) & 524287);
+        @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 25)
+                           | ((@in[2 + inpos] & 4095) << (19 - 12));
+        @out[4 + outpos] = (int)(((uint)@in[2 + inpos] >> 12) & 524287);
+        @out[5 + outpos] = (int)((uint)@in[2 + inpos] >> 31)
+                           | ((@in[3 + inpos] & 262143) << (19 - 18));
+        @out[6 + outpos] = (int)((uint)@in[3 + inpos] >> 18)
+                           | ((@in[4 + inpos] & 31) << (19 - 5));
+        @out[7 + outpos] = (int)(((uint)@in[4 + inpos] >> 5) & 524287);
+        @out[8 + outpos] = (int)((uint)@in[4 + inpos] >> 24)
+                           | ((@in[5 + inpos] & 2047) << (19 - 11));
+        @out[9 + outpos] = (int)(((uint)@in[5 + inpos] >> 11) & 524287);
+        @out[10 + outpos] = (int)((uint)@in[5 + inpos] >> 30)
+                            | ((@in[6 + inpos] & 131071) << (19 - 17));
+        @out[11 + outpos] = (int)((uint)@in[6 + inpos] >> 17)
+                            | ((@in[7 + inpos] & 15) << (19 - 4));
+        @out[12 + outpos] = (int)(((uint)@in[7 + inpos] >> 4) & 524287);
+        @out[13 + outpos] = (int)((uint)@in[7 + inpos] >> 23)
+                            | ((@in[8 + inpos] & 1023) << (19 - 10));
+        @out[14 + outpos] = (int)(((uint)@in[8 + inpos] >> 10) & 524287);
+        @out[15 + outpos] = (int)((uint)@in[8 + inpos] >> 29)
+                            | ((@in[9 + inpos] & 65535) << (19 - 16));
+        @out[16 + outpos] = (int)((uint)@in[9 + inpos] >> 16)
+                            | ((@in[10 + inpos] & 7) << (19 - 3));
+        @out[17 + outpos] = (int)(((uint)@in[10 + inpos] >> 3) & 524287);
+        @out[18 + outpos] = (int)((uint)@in[10 + inpos] >> 22)
+                            | ((@in[11 + inpos] & 511) << (19 - 9));
+        @out[19 + outpos] = (int)(((uint)@in[11 + inpos] >> 9) & 524287);
+        @out[20 + outpos] = (int)((uint)@in[11 + inpos] >> 28)
+                            | ((@in[12 + inpos] & 32767) << (19 - 15));
+        @out[21 + outpos] = (int)((uint)@in[12 + inpos] >> 15)
+                            | ((@in[13 + inpos] & 3) << (19 - 2));
+        @out[22 + outpos] = (int)(((uint)@in[13 + inpos] >> 2) & 524287);
+        @out[23 + outpos] = (int)((uint)@in[13 + inpos] >> 21)
+                            | ((@in[14 + inpos] & 255) << (19 - 8));
+        @out[24 + outpos] = (int)(((uint)@in[14 + inpos] >> 8) & 524287);
+        @out[25 + outpos] = (int)((uint)@in[14 + inpos] >> 27)
+                            | ((@in[15 + inpos] & 16383) << (19 - 14));
+        @out[26 + outpos] = (int)((uint)@in[15 + inpos] >> 14)
+                            | ((@in[16 + inpos] & 1) << (19 - 1));
+        @out[27 + outpos] = (int)(((uint)@in[16 + inpos] >> 1) & 524287);
+        @out[28 + outpos] = (int)((uint)@in[16 + inpos] >> 20)
+                            | ((@in[17 + inpos] & 127) << (19 - 7));
+        @out[29 + outpos] = (int)(((uint)@in[17 + inpos] >> 7) & 524287);
+        @out[30 + outpos] = (int)((uint)@in[17 + inpos] >> 26)
+                            | ((@in[18 + inpos] & 8191) << (19 - 13));
+        @out[31 + outpos] = (int)((uint)@in[18 + inpos] >> 13);
+    }
+
+    protected static void fastunpack2(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 3);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 2) & 3);
+        @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 4) & 3);
+        @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 6) & 3);
+        @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 8) & 3);
+        @out[5 + outpos] = (int)(((uint)@in[0 + inpos] >> 10) & 3);
+        @out[6 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 3);
+        @out[7 + outpos] = (int)(((uint)@in[0 + inpos] >> 14) & 3);
+        @out[8 + outpos] = (int)(((uint)@in[0 + inpos] >> 16) & 3);
+        @out[9 + outpos] = (int)(((uint)@in[0 + inpos] >> 18) & 3);
+        @out[10 + outpos] = (int)(((uint)@in[0 + inpos] >> 20) & 3);
+        @out[11 + outpos] = (int)(((uint)@in[0 + inpos] >> 22) & 3);
+        @out[12 + outpos] = (int)(((uint)@in[0 + inpos] >> 24) & 3);
+        @out[13 + outpos] = (int)(((uint)@in[0 + inpos] >> 26) & 3);
+        @out[14 + outpos] = (int)(((uint)@in[0 + inpos] >> 28) & 3);
+        @out[15 + outpos] = (int)((uint)@in[0 + inpos] >> 30);
+        @out[16 + outpos] = (int)(((uint)@in[1 + inpos] >> 0) & 3);
+        @out[17 + outpos] = (int)(((uint)@in[1 + inpos] >> 2) & 3);
+        @out[18 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 3);
+        @out[19 + outpos] = (int)(((uint)@in[1 + inpos] >> 6) & 3);
+        @out[20 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 3);
+        @out[21 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 3);
+        @out[22 + outpos] = (int)(((uint)@in[1 + inpos] >> 12) & 3);
+        @out[23 + outpos] = (int)(((uint)@in[1 + inpos] >> 14) & 3);
+        @out[24 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 3);
+        @out[25 + outpos] = (int)(((uint)@in[1 + inpos] >> 18) & 3);
+        @out[26 + outpos] = (int)(((uint)@in[1 + inpos] >> 20) & 3);
+        @out[27 + outpos] = (int)(((uint)@in[1 + inpos] >> 22) & 3);
+        @out[28 + outpos] = (int)(((uint)@in[1 + inpos] >> 24) & 3);
+        @out[29 + outpos] = (int)(((uint)@in[1 + inpos] >> 26) & 3);
+        @out[30 + outpos] = (int)(((uint)@in[1 + inpos] >> 28) & 3);
+        @out[31 + outpos] = (int)((uint)@in[1 + inpos] >> 30);
+    }
+
+    protected static void fastunpack20(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 1048575);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 20)
+                           | ((@in[1 + inpos] & 255) << (20 - 8));
+        @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 1048575);
+        @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
+                           | ((@in[2 + inpos] & 65535) << (20 - 16));
+        @out[4 + outpos] = (int)((uint)@in[2 + inpos] >> 16)
+                           | ((@in[3 + inpos] & 15) << (20 - 4));
+        @out[5 + outpos] = (int)(((uint)@in[3 + inpos] >> 4) & 1048575);
+        @out[6 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
+                           | ((@in[4 + inpos] & 4095) << (20 - 12));
+        @out[7 + outpos] = (int)((uint)@in[4 + inpos] >> 12);
+        @out[8 + outpos] = (int)(((uint)@in[5 + inpos] >> 0) & 1048575);
+        @out[9 + outpos] = (int)((uint)@in[5 + inpos] >> 20)
+                           | ((@in[6 + inpos] & 255) << (20 - 8));
+        @out[10 + outpos] = (int)(((uint)@in[6 + inpos] >> 8) & 1048575);
+        @out[11 + outpos] = (int)((uint)@in[6 + inpos] >> 28)
+                            | ((@in[7 + inpos] & 65535) << (20 - 16));
+        @out[12 + outpos] = (int)((uint)@in[7 + inpos] >> 16)
+                            | ((@in[8 + inpos] & 15) << (20 - 4));
+        @out[13 + outpos] = (int)(((uint)@in[8 + inpos] >> 4) & 1048575);
+        @out[14 + outpos] = (int)((uint)@in[8 + inpos] >> 24)
+                            | ((@in[9 + inpos] & 4095) << (20 - 12));
+        @out[15 + outpos] = (int)((uint)@in[9 + inpos] >> 12);
+        @out[16 + outpos] = (int)(((uint)@in[10 + inpos] >> 0) & 1048575);
+        @out[17 + outpos] = (int)((uint)@in[10 + inpos] >> 20)
+                            | ((@in[11 + inpos] & 255) << (20 - 8));
+        @out[18 + outpos] = (int)(((uint)@in[11 + inpos] >> 8) & 1048575);
+        @out[19 + outpos] = (int)((uint)@in[11 + inpos] >> 28)
+                            | ((@in[12 + inpos] & 65535) << (20 - 16));
+        @out[20 + outpos] = (int)((uint)@in[12 + inpos] >> 16)
+                            | ((@in[13 + inpos] & 15) << (20 - 4));
+        @out[21 + outpos] = (int)(((uint)@in[13 + inpos] >> 4) & 1048575);
+        @out[22 + outpos] = (int)((uint)@in[13 + inpos] >> 24)
+                            | ((@in[14 + inpos] & 4095) << (20 - 12));
+        @out[23 + outpos] = (int)((uint)@in[14 + inpos] >> 12);
+        @out[24 + outpos] = (int)(((uint)@in[15 + inpos] >> 0) & 1048575);
+        @out[25 + outpos] = (int)((uint)@in[15 + inpos] >> 20)
+                            | ((@in[16 + inpos] & 255) << (20 - 8));
+        @out[26 + outpos] = (int)(((uint)@in[16 + inpos] >> 8) & 1048575);
+        @out[27 + outpos] = (int)((uint)@in[16 + inpos] >> 28)
+                            | ((@in[17 + inpos] & 65535) << (20 - 16));
+        @out[28 + outpos] = (int)((uint)@in[17 + inpos] >> 16)
+                            | ((@in[18 + inpos] & 15) << (20 - 4));
+        @out[29 + outpos] = (int)(((uint)@in[18 + inpos] >> 4) & 1048575);
+        @out[30 + outpos] = (int)((uint)@in[18 + inpos] >> 24)
+                            | ((@in[19 + inpos] & 4095) << (20 - 12));
+        @out[31 + outpos] = (int)((uint)@in[19 + inpos] >> 12);
+    }
+
+    protected static void fastunpack21(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 2097151);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 21)
+                           | ((@in[1 + inpos] & 1023) << (21 - 10));
+        @out[2 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 2097151);
+        @out[3 + outpos] = (int)((uint)@in[1 + inpos] >> 31)
+                           | ((@in[2 + inpos] & 1048575) << (21 - 20));
+        @out[4 + outpos] = (int)((uint)@in[2 + inpos] >> 20)
+                           | ((@in[3 + inpos] & 511) << (21 - 9));
+        @out[5 + outpos] = (int)(((uint)@in[3 + inpos] >> 9) & 2097151);
+        @out[6 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
+                           | ((@in[4 + inpos] & 524287) << (21 - 19));
+        @out[7 + outpos] = (int)((uint)@in[4 + inpos] >> 19)
+                           | ((@in[5 + inpos] & 255) << (21 - 8));
+        @out[8 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 2097151);
+        @out[9 + outpos] = (int)((uint)@in[5 + inpos] >> 29)
+                           | ((@in[6 + inpos] & 262143) << (21 - 18));
+        @out[10 + outpos] = (int)((uint)@in[6 + inpos] >> 18)
+                            | ((@in[7 + inpos] & 127) << (21 - 7));
+        @out[11 + outpos] = (int)(((uint)@in[7 + inpos] >> 7) & 2097151);
+        @out[12 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
+                            | ((@in[8 + inpos] & 131071) << (21 - 17));
+        @out[13 + outpos] = (int)((uint)@in[8 + inpos] >> 17)
+                            | ((@in[9 + inpos] & 63) << (21 - 6));
+        @out[14 + outpos] = (int)(((uint)@in[9 + inpos] >> 6) & 2097151);
+        @out[15 + outpos] = (int)((uint)@in[9 + inpos] >> 27)
+                            | ((@in[10 + inpos] & 65535) << (21 - 16));
+        @out[16 + outpos] = (int)((uint)@in[10 + inpos] >> 16)
+                            | ((@in[11 + inpos] & 31) << (21 - 5));
+        @out[17 + outpos] = (int)(((uint)@in[11 + inpos] >> 5) & 2097151);
+        @out[18 + outpos] = (int)((uint)@in[11 + inpos] >> 26)
+                            | ((@in[12 + inpos] & 32767) << (21 - 15));
+        @out[19 + outpos] = (int)((uint)@in[12 + inpos] >> 15)
+                            | ((@in[13 + inpos] & 15) << (21 - 4));
+        @out[20 + outpos] = (int)(((uint)@in[13 + inpos] >> 4) & 2097151);
+        @out[21 + outpos] = (int)((uint)@in[13 + inpos] >> 25)
+                            | ((@in[14 + inpos] & 16383) << (21 - 14));
+        @out[22 + outpos] = (int)((uint)@in[14 + inpos] >> 14)
+                            | ((@in[15 + inpos] & 7) << (21 - 3));
+        @out[23 + outpos] = (int)(((uint)@in[15 + inpos] >> 3) & 2097151);
+        @out[24 + outpos] = (int)((uint)@in[15 + inpos] >> 24)
+                            | ((@in[16 + inpos] & 8191) << (21 - 13));
+        @out[25 + outpos] = (int)((uint)@in[16 + inpos] >> 13)
+                            | ((@in[17 + inpos] & 3) << (21 - 2));
+        @out[26 + outpos] = (int)(((uint)@in[17 + inpos] >> 2) & 2097151);
+        @out[27 + outpos] = (int)((uint)@in[17 + inpos] >> 23)
+                            | ((@in[18 + inpos] & 4095) << (21 - 12));
+        @out[28 + outpos] = (int)((uint)@in[18 + inpos] >> 12)
+                            | ((@in[19 + inpos] & 1) << (21 - 1));
+        @out[29 + outpos] = (int)(((uint)@in[19 + inpos] >> 1) & 2097151);
+        @out[30 + outpos] = (int)((uint)@in[19 + inpos] >> 22)
+                            | ((@in[20 + inpos] & 2047) << (21 - 11));
+        @out[31 + outpos] = (int)((uint)@in[20 + inpos] >> 11);
+    }
+
+    protected static void fastunpack22(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 4194303);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 22)
+                           | ((@in[1 + inpos] & 4095) << (22 - 12));
+        @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 12)
+                           | ((@in[2 + inpos] & 3) << (22 - 2));
+        @out[3 + outpos] = (int)(((uint)@in[2 + inpos] >> 2) & 4194303);
+        @out[4 + outpos] = (int)((uint)@in[2 + inpos] >> 24)
+                           | ((@in[3 + inpos] & 16383) << (22 - 14));
+        @out[5 + outpos] = (int)((uint)@in[3 + inpos] >> 14)
+                           | ((@in[4 + inpos] & 15) << (22 - 4));
+        @out[6 + outpos] = (int)(((uint)@in[4 + inpos] >> 4) & 4194303);
+        @out[7 + outpos] = (int)((uint)@in[4 + inpos] >> 26)
+                           | ((@in[5 + inpos] & 65535) << (22 - 16));
+        @out[8 + outpos] = (int)((uint)@in[5 + inpos] >> 16)
+                           | ((@in[6 + inpos] & 63) << (22 - 6));
+        @out[9 + outpos] = (int)(((uint)@in[6 + inpos] >> 6) & 4194303);
+        @out[10 + outpos] = (int)((uint)@in[6 + inpos] >> 28)
+                            | ((@in[7 + inpos] & 262143) << (22 - 18));
+        @out[11 + outpos] = (int)((uint)@in[7 + inpos] >> 18)
+                            | ((@in[8 + inpos] & 255) << (22 - 8));
+        @out[12 + outpos] = (int)(((uint)@in[8 + inpos] >> 8) & 4194303);
+        @out[13 + outpos] = (int)((uint)@in[8 + inpos] >> 30)
+                            | ((@in[9 + inpos] & 1048575) << (22 - 20));
+        @out[14 + outpos] = (int)((uint)@in[9 + inpos] >> 20)
+                            | ((@in[10 + inpos] & 1023) << (22 - 10));
+        @out[15 + outpos] = (int)((uint)@in[10 + inpos] >> 10);
+        @out[16 + outpos] = (int)(((uint)@in[11 + inpos] >> 0) & 4194303);
+        @out[17 + outpos] = (int)((uint)@in[11 + inpos] >> 22)
+                            | ((@in[12 + inpos] & 4095) << (22 - 12));
+        @out[18 + outpos] = (int)((uint)@in[12 + inpos] >> 12)
+                            | ((@in[13 + inpos] & 3) << (22 - 2));
+        @out[19 + outpos] = (int)(((uint)@in[13 + inpos] >> 2) & 4194303);
+        @out[20 + outpos] = (int)((uint)@in[13 + inpos] >> 24)
+                            | ((@in[14 + inpos] & 16383) << (22 - 14));
+        @out[21 + outpos] = (int)((uint)@in[14 + inpos] >> 14)
+                            | ((@in[15 + inpos] & 15) << (22 - 4));
+        @out[22 + outpos] = (int)(((uint)@in[15 + inpos] >> 4) & 4194303);
+        @out[23 + outpos] = (int)((uint)@in[15 + inpos] >> 26)
+                            | ((@in[16 + inpos] & 65535) << (22 - 16));
+        @out[24 + outpos] = (int)((uint)@in[16 + inpos] >> 16)
+                            | ((@in[17 + inpos] & 63) << (22 - 6));
+        @out[25 + outpos] = (int)(((uint)@in[17 + inpos] >> 6) & 4194303);
+        @out[26 + outpos] = (int)((uint)@in[17 + inpos] >> 28)
+                            | ((@in[18 + inpos] & 262143) << (22 - 18));
+        @out[27 + outpos] = (int)((uint)@in[18 + inpos] >> 18)
+                            | ((@in[19 + inpos] & 255) << (22 - 8));
+        @out[28 + outpos] = (int)(((uint)@in[19 + inpos] >> 8) & 4194303);
+        @out[29 + outpos] = (int)((uint)@in[19 + inpos] >> 30)
+                            | ((@in[20 + inpos] & 1048575) << (22 - 20));
+        @out[30 + outpos] = (int)((uint)@in[20 + inpos] >> 20)
+                            | ((@in[21 + inpos] & 1023) << (22 - 10));
+        @out[31 + outpos] = (int)((uint)@in[21 + inpos] >> 10);
+    }
+
+    protected static void fastunpack23(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 8388607);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 23)
+                           | ((@in[1 + inpos] & 16383) << (23 - 14));
+        @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 14)
+                           | ((@in[2 + inpos] & 31) << (23 - 5));
+        @out[3 + outpos] = (int)(((uint)@in[2 + inpos] >> 5) & 8388607);
+        @out[4 + outpos] = (int)((uint)@in[2 + inpos] >> 28)
+                           | ((@in[3 + inpos] & 524287) << (23 - 19));
+        @out[5 + outpos] = (int)((uint)@in[3 + inpos] >> 19)
+                           | ((@in[4 + inpos] & 1023) << (23 - 10));
+        @out[6 + outpos] = (int)((uint)@in[4 + inpos] >> 10)
+                           | ((@in[5 + inpos] & 1) << (23 - 1));
+        @out[7 + outpos] = (int)(((uint)@in[5 + inpos] >> 1) & 8388607);
+        @out[8 + outpos] = (int)((uint)@in[5 + inpos] >> 24)
+                           | ((@in[6 + inpos] & 32767) << (23 - 15));
+        @out[9 + outpos] = (int)((uint)@in[6 + inpos] >> 15)
+                           | ((@in[7 + inpos] & 63) << (23 - 6));
+        @out[10 + outpos] = (int)(((uint)@in[7 + inpos] >> 6) & 8388607);
+        @out[11 + outpos] = (int)((uint)@in[7 + inpos] >> 29)
+                            | ((@in[8 + inpos] & 1048575) << (23 - 20));
+        @out[12 + outpos] = (int)((uint)@in[8 + inpos] >> 20)
+                            | ((@in[9 + inpos] & 2047) << (23 - 11));
+        @out[13 + outpos] = (int)((uint)@in[9 + inpos] >> 11)
+                            | ((@in[10 + inpos] & 3) << (23 - 2));
+        @out[14 + outpos] = (int)(((uint)@in[10 + inpos] >> 2) & 8388607);
+        @out[15 + outpos] = (int)((uint)@in[10 + inpos] >> 25)
+                            | ((@in[11 + inpos] & 65535) << (23 - 16));
+        @out[16 + outpos] = (int)((uint)@in[11 + inpos] >> 16)
+                            | ((@in[12 + inpos] & 127) << (23 - 7));
+        @out[17 + outpos] = (int)(((uint)@in[12 + inpos] >> 7) & 8388607);
+        @out[18 + outpos] = (int)((uint)@in[12 + inpos] >> 30)
+                            | ((@in[13 + inpos] & 2097151) << (23 - 21));
+        @out[19 + outpos] = (int)((uint)@in[13 + inpos] >> 21)
+                            | ((@in[14 + inpos] & 4095) << (23 - 12));
+        @out[20 + outpos] = (int)((uint)@in[14 + inpos] >> 12)
+                            | ((@in[15 + inpos] & 7) << (23 - 3));
+        @out[21 + outpos] = (int)(((uint)@in[15 + inpos] >> 3) & 8388607);
+        @out[22 + outpos] = (int)((uint)@in[15 + inpos] >> 26)
+                            | ((@in[16 + inpos] & 131071) << (23 - 17));
+        @out[23 + outpos] = (int)((uint)@in[16 + inpos] >> 17)
+                            | ((@in[17 + inpos] & 255) << (23 - 8));
+        @out[24 + outpos] = (int)(((uint)@in[17 + inpos] >> 8) & 8388607);
+        @out[25 + outpos] = (int)((uint)@in[17 + inpos] >> 31)
+                            | ((@in[18 + inpos] & 4194303) << (23 - 22));
+        @out[26 + outpos] = (int)((uint)@in[18 + inpos] >> 22)
+                            | ((@in[19 + inpos] & 8191) << (23 - 13));
+        @out[27 + outpos] = (int)((uint)@in[19 + inpos] >> 13)
+                            | ((@in[20 + inpos] & 15) << (23 - 4));
+        @out[28 + outpos] = (int)(((uint)@in[20 + inpos] >> 4) & 8388607);
+        @out[29 + outpos] = (int)((uint)@in[20 + inpos] >> 27)
+                            | ((@in[21 + inpos] & 262143) << (23 - 18));
+        @out[30 + outpos] = (int)((uint)@in[21 + inpos] >> 18)
+                            | ((@in[22 + inpos] & 511) << (23 - 9));
+        @out[31 + outpos] = (int)((uint)@in[22 + inpos] >> 9);
+    }
+
+    protected static void fastunpack24(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 16777215);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 24)
+                           | ((@in[1 + inpos] & 65535) << (24 - 16));
+        @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 16)
+                           | ((@in[2 + inpos] & 255) << (24 - 8));
+        @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 8);
+        @out[4 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 16777215);
+        @out[5 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
+                           | ((@in[4 + inpos] & 65535) << (24 - 16));
+        @out[6 + outpos] = (int)((uint)@in[4 + inpos] >> 16)
+                           | ((@in[5 + inpos] & 255) << (24 - 8));
+        @out[7 + outpos] = (int)((uint)@in[5 + inpos] >> 8);
+        @out[8 + outpos] = (int)(((uint)@in[6 + inpos] >> 0) & 16777215);
+        @out[9 + outpos] = (int)((uint)@in[6 + inpos] >> 24)
+                           | ((@in[7 + inpos] & 65535) << (24 - 16));
+        @out[10 + outpos] = (int)((uint)@in[7 + inpos] >> 16)
+                            | ((@in[8 + inpos] & 255) << (24 - 8));
+        @out[11 + outpos] = (int)((uint)@in[8 + inpos] >> 8);
+        @out[12 + outpos] = (int)(((uint)@in[9 + inpos] >> 0) & 16777215);
+        @out[13 + outpos] = (int)((uint)@in[9 + inpos] >> 24)
+                            | ((@in[10 + inpos] & 65535) << (24 - 16));
+        @out[14 + outpos] = (int)((uint)@in[10 + inpos] >> 16)
+                            | ((@in[11 + inpos] & 255) << (24 - 8));
+        @out[15 + outpos] = (int)((uint)@in[11 + inpos] >> 8);
+        @out[16 + outpos] = (int)(((uint)@in[12 + inpos] >> 0) & 16777215);
+        @out[17 + outpos] = (int)((uint)@in[12 + inpos] >> 24)
+                            | ((@in[13 + inpos] & 65535) << (24 - 16));
+        @out[18 + outpos] = (int)((uint)@in[13 + inpos] >> 16)
+                            | ((@in[14 + inpos] & 255) << (24 - 8));
+        @out[19 + outpos] = (int)((uint)@in[14 + inpos] >> 8);
+        @out[20 + outpos] = (int)(((uint)@in[15 + inpos] >> 0) & 16777215);
+        @out[21 + outpos] = (int)((uint)@in[15 + inpos] >> 24)
+                            | ((@in[16 + inpos] & 65535) << (24 - 16));
+        @out[22 + outpos] = (int)((uint)@in[16 + inpos] >> 16)
+                            | ((@in[17 + inpos] & 255) << (24 - 8));
+        @out[23 + outpos] = (int)((uint)@in[17 + inpos] >> 8);
+        @out[24 + outpos] = (int)(((uint)@in[18 + inpos] >> 0) & 16777215);
+        @out[25 + outpos] = (int)((uint)@in[18 + inpos] >> 24)
+                            | ((@in[19 + inpos] & 65535) << (24 - 16));
+        @out[26 + outpos] = (int)((uint)@in[19 + inpos] >> 16)
+                            | ((@in[20 + inpos] & 255) << (24 - 8));
+        @out[27 + outpos] = (int)((uint)@in[20 + inpos] >> 8);
+        @out[28 + outpos] = (int)(((uint)@in[21 + inpos] >> 0) & 16777215);
+        @out[29 + outpos] = (int)((uint)@in[21 + inpos] >> 24)
+                            | ((@in[22 + inpos] & 65535) << (24 - 16));
+        @out[30 + outpos] = (int)((uint)@in[22 + inpos] >> 16)
+                            | ((@in[23 + inpos] & 255) << (24 - 8));
+        @out[31 + outpos] = (int)((uint)@in[23 + inpos] >> 8);
+    }
+
+    protected static void fastunpack25(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 33554431);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 25)
+                           | ((@in[1 + inpos] & 262143) << (25 - 18));
+        @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 18)
+                           | ((@in[2 + inpos] & 2047) << (25 - 11));
+        @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 11)
+                           | ((@in[3 + inpos] & 15) << (25 - 4));
+        @out[4 + outpos] = (int)(((uint)@in[3 + inpos] >> 4) & 33554431);
+        @out[5 + outpos] = (int)((uint)@in[3 + inpos] >> 29)
+                           | ((@in[4 + inpos] & 4194303) << (25 - 22));
+        @out[6 + outpos] = (int)((uint)@in[4 + inpos] >> 22)
+                           | ((@in[5 + inpos] & 32767) << (25 - 15));
+        @out[7 + outpos] = (int)((uint)@in[5 + inpos] >> 15)
+                           | ((@in[6 + inpos] & 255) << (25 - 8));
+        @out[8 + outpos] = (int)((uint)@in[6 + inpos] >> 8)
+                           | ((@in[7 + inpos] & 1) << (25 - 1));
+        @out[9 + outpos] = (int)(((uint)@in[7 + inpos] >> 1) & 33554431);
+        @out[10 + outpos] = (int)((uint)@in[7 + inpos] >> 26)
+                            | ((@in[8 + inpos] & 524287) << (25 - 19));
+        @out[11 + outpos] = (int)((uint)@in[8 + inpos] >> 19)
+                            | ((@in[9 + inpos] & 4095) << (25 - 12));
+        @out[12 + outpos] = (int)((uint)@in[9 + inpos] >> 12)
+                            | ((@in[10 + inpos] & 31) << (25 - 5));
+        @out[13 + outpos] = (int)(((uint)@in[10 + inpos] >> 5) & 33554431);
+        @out[14 + outpos] = (int)((uint)@in[10 + inpos] >> 30)
+                            | ((@in[11 + inpos] & 8388607) << (25 - 23));
+        @out[15 + outpos] = (int)((uint)@in[11 + inpos] >> 23)
+                            | ((@in[12 + inpos] & 65535) << (25 - 16));
+        @out[16 + outpos] = (int)((uint)@in[12 + inpos] >> 16)
+                            | ((@in[13 + inpos] & 511) << (25 - 9));
+        @out[17 + outpos] = (int)((uint)@in[13 + inpos] >> 9)
+                            | ((@in[14 + inpos] & 3) << (25 - 2));
+        @out[18 + outpos] = (int)(((uint)@in[14 + inpos] >> 2) & 33554431);
+        @out[19 + outpos] = (int)((uint)@in[14 + inpos] >> 27)
+                            | ((@in[15 + inpos] & 1048575) << (25 - 20));
+        @out[20 + outpos] = (int)((uint)@in[15 + inpos] >> 20)
+                            | ((@in[16 + inpos] & 8191) << (25 - 13));
+        @out[21 + outpos] = (int)((uint)@in[16 + inpos] >> 13)
+                            | ((@in[17 + inpos] & 63) << (25 - 6));
+        @out[22 + outpos] = (int)(((uint)@in[17 + inpos] >> 6) & 33554431);
+        @out[23 + outpos] = (int)((uint)@in[17 + inpos] >> 31)
+                            | ((@in[18 + inpos] & 16777215) << (25 - 24));
+        @out[24 + outpos] = (int)((uint)@in[18 + inpos] >> 24)
+                            | ((@in[19 + inpos] & 131071) << (25 - 17));
+        @out[25 + outpos] = (int)((uint)@in[19 + inpos] >> 17)
+                            | ((@in[20 + inpos] & 1023) << (25 - 10));
+        @out[26 + outpos] = (int)((uint)@in[20 + inpos] >> 10)
+                            | ((@in[21 + inpos] & 7) << (25 - 3));
+        @out[27 + outpos] = (int)(((uint)@in[21 + inpos] >> 3) & 33554431);
+        @out[28 + outpos] = (int)((uint)@in[21 + inpos] >> 28)
+                            | ((@in[22 + inpos] & 2097151) << (25 - 21));
+        @out[29 + outpos] = (int)((uint)@in[22 + inpos] >> 21)
+                            | ((@in[23 + inpos] & 16383) << (25 - 14));
+        @out[30 + outpos] = (int)((uint)@in[23 + inpos] >> 14)
+                            | ((@in[24 + inpos] & 127) << (25 - 7));
+        @out[31 + outpos] = (int)((uint)@in[24 + inpos] >> 7);
+    }
+
+    protected static void fastunpack26(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 67108863);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 26)
+                           | ((@in[1 + inpos] & 1048575) << (26 - 20));
+        @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 20)
+                           | ((@in[2 + inpos] & 16383) << (26 - 14));
+        @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 14)
+                           | ((@in[3 + inpos] & 255) << (26 - 8));
+        @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 8)
+                           | ((@in[4 + inpos] & 3) << (26 - 2));
+        @out[5 + outpos] = (int)(((uint)@in[4 + inpos] >> 2) & 67108863);
+        @out[6 + outpos] = (int)((uint)@in[4 + inpos] >> 28)
+                           | ((@in[5 + inpos] & 4194303) << (26 - 22));
+        @out[7 + outpos] = (int)((uint)@in[5 + inpos] >> 22)
+                           | ((@in[6 + inpos] & 65535) << (26 - 16));
+        @out[8 + outpos] = (int)((uint)@in[6 + inpos] >> 16)
+                           | ((@in[7 + inpos] & 1023) << (26 - 10));
+        @out[9 + outpos] = (int)((uint)@in[7 + inpos] >> 10)
+                           | ((@in[8 + inpos] & 15) << (26 - 4));
+        @out[10 + outpos] = (int)(((uint)@in[8 + inpos] >> 4) & 67108863);
+        @out[11 + outpos] = (int)((uint)@in[8 + inpos] >> 30)
+                            | ((@in[9 + inpos] & 16777215) << (26 - 24));
+        @out[12 + outpos] = (int)((uint)@in[9 + inpos] >> 24)
+                            | ((@in[10 + inpos] & 262143) << (26 - 18));
+        @out[13 + outpos] = (int)((uint)@in[10 + inpos] >> 18)
+                            | ((@in[11 + inpos] & 4095) << (26 - 12));
+        @out[14 + outpos] = (int)((uint)@in[11 + inpos] >> 12)
+                            | ((@in[12 + inpos] & 63) << (26 - 6));
+        @out[15 + outpos] = (int)((uint)@in[12 + inpos] >> 6);
+        @out[16 + outpos] = (int)(((uint)@in[13 + inpos] >> 0) & 67108863);
+        @out[17 + outpos] = (int)((uint)@in[13 + inpos] >> 26)
+                            | ((@in[14 + inpos] & 1048575) << (26 - 20));
+        @out[18 + outpos] = (int)((uint)@in[14 + inpos] >> 20)
+                            | ((@in[15 + inpos] & 16383) << (26 - 14));
+        @out[19 + outpos] = (int)((uint)@in[15 + inpos] >> 14)
+                            | ((@in[16 + inpos] & 255) << (26 - 8));
+        @out[20 + outpos] = (int)((uint)@in[16 + inpos] >> 8)
+                            | ((@in[17 + inpos] & 3) << (26 - 2));
+        @out[21 + outpos] = (int)(((uint)@in[17 + inpos] >> 2) & 67108863);
+        @out[22 + outpos] = (int)((uint)@in[17 + inpos] >> 28)
+                            | ((@in[18 + inpos] & 4194303) << (26 - 22));
+        @out[23 + outpos] = (int)((uint)@in[18 + inpos] >> 22)
+                            | ((@in[19 + inpos] & 65535) << (26 - 16));
+        @out[24 + outpos] = (int)((uint)@in[19 + inpos] >> 16)
+                            | ((@in[20 + inpos] & 1023) << (26 - 10));
+        @out[25 + outpos] = (int)((uint)@in[20 + inpos] >> 10)
+                            | ((@in[21 + inpos] & 15) << (26 - 4));
+        @out[26 + outpos] = (int)(((uint)@in[21 + inpos] >> 4) & 67108863);
+        @out[27 + outpos] = (int)((uint)@in[21 + inpos] >> 30)
+                            | ((@in[22 + inpos] & 16777215) << (26 - 24));
+        @out[28 + outpos] = (int)((uint)@in[22 + inpos] >> 24)
+                            | ((@in[23 + inpos] & 262143) << (26 - 18));
+        @out[29 + outpos] = (int)((uint)@in[23 + inpos] >> 18)
+                            | ((@in[24 + inpos] & 4095) << (26 - 12));
+        @out[30 + outpos] = (int)((uint)@in[24 + inpos] >> 12)
+                            | ((@in[25 + inpos] & 63) << (26 - 6));
+        @out[31 + outpos] = (int)((uint)@in[25 + inpos] >> 6);
+    }
+
+    protected static void fastunpack27(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 134217727);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 27)
+                           | ((@in[1 + inpos] & 4194303) << (27 - 22));
+        @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 22)
+                           | ((@in[2 + inpos] & 131071) << (27 - 17));
+        @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 17)
+                           | ((@in[3 + inpos] & 4095) << (27 - 12));
+        @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 12)
+                           | ((@in[4 + inpos] & 127) << (27 - 7));
+        @out[5 + outpos] = (int)((uint)@in[4 + inpos] >> 7)
+                           | ((@in[5 + inpos] & 3) << (27 - 2));
+        @out[6 + outpos] = (int)(((uint)@in[5 + inpos] >> 2) & 134217727);
+        @out[7 + outpos] = (int)((uint)@in[5 + inpos] >> 29)
+                           | ((@in[6 + inpos] & 16777215) << (27 - 24));
+        @out[8 + outpos] = (int)((uint)@in[6 + inpos] >> 24)
+                           | ((@in[7 + inpos] & 524287) << (27 - 19));
+        @out[9 + outpos] = (int)((uint)@in[7 + inpos] >> 19)
+                           | ((@in[8 + inpos] & 16383) << (27 - 14));
+        @out[10 + outpos] = (int)((uint)@in[8 + inpos] >> 14)
+                            | ((@in[9 + inpos] & 511) << (27 - 9));
+        @out[11 + outpos] = (int)((uint)@in[9 + inpos] >> 9)
+                            | ((@in[10 + inpos] & 15) << (27 - 4));
+        @out[12 + outpos] = (int)(((uint)@in[10 + inpos] >> 4) & 134217727);
+        @out[13 + outpos] = (int)((uint)@in[10 + inpos] >> 31)
+                            | ((@in[11 + inpos] & 67108863) << (27 - 26));
+        @out[14 + outpos] = (int)((uint)@in[11 + inpos] >> 26)
+                            | ((@in[12 + inpos] & 2097151) << (27 - 21));
+        @out[15 + outpos] = (int)((uint)@in[12 + inpos] >> 21)
+                            | ((@in[13 + inpos] & 65535) << (27 - 16));
+        @out[16 + outpos] = (int)((uint)@in[13 + inpos] >> 16)
+                            | ((@in[14 + inpos] & 2047) << (27 - 11));
+        @out[17 + outpos] = (int)((uint)@in[14 + inpos] >> 11)
+                            | ((@in[15 + inpos] & 63) << (27 - 6));
+        @out[18 + outpos] = (int)((uint)@in[15 + inpos] >> 6)
+                            | ((@in[16 + inpos] & 1) << (27 - 1));
+        @out[19 + outpos] = (int)(((uint)@in[16 + inpos] >> 1) & 134217727);
+        @out[20 + outpos] = (int)((uint)@in[16 + inpos] >> 28)
+                            | ((@in[17 + inpos] & 8388607) << (27 - 23));
+        @out[21 + outpos] = (int)((uint)@in[17 + inpos] >> 23)
+                            | ((@in[18 + inpos] & 262143) << (27 - 18));
+        @out[22 + outpos] = (int)((uint)@in[18 + inpos] >> 18)
+                            | ((@in[19 + inpos] & 8191) << (27 - 13));
+        @out[23 + outpos] = (int)((uint)@in[19 + inpos] >> 13)
+                            | ((@in[20 + inpos] & 255) << (27 - 8));
+        @out[24 + outpos] = (int)((uint)@in[20 + inpos] >> 8)
+                            | ((@in[21 + inpos] & 7) << (27 - 3));
+        @out[25 + outpos] = (int)(((uint)@in[21 + inpos] >> 3) & 134217727);
+        @out[26 + outpos] = (int)((uint)@in[21 + inpos] >> 30)
+                            | ((@in[22 + inpos] & 33554431) << (27 - 25));
+        @out[27 + outpos] = (int)((uint)@in[22 + inpos] >> 25)
+                            | ((@in[23 + inpos] & 1048575) << (27 - 20));
+        @out[28 + outpos] = (int)((uint)@in[23 + inpos] >> 20)
+                            | ((@in[24 + inpos] & 32767) << (27 - 15));
+        @out[29 + outpos] = (int)((uint)@in[24 + inpos] >> 15)
+                            | ((@in[25 + inpos] & 1023) << (27 - 10));
+        @out[30 + outpos] = (int)((uint)@in[25 + inpos] >> 10)
+                            | ((@in[26 + inpos] & 31) << (27 - 5));
+        @out[31 + outpos] = (int)((uint)@in[26 + inpos] >> 5);
+    }
+
+    protected static void fastunpack28(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 268435455);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 28)
+                           | ((@in[1 + inpos] & 16777215) << (28 - 24));
+        @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 24)
+                           | ((@in[2 + inpos] & 1048575) << (28 - 20));
+        @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 20)
+                           | ((@in[3 + inpos] & 65535) << (28 - 16));
+        @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 16)
+                           | ((@in[4 + inpos] & 4095) << (28 - 12));
+        @out[5 + outpos] = (int)((uint)@in[4 + inpos] >> 12)
+                           | ((@in[5 + inpos] & 255) << (28 - 8));
+        @out[6 + outpos] = (int)((uint)@in[5 + inpos] >> 8)
+                           | ((@in[6 + inpos] & 15) << (28 - 4));
+        @out[7 + outpos] = (int)((uint)@in[6 + inpos] >> 4);
+        @out[8 + outpos] = (int)(((uint)@in[7 + inpos] >> 0) & 268435455);
+        @out[9 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
+                           | ((@in[8 + inpos] & 16777215) << (28 - 24));
+        @out[10 + outpos] = (int)((uint)@in[8 + inpos] >> 24)
+                            | ((@in[9 + inpos] & 1048575) << (28 - 20));
+        @out[11 + outpos] = (int)((uint)@in[9 + inpos] >> 20)
+                            | ((@in[10 + inpos] & 65535) << (28 - 16));
+        @out[12 + outpos] = (int)((uint)@in[10 + inpos] >> 16)
+                            | ((@in[11 + inpos] & 4095) << (28 - 12));
+        @out[13 + outpos] = (int)((uint)@in[11 + inpos] >> 12)
+                            | ((@in[12 + inpos] & 255) << (28 - 8));
+        @out[14 + outpos] = (int)((uint)@in[12 + inpos] >> 8)
+                            | ((@in[13 + inpos] & 15) << (28 - 4));
+        @out[15 + outpos] = (int)((uint)@in[13 + inpos] >> 4);
+        @out[16 + outpos] = (int)(((uint)@in[14 + inpos] >> 0) & 268435455);
+        @out[17 + outpos] = (int)((uint)@in[14 + inpos] >> 28)
+                            | ((@in[15 + inpos] & 16777215) << (28 - 24));
+        @out[18 + outpos] = (int)((uint)@in[15 + inpos] >> 24)
+                            | ((@in[16 + inpos] & 1048575) << (28 - 20));
+        @out[19 + outpos] = (int)((uint)@in[16 + inpos] >> 20)
+                            | ((@in[17 + inpos] & 65535) << (28 - 16));
+        @out[20 + outpos] = (int)((uint)@in[17 + inpos] >> 16)
+                            | ((@in[18 + inpos] & 4095) << (28 - 12));
+        @out[21 + outpos] = (int)((uint)@in[18 + inpos] >> 12)
+                            | ((@in[19 + inpos] & 255) << (28 - 8));
+        @out[22 + outpos] = (int)((uint)@in[19 + inpos] >> 8)
+                            | ((@in[20 + inpos] & 15) << (28 - 4));
+        @out[23 + outpos] = (int)((uint)@in[20 + inpos] >> 4);
+        @out[24 + outpos] = (int)(((uint)@in[21 + inpos] >> 0) & 268435455);
+        @out[25 + outpos] = (int)((uint)@in[21 + inpos] >> 28)
+                            | ((@in[22 + inpos] & 16777215) << (28 - 24));
+        @out[26 + outpos] = (int)((uint)@in[22 + inpos] >> 24)
+                            | ((@in[23 + inpos] & 1048575) << (28 - 20));
+        @out[27 + outpos] = (int)((uint)@in[23 + inpos] >> 20)
+                            | ((@in[24 + inpos] & 65535) << (28 - 16));
+        @out[28 + outpos] = (int)((uint)@in[24 + inpos] >> 16)
+                            | ((@in[25 + inpos] & 4095) << (28 - 12));
+        @out[29 + outpos] = (int)((uint)@in[25 + inpos] >> 12)
+                            | ((@in[26 + inpos] & 255) << (28 - 8));
+        @out[30 + outpos] = (int)((uint)@in[26 + inpos] >> 8)
+                            | ((@in[27 + inpos] & 15) << (28 - 4));
+        @out[31 + outpos] = (int)((uint)@in[27 + inpos] >> 4);
+    }
+
+    protected static void fastunpack29(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 536870911);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 29)
+                           | ((@in[1 + inpos] & 67108863) << (29 - 26));
+        @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 26)
+                           | ((@in[2 + inpos] & 8388607) << (29 - 23));
+        @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 23)
+                           | ((@in[3 + inpos] & 1048575) << (29 - 20));
+        @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 20)
+                           | ((@in[4 + inpos] & 131071) << (29 - 17));
+        @out[5 + outpos] = (int)((uint)@in[4 + inpos] >> 17)
+                           | ((@in[5 + inpos] & 16383) << (29 - 14));
+        @out[6 + outpos] = (int)((uint)@in[5 + inpos] >> 14)
+                           | ((@in[6 + inpos] & 2047) << (29 - 11));
+        @out[7 + outpos] = (int)((uint)@in[6 + inpos] >> 11)
+                           | ((@in[7 + inpos] & 255) << (29 - 8));
+        @out[8 + outpos] = (int)((uint)@in[7 + inpos] >> 8)
+                           | ((@in[8 + inpos] & 31) << (29 - 5));
+        @out[9 + outpos] = (int)((uint)@in[8 + inpos] >> 5)
+                           | ((@in[9 + inpos] & 3) << (29 - 2));
+        @out[10 + outpos] = (int)(((uint)@in[9 + inpos] >> 2) & 536870911);
+        @out[11 + outpos] = (int)((uint)@in[9 + inpos] >> 31)
+                            | ((@in[10 + inpos] & 268435455) << (29 - 28));
+        @out[12 + outpos] = (int)((uint)@in[10 + inpos] >> 28)
+                            | ((@in[11 + inpos] & 33554431) << (29 - 25));
+        @out[13 + outpos] = (int)((uint)@in[11 + inpos] >> 25)
+                            | ((@in[12 + inpos] & 4194303) << (29 - 22));
+        @out[14 + outpos] = (int)((uint)@in[12 + inpos] >> 22)
+                            | ((@in[13 + inpos] & 524287) << (29 - 19));
+        @out[15 + outpos] = (int)((uint)@in[13 + inpos] >> 19)
+                            | ((@in[14 + inpos] & 65535) << (29 - 16));
+        @out[16 + outpos] = (int)((uint)@in[14 + inpos] >> 16)
+                            | ((@in[15 + inpos] & 8191) << (29 - 13));
+        @out[17 + outpos] = (int)((uint)@in[15 + inpos] >> 13)
+                            | ((@in[16 + inpos] & 1023) << (29 - 10));
+        @out[18 + outpos] = (int)((uint)@in[16 + inpos] >> 10)
+                            | ((@in[17 + inpos] & 127) << (29 - 7));
+        @out[19 + outpos] = (int)((uint)@in[17 + inpos] >> 7)
+                            | ((@in[18 + inpos] & 15) << (29 - 4));
+        @out[20 + outpos] = (int)((uint)@in[18 + inpos] >> 4)
+                            | ((@in[19 + inpos] & 1) << (29 - 1));
+        @out[21 + outpos] = (int)(((uint)@in[19 + inpos] >> 1) & 536870911);
+        @out[22 + outpos] = (int)((uint)@in[19 + inpos] >> 30)
+                            | ((@in[20 + inpos] & 134217727) << (29 - 27));
+        @out[23 + outpos] = (int)((uint)@in[20 + inpos] >> 27)
+                            | ((@in[21 + inpos] & 16777215) << (29 - 24));
+        @out[24 + outpos] = (int)((uint)@in[21 + inpos] >> 24)
+                            | ((@in[22 + inpos] & 2097151) << (29 - 21));
+        @out[25 + outpos] = (int)((uint)@in[22 + inpos] >> 21)
+                            | ((@in[23 + inpos] & 262143) << (29 - 18));
+        @out[26 + outpos] = (int)((uint)@in[23 + inpos] >> 18)
+                            | ((@in[24 + inpos] & 32767) << (29 - 15));
+        @out[27 + outpos] = (int)((uint)@in[24 + inpos] >> 15)
+                            | ((@in[25 + inpos] & 4095) << (29 - 12));
+        @out[28 + outpos] = (int)((uint)@in[25 + inpos] >> 12)
+                            | ((@in[26 + inpos] & 511) << (29 - 9));
+        @out[29 + outpos] = (int)((uint)@in[26 + inpos] >> 9)
+                            | ((@in[27 + inpos] & 63) << (29 - 6));
+        @out[30 + outpos] = (int)((uint)@in[27 + inpos] >> 6)
+                            | ((@in[28 + inpos] & 7) << (29 - 3));
+        @out[31 + outpos] = (int)((uint)@in[28 + inpos] >> 3);
+    }
+
+    protected static void fastunpack3(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 7);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 3) & 7);
+        @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 6) & 7);
+        @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 9) & 7);
+        @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 7);
+        @out[5 + outpos] = (int)(((uint)@in[0 + inpos] >> 15) & 7);
+        @out[6 + outpos] = (int)(((uint)@in[0 + inpos] >> 18) & 7);
+        @out[7 + outpos] = (int)(((uint)@in[0 + inpos] >> 21) & 7);
+        @out[8 + outpos] = (int)(((uint)@in[0 + inpos] >> 24) & 7);
+        @out[9 + outpos] = (int)(((uint)@in[0 + inpos] >> 27) & 7);
+        @out[10 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
+                            | ((@in[1 + inpos] & 1) << (3 - 1));
+        @out[11 + outpos] = (int)(((uint)@in[1 + inpos] >> 1) & 7);
+        @out[12 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 7);
+        @out[13 + outpos] = (int)(((uint)@in[1 + inpos] >> 7) & 7);
+        @out[14 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 7);
+        @out[15 + outpos] = (int)(((uint)@in[1 + inpos] >> 13) & 7);
+        @out[16 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 7);
+        @out[17 + outpos] = (int)(((uint)@in[1 + inpos] >> 19) & 7);
+        @out[18 + outpos] = (int)(((uint)@in[1 + inpos] >> 22) & 7);
+        @out[19 + outpos] = (int)(((uint)@in[1 + inpos] >> 25) & 7);
+        @out[20 + outpos] = (int)(((uint)@in[1 + inpos] >> 28) & 7);
+        @out[21 + outpos] = (int)((uint)@in[1 + inpos] >> 31)
+                            | ((@in[2 + inpos] & 3) << (3 - 2));
+        @out[22 + outpos] = (int)(((uint)@in[2 + inpos] >> 2) & 7);
+        @out[23 + outpos] = (int)(((uint)@in[2 + inpos] >> 5) & 7);
+        @out[24 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 7);
+        @out[25 + outpos] = (int)(((uint)@in[2 + inpos] >> 11) & 7);
+        @out[26 + outpos] = (int)(((uint)@in[2 + inpos] >> 14) & 7);
+        @out[27 + outpos] = (int)(((uint)@in[2 + inpos] >> 17) & 7);
+        @out[28 + outpos] = (int)(((uint)@in[2 + inpos] >> 20) & 7);
+        @out[29 + outpos] = (int)(((uint)@in[2 + inpos] >> 23) & 7);
+        @out[30 + outpos] = (int)(((uint)@in[2 + inpos] >> 26) & 7);
+        @out[31 + outpos] = (int)((uint)@in[2 + inpos] >> 29);
+    }
+
+    protected static void fastunpack30(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 1073741823);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
+                           | ((@in[1 + inpos] & 268435455) << (30 - 28));
+        @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
+                           | ((@in[2 + inpos] & 67108863) << (30 - 26));
+        @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 26)
+                           | ((@in[3 + inpos] & 16777215) << (30 - 24));
+        @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 24)
+                           | ((@in[4 + inpos] & 4194303) << (30 - 22));
+        @out[5 + outpos] = (int)((uint)@in[4 + inpos] >> 22)
+                           | ((@in[5 + inpos] & 1048575) << (30 - 20));
+        @out[6 + outpos] = (int)((uint)@in[5 + inpos] >> 20)
+                           | ((@in[6 + inpos] & 262143) << (30 - 18));
+        @out[7 + outpos] = (int)((uint)@in[6 + inpos] >> 18)
+                           | ((@in[7 + inpos] & 65535) << (30 - 16));
+        @out[8 + outpos] = (int)((uint)@in[7 + inpos] >> 16)
+                           | ((@in[8 + inpos] & 16383) << (30 - 14));
+        @out[9 + outpos] = (int)((uint)@in[8 + inpos] >> 14)
+                           | ((@in[9 + inpos] & 4095) << (30 - 12));
+        @out[10 + outpos] = (int)((uint)@in[9 + inpos] >> 12)
+                            | ((@in[10 + inpos] & 1023) << (30 - 10));
+        @out[11 + outpos] = (int)((uint)@in[10 + inpos] >> 10)
+                            | ((@in[11 + inpos] & 255) << (30 - 8));
+        @out[12 + outpos] = (int)((uint)@in[11 + inpos] >> 8)
+                            | ((@in[12 + inpos] & 63) << (30 - 6));
+        @out[13 + outpos] = (int)((uint)@in[12 + inpos] >> 6)
+                            | ((@in[13 + inpos] & 15) << (30 - 4));
+        @out[14 + outpos] = (int)((uint)@in[13 + inpos] >> 4)
+                            | ((@in[14 + inpos] & 3) << (30 - 2));
+        @out[15 + outpos] = (int)((uint)@in[14 + inpos] >> 2);
+        @out[16 + outpos] = (int)(((uint)@in[15 + inpos] >> 0) & 1073741823);
+        @out[17 + outpos] = (int)((uint)@in[15 + inpos] >> 30)
+                            | ((@in[16 + inpos] & 268435455) << (30 - 28));
+        @out[18 + outpos] = (int)((uint)@in[16 + inpos] >> 28)
+                            | ((@in[17 + inpos] & 67108863) << (30 - 26));
+        @out[19 + outpos] = (int)((uint)@in[17 + inpos] >> 26)
+                            | ((@in[18 + inpos] & 16777215) << (30 - 24));
+        @out[20 + outpos] = (int)((uint)@in[18 + inpos] >> 24)
+                            | ((@in[19 + inpos] & 4194303) << (30 - 22));
+        @out[21 + outpos] = (int)((uint)@in[19 + inpos] >> 22)
+                            | ((@in[20 + inpos] & 1048575) << (30 - 20));
+        @out[22 + outpos] = (int)((uint)@in[20 + inpos] >> 20)
+                            | ((@in[21 + inpos] & 262143) << (30 - 18));
+        @out[23 + outpos] = (int)((uint)@in[21 + inpos] >> 18)
+                            | ((@in[22 + inpos] & 65535) << (30 - 16));
+        @out[24 + outpos] = (int)((uint)@in[22 + inpos] >> 16)
+                            | ((@in[23 + inpos] & 16383) << (30 - 14));
+        @out[25 + outpos] = (int)((uint)@in[23 + inpos] >> 14)
+                            | ((@in[24 + inpos] & 4095) << (30 - 12));
+        @out[26 + outpos] = (int)((uint)@in[24 + inpos] >> 12)
+                            | ((@in[25 + inpos] & 1023) << (30 - 10));
+        @out[27 + outpos] = (int)((uint)@in[25 + inpos] >> 10)
+                            | ((@in[26 + inpos] & 255) << (30 - 8));
+        @out[28 + outpos] = (int)((uint)@in[26 + inpos] >> 8)
+                            | ((@in[27 + inpos] & 63) << (30 - 6));
+        @out[29 + outpos] = (int)((uint)@in[27 + inpos] >> 6)
+                            | ((@in[28 + inpos] & 15) << (30 - 4));
+        @out[30 + outpos] = (int)((uint)@in[28 + inpos] >> 4)
+                            | ((@in[29 + inpos] & 3) << (30 - 2));
+        @out[31 + outpos] = (int)((uint)@in[29 + inpos] >> 2);
+    }
+
+    protected static void fastunpack31(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 2147483647);
+        @out[1 + outpos] = (int)((uint)@in[0 + inpos] >> 31)
+                           | ((@in[1 + inpos] & 1073741823) << (31 - 30));
+        @out[2 + outpos] = (int)((uint)@in[1 + inpos] >> 30)
+                           | ((@in[2 + inpos] & 536870911) << (31 - 29));
+        @out[3 + outpos] = (int)((uint)@in[2 + inpos] >> 29)
+                           | ((@in[3 + inpos] & 268435455) << (31 - 28));
+        @out[4 + outpos] = (int)((uint)@in[3 + inpos] >> 28)
+                           | ((@in[4 + inpos] & 134217727) << (31 - 27));
+        @out[5 + outpos] = (int)((uint)@in[4 + inpos] >> 27)
+                           | ((@in[5 + inpos] & 67108863) << (31 - 26));
+        @out[6 + outpos] = (int)((uint)@in[5 + inpos] >> 26)
+                           | ((@in[6 + inpos] & 33554431) << (31 - 25));
+        @out[7 + outpos] = (int)((uint)@in[6 + inpos] >> 25)
+                           | ((@in[7 + inpos] & 16777215) << (31 - 24));
+        @out[8 + outpos] = (int)((uint)@in[7 + inpos] >> 24)
+                           | ((@in[8 + inpos] & 8388607) << (31 - 23));
+        @out[9 + outpos] = (int)((uint)@in[8 + inpos] >> 23)
+                           | ((@in[9 + inpos] & 4194303) << (31 - 22));
+        @out[10 + outpos] = (int)((uint)@in[9 + inpos] >> 22)
+                            | ((@in[10 + inpos] & 2097151) << (31 - 21));
+        @out[11 + outpos] = (int)((uint)@in[10 + inpos] >> 21)
+                            | ((@in[11 + inpos] & 1048575) << (31 - 20));
+        @out[12 + outpos] = (int)((uint)@in[11 + inpos] >> 20)
+                            | ((@in[12 + inpos] & 524287) << (31 - 19));
+        @out[13 + outpos] = (int)((uint)@in[12 + inpos] >> 19)
+                            | ((@in[13 + inpos] & 262143) << (31 - 18));
+        @out[14 + outpos] = (int)((uint)@in[13 + inpos] >> 18)
+                            | ((@in[14 + inpos] & 131071) << (31 - 17));
+        @out[15 + outpos] = (int)((uint)@in[14 + inpos] >> 17)
+                            | ((@in[15 + inpos] & 65535) << (31 - 16));
+        @out[16 + outpos] = (int)((uint)@in[15 + inpos] >> 16)
+                            | ((@in[16 + inpos] & 32767) << (31 - 15));
+        @out[17 + outpos] = (int)((uint)@in[16 + inpos] >> 15)
+                            | ((@in[17 + inpos] & 16383) << (31 - 14));
+        @out[18 + outpos] = (int)((uint)@in[17 + inpos] >> 14)
+                            | ((@in[18 + inpos] & 8191) << (31 - 13));
+        @out[19 + outpos] = (int)((uint)@in[18 + inpos] >> 13)
+                            | ((@in[19 + inpos] & 4095) << (31 - 12));
+        @out[20 + outpos] = (int)((uint)@in[19 + inpos] >> 12)
+                            | ((@in[20 + inpos] & 2047) << (31 - 11));
+        @out[21 + outpos] = (int)((uint)@in[20 + inpos] >> 11)
+                            | ((@in[21 + inpos] & 1023) << (31 - 10));
+        @out[22 + outpos] = (int)((uint)@in[21 + inpos] >> 10)
+                            | ((@in[22 + inpos] & 511) << (31 - 9));
+        @out[23 + outpos] = (int)((uint)@in[22 + inpos] >> 9)
+                            | ((@in[23 + inpos] & 255) << (31 - 8));
+        @out[24 + outpos] = (int)((uint)@in[23 + inpos] >> 8)
+                            | ((@in[24 + inpos] & 127) << (31 - 7));
+        @out[25 + outpos] = (int)((uint)@in[24 + inpos] >> 7)
+                            | ((@in[25 + inpos] & 63) << (31 - 6));
+        @out[26 + outpos] = (int)((uint)@in[25 + inpos] >> 6)
+                            | ((@in[26 + inpos] & 31) << (31 - 5));
+        @out[27 + outpos] = (int)((uint)@in[26 + inpos] >> 5)
+                            | ((@in[27 + inpos] & 15) << (31 - 4));
+        @out[28 + outpos] = (int)((uint)@in[27 + inpos] >> 4)
+                            | ((@in[28 + inpos] & 7) << (31 - 3));
+        @out[29 + outpos] = (int)((uint)@in[28 + inpos] >> 3)
+                            | ((@in[29 + inpos] & 3) << (31 - 2));
+        @out[30 + outpos] = (int)((uint)@in[29 + inpos] >> 2)
+                            | ((@in[30 + inpos] & 1) << (31 - 1));
+        @out[31 + outpos] = (int)((uint)@in[30 + inpos] >> 1);
+    }
+
+    protected static void fastunpack32(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        Array.Copy(@in, inpos, @out, outpos, 32);
+    }
+
+    protected static void fastunpack4(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 15);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 4) & 15);
+        @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 8) & 15);
+        @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 15);
+        @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 16) & 15);
+        @out[5 + outpos] = (int)(((uint)@in[0 + inpos] >> 20) & 15);
+        @out[6 + outpos] = (int)(((uint)@in[0 + inpos] >> 24) & 15);
+        @out[7 + outpos] = (int)((uint)@in[0 + inpos] >> 28);
+        @out[8 + outpos] = (int)(((uint)@in[1 + inpos] >> 0) & 15);
+        @out[9 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 15);
+        @out[10 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 15);
+        @out[11 + outpos] = (int)(((uint)@in[1 + inpos] >> 12) & 15);
+        @out[12 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 15);
+        @out[13 + outpos] = (int)(((uint)@in[1 + inpos] >> 20) & 15);
+        @out[14 + outpos] = (int)(((uint)@in[1 + inpos] >> 24) & 15);
+        @out[15 + outpos] = (int)((uint)@in[1 + inpos] >> 28);
+        @out[16 + outpos] = (int)(((uint)@in[2 + inpos] >> 0) & 15);
+        @out[17 + outpos] = (int)(((uint)@in[2 + inpos] >> 4) & 15);
+        @out[18 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 15);
+        @out[19 + outpos] = (int)(((uint)@in[2 + inpos] >> 12) & 15);
+        @out[20 + outpos] = (int)(((uint)@in[2 + inpos] >> 16) & 15);
+        @out[21 + outpos] = (int)(((uint)@in[2 + inpos] >> 20) & 15);
+        @out[22 + outpos] = (int)(((uint)@in[2 + inpos] >> 24) & 15);
+        @out[23 + outpos] = (int)((uint)@in[2 + inpos] >> 28);
+        @out[24 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 15);
+        @out[25 + outpos] = (int)(((uint)@in[3 + inpos] >> 4) & 15);
+        @out[26 + outpos] = (int)(((uint)@in[3 + inpos] >> 8) & 15);
+        @out[27 + outpos] = (int)(((uint)@in[3 + inpos] >> 12) & 15);
+        @out[28 + outpos] = (int)(((uint)@in[3 + inpos] >> 16) & 15);
+        @out[29 + outpos] = (int)(((uint)@in[3 + inpos] >> 20) & 15);
+        @out[30 + outpos] = (int)(((uint)@in[3 + inpos] >> 24) & 15);
+        @out[31 + outpos] = (int)((uint)@in[3 + inpos] >> 28);
+    }
+
+    protected static void fastunpack5(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 31);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 5) & 31);
+        @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 10) & 31);
+        @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 15) & 31);
+        @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 20) & 31);
+        @out[5 + outpos] = (int)(((uint)@in[0 + inpos] >> 25) & 31);
+        @out[6 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
+                           | ((@in[1 + inpos] & 7) << (5 - 3));
+        @out[7 + outpos] = (int)(((uint)@in[1 + inpos] >> 3) & 31);
+        @out[8 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 31);
+        @out[9 + outpos] = (int)(((uint)@in[1 + inpos] >> 13) & 31);
+        @out[10 + outpos] = (int)(((uint)@in[1 + inpos] >> 18) & 31);
+        @out[11 + outpos] = (int)(((uint)@in[1 + inpos] >> 23) & 31);
+        @out[12 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
+                            | ((@in[2 + inpos] & 1) << (5 - 1));
+        @out[13 + outpos] = (int)(((uint)@in[2 + inpos] >> 1) & 31);
+        @out[14 + outpos] = (int)(((uint)@in[2 + inpos] >> 6) & 31);
+        @out[15 + outpos] = (int)(((uint)@in[2 + inpos] >> 11) & 31);
+        @out[16 + outpos] = (int)(((uint)@in[2 + inpos] >> 16) & 31);
+        @out[17 + outpos] = (int)(((uint)@in[2 + inpos] >> 21) & 31);
+        @out[18 + outpos] = (int)(((uint)@in[2 + inpos] >> 26) & 31);
+        @out[19 + outpos] = (int)((uint)@in[2 + inpos] >> 31)
+                            | ((@in[3 + inpos] & 15) << (5 - 4));
+        @out[20 + outpos] = (int)(((uint)@in[3 + inpos] >> 4) & 31);
+        @out[21 + outpos] = (int)(((uint)@in[3 + inpos] >> 9) & 31);
+        @out[22 + outpos] = (int)(((uint)@in[3 + inpos] >> 14) & 31);
+        @out[23 + outpos] = (int)(((uint)@in[3 + inpos] >> 19) & 31);
+        @out[24 + outpos] = (int)(((uint)@in[3 + inpos] >> 24) & 31);
+        @out[25 + outpos] = (int)((uint)@in[3 + inpos] >> 29)
+                            | ((@in[4 + inpos] & 3) << (5 - 2));
+        @out[26 + outpos] = (int)(((uint)@in[4 + inpos] >> 2) & 31);
+        @out[27 + outpos] = (int)(((uint)@in[4 + inpos] >> 7) & 31);
+        @out[28 + outpos] = (int)(((uint)@in[4 + inpos] >> 12) & 31);
+        @out[29 + outpos] = (int)(((uint)@in[4 + inpos] >> 17) & 31);
+        @out[30 + outpos] = (int)(((uint)@in[4 + inpos] >> 22) & 31);
+        @out[31 + outpos] = (int)((uint)@in[4 + inpos] >> 27);
+    }
+
+    protected static void fastunpack6(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 63);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 6) & 63);
+        @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 12) & 63);
+        @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 18) & 63);
+        @out[4 + outpos] = (int)(((uint)@in[0 + inpos] >> 24) & 63);
+        @out[5 + outpos] = (int)((uint)@in[0 + inpos] >> 30)
+                           | ((@in[1 + inpos] & 15) << (6 - 4));
+        @out[6 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 63);
+        @out[7 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 63);
+        @out[8 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 63);
+        @out[9 + outpos] = (int)(((uint)@in[1 + inpos] >> 22) & 63);
+        @out[10 + outpos] = (int)((uint)@in[1 + inpos] >> 28)
+                            | ((@in[2 + inpos] & 3) << (6 - 2));
+        @out[11 + outpos] = (int)(((uint)@in[2 + inpos] >> 2) & 63);
+        @out[12 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 63);
+        @out[13 + outpos] = (int)(((uint)@in[2 + inpos] >> 14) & 63);
+        @out[14 + outpos] = (int)(((uint)@in[2 + inpos] >> 20) & 63);
+        @out[15 + outpos] = (int)((uint)@in[2 + inpos] >> 26);
+        @out[16 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 63);
+        @out[17 + outpos] = (int)(((uint)@in[3 + inpos] >> 6) & 63);
+        @out[18 + outpos] = (int)(((uint)@in[3 + inpos] >> 12) & 63);
+        @out[19 + outpos] = (int)(((uint)@in[3 + inpos] >> 18) & 63);
+        @out[20 + outpos] = (int)(((uint)@in[3 + inpos] >> 24) & 63);
+        @out[21 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
+                            | ((@in[4 + inpos] & 15) << (6 - 4));
+        @out[22 + outpos] = (int)(((uint)@in[4 + inpos] >> 4) & 63);
+        @out[23 + outpos] = (int)(((uint)@in[4 + inpos] >> 10) & 63);
+        @out[24 + outpos] = (int)(((uint)@in[4 + inpos] >> 16) & 63);
+        @out[25 + outpos] = (int)(((uint)@in[4 + inpos] >> 22) & 63);
+        @out[26 + outpos] = (int)((uint)@in[4 + inpos] >> 28)
+                            | ((@in[5 + inpos] & 3) << (6 - 2));
+        @out[27 + outpos] = (int)(((uint)@in[5 + inpos] >> 2) & 63);
+        @out[28 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 63);
+        @out[29 + outpos] = (int)(((uint)@in[5 + inpos] >> 14) & 63);
+        @out[30 + outpos] = (int)(((uint)@in[5 + inpos] >> 20) & 63);
+        @out[31 + outpos] = (int)((uint)@in[5 + inpos] >> 26);
+    }
+
+    protected static void fastunpack7(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 127);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 7) & 127);
+        @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 14) & 127);
+        @out[3 + outpos] = (int)(((uint)@in[0 + inpos] >> 21) & 127);
+        @out[4 + outpos] = (int)((uint)@in[0 + inpos] >> 28)
+                           | ((@in[1 + inpos] & 7) << (7 - 3));
+        @out[5 + outpos] = (int)(((uint)@in[1 + inpos] >> 3) & 127);
+        @out[6 + outpos] = (int)(((uint)@in[1 + inpos] >> 10) & 127);
+        @out[7 + outpos] = (int)(((uint)@in[1 + inpos] >> 17) & 127);
+        @out[8 + outpos] = (int)(((uint)@in[1 + inpos] >> 24) & 127);
+        @out[9 + outpos] = (int)((uint)@in[1 + inpos] >> 31)
+                           | ((@in[2 + inpos] & 63) << (7 - 6));
+        @out[10 + outpos] = (int)(((uint)@in[2 + inpos] >> 6) & 127);
+        @out[11 + outpos] = (int)(((uint)@in[2 + inpos] >> 13) & 127);
+        @out[12 + outpos] = (int)(((uint)@in[2 + inpos] >> 20) & 127);
+        @out[13 + outpos] = (int)((uint)@in[2 + inpos] >> 27)
+                            | ((@in[3 + inpos] & 3) << (7 - 2));
+        @out[14 + outpos] = (int)(((uint)@in[3 + inpos] >> 2) & 127);
+        @out[15 + outpos] = (int)(((uint)@in[3 + inpos] >> 9) & 127);
+        @out[16 + outpos] = (int)(((uint)@in[3 + inpos] >> 16) & 127);
+        @out[17 + outpos] = (int)(((uint)@in[3 + inpos] >> 23) & 127);
+        @out[18 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
+                            | ((@in[4 + inpos] & 31) << (7 - 5));
+        @out[19 + outpos] = (int)(((uint)@in[4 + inpos] >> 5) & 127);
+        @out[20 + outpos] = (int)(((uint)@in[4 + inpos] >> 12) & 127);
+        @out[21 + outpos] = (int)(((uint)@in[4 + inpos] >> 19) & 127);
+        @out[22 + outpos] = (int)((uint)@in[4 + inpos] >> 26)
+                            | ((@in[5 + inpos] & 1) << (7 - 1));
+        @out[23 + outpos] = (int)(((uint)@in[5 + inpos] >> 1) & 127);
+        @out[24 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 127);
+        @out[25 + outpos] = (int)(((uint)@in[5 + inpos] >> 15) & 127);
+        @out[26 + outpos] = (int)(((uint)@in[5 + inpos] >> 22) & 127);
+        @out[27 + outpos] = (int)((uint)@in[5 + inpos] >> 29)
+                            | ((@in[6 + inpos] & 15) << (7 - 4));
+        @out[28 + outpos] = (int)(((uint)@in[6 + inpos] >> 4) & 127);
+        @out[29 + outpos] = (int)(((uint)@in[6 + inpos] >> 11) & 127);
+        @out[30 + outpos] = (int)(((uint)@in[6 + inpos] >> 18) & 127);
+        @out[31 + outpos] = (int)((uint)@in[6 + inpos] >> 25);
+    }
+
+    protected static void fastunpack8(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 255);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 8) & 255);
+        @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 16) & 255);
+        @out[3 + outpos] = (int)((uint)@in[0 + inpos] >> 24);
+        @out[4 + outpos] = (int)(((uint)@in[1 + inpos] >> 0) & 255);
+        @out[5 + outpos] = (int)(((uint)@in[1 + inpos] >> 8) & 255);
+        @out[6 + outpos] = (int)(((uint)@in[1 + inpos] >> 16) & 255);
+        @out[7 + outpos] = (int)((uint)@in[1 + inpos] >> 24);
+        @out[8 + outpos] = (int)(((uint)@in[2 + inpos] >> 0) & 255);
+        @out[9 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 255);
+        @out[10 + outpos] = (int)(((uint)@in[2 + inpos] >> 16) & 255);
+        @out[11 + outpos] = (int)((uint)@in[2 + inpos] >> 24);
+        @out[12 + outpos] = (int)(((uint)@in[3 + inpos] >> 0) & 255);
+        @out[13 + outpos] = (int)(((uint)@in[3 + inpos] >> 8) & 255);
+        @out[14 + outpos] = (int)(((uint)@in[3 + inpos] >> 16) & 255);
+        @out[15 + outpos] = (int)((uint)@in[3 + inpos] >> 24);
+        @out[16 + outpos] = (int)(((uint)@in[4 + inpos] >> 0) & 255);
+        @out[17 + outpos] = (int)(((uint)@in[4 + inpos] >> 8) & 255);
+        @out[18 + outpos] = (int)(((uint)@in[4 + inpos] >> 16) & 255);
+        @out[19 + outpos] = (int)((uint)@in[4 + inpos] >> 24);
+        @out[20 + outpos] = (int)(((uint)@in[5 + inpos] >> 0) & 255);
+        @out[21 + outpos] = (int)(((uint)@in[5 + inpos] >> 8) & 255);
+        @out[22 + outpos] = (int)(((uint)@in[5 + inpos] >> 16) & 255);
+        @out[23 + outpos] = (int)((uint)@in[5 + inpos] >> 24);
+        @out[24 + outpos] = (int)(((uint)@in[6 + inpos] >> 0) & 255);
+        @out[25 + outpos] = (int)(((uint)@in[6 + inpos] >> 8) & 255);
+        @out[26 + outpos] = (int)(((uint)@in[6 + inpos] >> 16) & 255);
+        @out[27 + outpos] = (int)((uint)@in[6 + inpos] >> 24);
+        @out[28 + outpos] = (int)(((uint)@in[7 + inpos] >> 0) & 255);
+        @out[29 + outpos] = (int)(((uint)@in[7 + inpos] >> 8) & 255);
+        @out[30 + outpos] = (int)(((uint)@in[7 + inpos] >> 16) & 255);
+        @out[31 + outpos] = (int)((uint)@in[7 + inpos] >> 24);
+    }
+
+    protected static void fastunpack9(int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (int)(((uint)@in[0 + inpos] >> 0) & 511);
+        @out[1 + outpos] = (int)(((uint)@in[0 + inpos] >> 9) & 511);
+        @out[2 + outpos] = (int)(((uint)@in[0 + inpos] >> 18) & 511);
+        @out[3 + outpos] = (int)((uint)@in[0 + inpos] >> 27)
+                           | ((@in[1 + inpos] & 15) << (9 - 4));
+        @out[4 + outpos] = (int)(((uint)@in[1 + inpos] >> 4) & 511);
+        @out[5 + outpos] = (int)(((uint)@in[1 + inpos] >> 13) & 511);
+        @out[6 + outpos] = (int)(((uint)@in[1 + inpos] >> 22) & 511);
+        @out[7 + outpos] = (int)((uint)@in[1 + inpos] >> 31)
+                           | ((@in[2 + inpos] & 255) << (9 - 8));
+        @out[8 + outpos] = (int)(((uint)@in[2 + inpos] >> 8) & 511);
+        @out[9 + outpos] = (int)(((uint)@in[2 + inpos] >> 17) & 511);
+        @out[10 + outpos] = (int)((uint)@in[2 + inpos] >> 26)
+                            | ((@in[3 + inpos] & 7) << (9 - 3));
+        @out[11 + outpos] = (int)(((uint)@in[3 + inpos] >> 3) & 511);
+        @out[12 + outpos] = (int)(((uint)@in[3 + inpos] >> 12) & 511);
+        @out[13 + outpos] = (int)(((uint)@in[3 + inpos] >> 21) & 511);
+        @out[14 + outpos] = (int)((uint)@in[3 + inpos] >> 30)
+                            | ((@in[4 + inpos] & 127) << (9 - 7));
+        @out[15 + outpos] = (int)(((uint)@in[4 + inpos] >> 7) & 511);
+        @out[16 + outpos] = (int)(((uint)@in[4 + inpos] >> 16) & 511);
+        @out[17 + outpos] = (int)((uint)@in[4 + inpos] >> 25)
+                            | ((@in[5 + inpos] & 3) << (9 - 2));
+        @out[18 + outpos] = (int)(((uint)@in[5 + inpos] >> 2) & 511);
+        @out[19 + outpos] = (int)(((uint)@in[5 + inpos] >> 11) & 511);
+        @out[20 + outpos] = (int)(((uint)@in[5 + inpos] >> 20) & 511);
+        @out[21 + outpos] = (int)((uint)@in[5 + inpos] >> 29)
+                            | ((@in[6 + inpos] & 63) << (9 - 6));
+        @out[22 + outpos] = (int)(((uint)@in[6 + inpos] >> 6) & 511);
+        @out[23 + outpos] = (int)(((uint)@in[6 + inpos] >> 15) & 511);
+        @out[24 + outpos] = (int)((uint)@in[6 + inpos] >> 24)
+                            | ((@in[7 + inpos] & 1) << (9 - 1));
+        @out[25 + outpos] = (int)(((uint)@in[7 + inpos] >> 1) & 511);
+        @out[26 + outpos] = (int)(((uint)@in[7 + inpos] >> 10) & 511);
+        @out[27 + outpos] = (int)(((uint)@in[7 + inpos] >> 19) & 511);
+        @out[28 + outpos] = (int)((uint)@in[7 + inpos] >> 28)
+                            | ((@in[8 + inpos] & 31) << (9 - 5));
+        @out[29 + outpos] = (int)(((uint)@in[8 + inpos] >> 5) & 511);
+        @out[30 + outpos] = (int)(((uint)@in[8 + inpos] >> 14) & 511);
+        @out[31 + outpos] = (int)((uint)@in[8 + inpos] >> 23);
+    }
+
 }

--- a/src/CSharpFastPFOR/ByteIntegerCODEC.cs
+++ b/src/CSharpFastPFOR/ByteIntegerCODEC.cs
@@ -11,49 +11,48 @@
  * @author Daniel Lemire
  * 
  */
-namespace Genbox.CSharpFastPFOR
-{
-    public interface ByteIntegerCODEC
-    {
-        /**
-         * Compress data from an array to another array.
-         * 
-         * Both inpos and outpos are modified to represent how much data was
-         * read and written to if 12 ints (inlength = 12) are compressed to 3
-         * bytes, then inpos will be incremented by 12 while outpos will be
-         * incremented by 3 we use IntWrapper to pass the values by reference.
-         * 
-         * @param in
-         *                input array
-         * @param inpos
-         *                location in the input array
-         * @param inlength
-         *                how many integers to compress
-         * @param out
-         *                output array
-         * @param outpos
-         *                where to write in the output array
-         */
-        void compress(int[] @in, IntWrapper inpos, int inlength, sbyte[] @out, IntWrapper outpos);
+namespace Genbox.CSharpFastPFOR;
 
-        /**
-         * Uncompress data from an array to another array.
-         * 
-         * Both inpos and outpos parameters are modified to indicate new
-         * positions after read/write.
-         * 
-         * @param in
-         *                array containing data in compressed form
-         * @param inpos
-         *                where to start reading in the array
-         * @param inlength
-         *                length of the compressed data (ignored by some
-         *                schemes)
-         * @param out
-         *                array where to write the compressed output
-         * @param outpos
-         *                where to write the compressed output in out
-         */
-        void uncompress(sbyte[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos);
-    }
+public interface ByteIntegerCODEC
+{
+    /**
+     * Compress data from an array to another array.
+     * 
+     * Both inpos and outpos are modified to represent how much data was
+     * read and written to if 12 ints (inlength = 12) are compressed to 3
+     * bytes, then inpos will be incremented by 12 while outpos will be
+     * incremented by 3 we use IntWrapper to pass the values by reference.
+     * 
+     * @param in
+     *                input array
+     * @param inpos
+     *                location in the input array
+     * @param inlength
+     *                how many integers to compress
+     * @param out
+     *                output array
+     * @param outpos
+     *                where to write in the output array
+     */
+    void compress(int[] @in, IntWrapper inpos, int inlength, sbyte[] @out, IntWrapper outpos);
+
+    /**
+     * Uncompress data from an array to another array.
+     * 
+     * Both inpos and outpos parameters are modified to indicate new
+     * positions after read/write.
+     * 
+     * @param in
+     *                array containing data in compressed form
+     * @param inpos
+     *                where to start reading in the array
+     * @param inlength
+     *                length of the compressed data (ignored by some
+     *                schemes)
+     * @param out
+     *                array where to write the compressed output
+     * @param outpos
+     *                where to write the compressed output in out
+     */
+    void uncompress(sbyte[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos);
 }

--- a/src/CSharpFastPFOR/Composition.cs
+++ b/src/CSharpFastPFOR/Composition.cs
@@ -12,10 +12,10 @@
  */
 namespace Genbox.CSharpFastPFOR;
 
-public class Composition : IntegerCODEC
+public sealed class Composition : IntegerCODEC
 {
-    private IntegerCODEC F1;
-    private IntegerCODEC F2;
+    private readonly IntegerCODEC F1;
+    private readonly IntegerCODEC F2;
 
     /**
  * Compose a scheme from a first one (f1) and a second one (f2). The

--- a/src/CSharpFastPFOR/Composition.cs
+++ b/src/CSharpFastPFOR/Composition.cs
@@ -10,65 +10,64 @@
  * 
  * @author Daniel Lemire
  */
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class Composition : IntegerCODEC
 {
-    public class Composition : IntegerCODEC
+    private IntegerCODEC F1;
+    private IntegerCODEC F2;
+
+    /**
+ * Compose a scheme from a first one (f1) and a second one (f2). The
+ * first one is called first and then the second one tries to compress
+ * whatever remains from the first run.
+ * 
+ * By convention, the first scheme should be such that if, during
+ * decoding, a 32-bit zero is first encountered, then there is no
+ * output.
+ * 
+ * @param f1
+ *                first codec
+ * @param f2
+ *                second codec
+ */
+    public Composition(IntegerCODEC f1, IntegerCODEC f2)
     {
-        private IntegerCODEC F1;
-        private IntegerCODEC F2;
+        F1 = f1;
+        F2 = f2;
+    }
 
-        /**
-     * Compose a scheme from a first one (f1) and a second one (f2). The
-     * first one is called first and then the second one tries to compress
-     * whatever remains from the first run.
-     * 
-     * By convention, the first scheme should be such that if, during
-     * decoding, a 32-bit zero is first encountered, then there is no
-     * output.
-     * 
-     * @param f1
-     *                first codec
-     * @param f2
-     *                second codec
-     */
-        public Composition(IntegerCODEC f1, IntegerCODEC f2)
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
         {
-            F1 = f1;
-            F2 = f2;
+            return;
         }
-
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+        int inposInit = inpos.get();
+        int outposInit = outpos.get();
+        F1.compress(@in, inpos, inlength, @out, outpos);
+        if (outpos.get() == outposInit)
         {
-            if (inlength == 0)
-            {
-                return;
-            }
-            int inposInit = inpos.get();
-            int outposInit = outpos.get();
-            F1.compress(@in, inpos, inlength, @out, outpos);
-            if (outpos.get() == outposInit)
-            {
-                @out[outposInit] = 0;
-                outpos.increment();
-            }
-            inlength -= inpos.get() - inposInit;
-            F2.compress(@in, inpos, inlength, @out, outpos);
+            @out[outposInit] = 0;
+            outpos.increment();
         }
+        inlength -= inpos.get() - inposInit;
+        F2.compress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
 
-            int init = inpos.get();
-            F1.uncompress(@in, inpos, inlength, @out, outpos);
-            inlength -= inpos.get() - init;
-            F2.uncompress(@in, inpos, inlength, @out, outpos);
-        }
+        int init = inpos.get();
+        F1.uncompress(@in, inpos, inlength, @out, outpos);
+        inlength -= inpos.get() - init;
+        F2.uncompress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public override string ToString()
-        {
-            return F1 + " + " + F2;
-        }
+    public override string ToString()
+    {
+        return F1 + " + " + F2;
     }
 }

--- a/src/CSharpFastPFOR/DeltaZigzagBinaryPacking.cs
+++ b/src/CSharpFastPFOR/DeltaZigzagBinaryPacking.cs
@@ -33,7 +33,7 @@ public class DeltaZigzagBinaryPacking : IntegerCODEC
         outBuf[outPos.get()] = inLen;
         outPos.increment();
 
-        DeltaZigzagEncoding.Encoder ctx = new DeltaZigzagEncoding.Encoder(0);
+        var ctx = new DeltaZigzagEncoding.Encoder(0);
         int[] work = new int[BLOCK_LENGTH];
 
         int op = outPos.get();
@@ -68,7 +68,7 @@ public class DeltaZigzagBinaryPacking : IntegerCODEC
         int outLen = inBuf[inPos.get()];
         inPos.increment();
 
-        DeltaZigzagEncoding.Decoder ctx = new DeltaZigzagEncoding.Decoder(0);
+        var ctx = new DeltaZigzagEncoding.Decoder(0);
         int[] work = new int[BLOCK_LENGTH];
 
         int ip = inPos.get();

--- a/src/CSharpFastPFOR/DeltaZigzagBinaryPacking.cs
+++ b/src/CSharpFastPFOR/DeltaZigzagBinaryPacking.cs
@@ -18,7 +18,7 @@
 
 namespace Genbox.CSharpFastPFOR;
 
-public class DeltaZigzagBinaryPacking : IntegerCODEC
+public sealed class DeltaZigzagBinaryPacking : IntegerCODEC
 {
     private const int BLOCK_LENGTH = 128;
 

--- a/src/CSharpFastPFOR/DeltaZigzagBinaryPacking.cs
+++ b/src/CSharpFastPFOR/DeltaZigzagBinaryPacking.cs
@@ -16,93 +16,92 @@
  * @author MURAOKA Taro http://github.com/koron
  */
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class DeltaZigzagBinaryPacking : IntegerCODEC
 {
-    public class DeltaZigzagBinaryPacking : IntegerCODEC
+    private const int BLOCK_LENGTH = 128;
+
+    public void compress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
     {
-        private const int BLOCK_LENGTH = 128;
-
-        public void compress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
+        inLen = inLen - inLen % BLOCK_LENGTH;
+        if (inLen == 0)
         {
-            inLen = inLen - inLen % BLOCK_LENGTH;
-            if (inLen == 0)
-            {
-                return;
-            }
-
-            outBuf[outPos.get()] = inLen;
-            outPos.increment();
-
-            DeltaZigzagEncoding.Encoder ctx = new DeltaZigzagEncoding.Encoder(0);
-            int[] work = new int[BLOCK_LENGTH];
-
-            int op = outPos.get();
-            int ip = inPos.get();
-            int inPosLast = ip + inLen;
-            for (; ip < inPosLast; ip += BLOCK_LENGTH)
-            {
-                ctx.encodeArray(inBuf, ip, BLOCK_LENGTH, work);
-                int bits1 = Util.maxbits32(work, 0);
-                int bits2 = Util.maxbits32(work, 32);
-                int bits3 = Util.maxbits32(work, 64);
-                int bits4 = Util.maxbits32(work, 96);
-                outBuf[op++] = (bits1 << 24) | (bits2 << 16)
-                               | (bits3 << 8) | (bits4 << 0);
-                op += pack(work, 0, outBuf, op, bits1);
-                op += pack(work, 32, outBuf, op, bits2);
-                op += pack(work, 64, outBuf, op, bits3);
-                op += pack(work, 96, outBuf, op, bits4);
-            }
-
-            inPos.add(inLen);
-            outPos.set(op);
+            return;
         }
 
-        public void uncompress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
+        outBuf[outPos.get()] = inLen;
+        outPos.increment();
+
+        DeltaZigzagEncoding.Encoder ctx = new DeltaZigzagEncoding.Encoder(0);
+        int[] work = new int[BLOCK_LENGTH];
+
+        int op = outPos.get();
+        int ip = inPos.get();
+        int inPosLast = ip + inLen;
+        for (; ip < inPosLast; ip += BLOCK_LENGTH)
         {
-            if (inLen == 0)
-            {
-                return;
-            }
-
-            int outLen = inBuf[inPos.get()];
-            inPos.increment();
-
-            DeltaZigzagEncoding.Decoder ctx = new DeltaZigzagEncoding.Decoder(0);
-            int[] work = new int[BLOCK_LENGTH];
-
-            int ip = inPos.get();
-            int op = outPos.get();
-            int outPosLast = op + outLen;
-            for (; op < outPosLast; op += BLOCK_LENGTH)
-            {
-                int n = inBuf[ip++];
-                ip += unpack(inBuf, ip, work, 0, (n >> 24) & 0x3F);
-                ip += unpack(inBuf, ip, work, 32, (n >> 16) & 0x3F);
-                ip += unpack(inBuf, ip, work, 64, (n >> 8) & 0x3F);
-                ip += unpack(inBuf, ip, work, 96, (n >> 0) & 0x3F);
-                ctx.decodeArray(work, 0, BLOCK_LENGTH, outBuf, op);
-            }
-
-            outPos.add(outLen);
-            inPos.set(ip);
+            ctx.encodeArray(inBuf, ip, BLOCK_LENGTH, work);
+            int bits1 = Util.maxbits32(work, 0);
+            int bits2 = Util.maxbits32(work, 32);
+            int bits3 = Util.maxbits32(work, 64);
+            int bits4 = Util.maxbits32(work, 96);
+            outBuf[op++] = (bits1 << 24) | (bits2 << 16)
+                           | (bits3 << 8) | (bits4 << 0);
+            op += pack(work, 0, outBuf, op, bits1);
+            op += pack(work, 32, outBuf, op, bits2);
+            op += pack(work, 64, outBuf, op, bits3);
+            op += pack(work, 96, outBuf, op, bits4);
         }
 
-        private static int pack(int[] inBuf, int inOff, int[] outBuf, int outOff, int validBits)
+        inPos.add(inLen);
+        outPos.set(op);
+    }
+
+    public void uncompress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
+    {
+        if (inLen == 0)
         {
-            BitPacking.fastpackwithoutmask(inBuf, inOff, outBuf, outOff, validBits);
-            return validBits;
+            return;
         }
 
-        private static int unpack(int[] inBuf, int inOff, int[] outBuf, int outOff, int validBits)
+        int outLen = inBuf[inPos.get()];
+        inPos.increment();
+
+        DeltaZigzagEncoding.Decoder ctx = new DeltaZigzagEncoding.Decoder(0);
+        int[] work = new int[BLOCK_LENGTH];
+
+        int ip = inPos.get();
+        int op = outPos.get();
+        int outPosLast = op + outLen;
+        for (; op < outPosLast; op += BLOCK_LENGTH)
         {
-            BitPacking.fastunpack(inBuf, inOff, outBuf, outOff, validBits);
-            return validBits;
+            int n = inBuf[ip++];
+            ip += unpack(inBuf, ip, work, 0, (n >> 24) & 0x3F);
+            ip += unpack(inBuf, ip, work, 32, (n >> 16) & 0x3F);
+            ip += unpack(inBuf, ip, work, 64, (n >> 8) & 0x3F);
+            ip += unpack(inBuf, ip, work, 96, (n >> 0) & 0x3F);
+            ctx.decodeArray(work, 0, BLOCK_LENGTH, outBuf, op);
         }
 
-        public override string ToString()
-        {
-            return nameof(DeltaZigzagBinaryPacking);
-        }
+        outPos.add(outLen);
+        inPos.set(ip);
+    }
+
+    private static int pack(int[] inBuf, int inOff, int[] outBuf, int outOff, int validBits)
+    {
+        BitPacking.fastpackwithoutmask(inBuf, inOff, outBuf, outOff, validBits);
+        return validBits;
+    }
+
+    private static int unpack(int[] inBuf, int inOff, int[] outBuf, int outOff, int validBits)
+    {
+        BitPacking.fastunpack(inBuf, inOff, outBuf, outOff, validBits);
+        return validBits;
+    }
+
+    public override string ToString()
+    {
+        return nameof(DeltaZigzagBinaryPacking);
     }
 }

--- a/src/CSharpFastPFOR/DeltaZigzagEncoding.cs
+++ b/src/CSharpFastPFOR/DeltaZigzagEncoding.cs
@@ -8,101 +8,100 @@
  * 
  * @author MURAOKA Taro http://github.com/koron
  */
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class DeltaZigzagEncoding
 {
-    public class DeltaZigzagEncoding
+    public class Context
     {
-        public class Context
+        protected int ContextValue;
+
+        protected Context(int contextValue)
         {
-            protected int ContextValue;
-
-            protected Context(int contextValue)
-            {
-                ContextValue = contextValue;
-            }
-
-            public void setContextValue(int contextValue)
-            {
-                ContextValue = contextValue;
-            }
-
-            public int getContextValue()
-            {
-                return ContextValue;
-            }
+            ContextValue = contextValue;
         }
 
-        public class Encoder : Context
+        public void setContextValue(int contextValue)
         {
-            public Encoder(int contextValue) : base(contextValue)
-            {
-            }
-
-            public int encodeInt(int value)
-            {
-                int n = value - ContextValue;
-                ContextValue = value;
-                return (n << 1) ^ (n >> 31);
-            }
-
-            public int[] encodeArray(int[] src, int srcoff, int length, int[] dst, int dstoff)
-            {
-                for (int i = 0; i < length; ++i)
-                {
-                    dst[dstoff + i] = encodeInt(src[srcoff + i]);
-                }
-                return dst;
-            }
-
-            public int[] encodeArray(int[] src, int srcoff, int length, int[] dst)
-            {
-                return encodeArray(src, srcoff, length, dst, 0);
-            }
-
-            public int[] encodeArray(int[] src, int offset, int length)
-            {
-                return encodeArray(src, offset, length, new int[length], 0);
-            }
-
-            public int[] encodeArray(int[] src)
-            {
-                return encodeArray(src, 0, src.Length, new int[src.Length], 0);
-            }
+            ContextValue = contextValue;
         }
 
-        public class Decoder : Context
+        public int getContextValue()
         {
-            public Decoder(int contextValue) : base(contextValue)
-            {
-            }
+            return ContextValue;
+        }
+    }
 
-            public int decodeInt(int value)
-            {
-                int n = (int)((uint)value >> 1) ^ ((value << 31) >> 31);
-                n += ContextValue;
-                ContextValue = n;
-                return n;
-            }
+    public class Encoder : Context
+    {
+        public Encoder(int contextValue) : base(contextValue)
+        {
+        }
 
-            public int[] decodeArray(int[] src, int srcoff, int length,
-                int[] dst, int dstoff)
-            {
-                for (int i = 0; i < length; ++i)
-                {
-                    dst[dstoff + i] = decodeInt(src[srcoff + i]);
-                }
-                return dst;
-            }
+        public int encodeInt(int value)
+        {
+            int n = value - ContextValue;
+            ContextValue = value;
+            return (n << 1) ^ (n >> 31);
+        }
 
-            public int[] decodeArray(int[] src, int offset, int length)
+        public int[] encodeArray(int[] src, int srcoff, int length, int[] dst, int dstoff)
+        {
+            for (int i = 0; i < length; ++i)
             {
-                return decodeArray(src, offset, length, new int[length], 0);
+                dst[dstoff + i] = encodeInt(src[srcoff + i]);
             }
+            return dst;
+        }
 
-            public int[] decodeArray(int[] src)
+        public int[] encodeArray(int[] src, int srcoff, int length, int[] dst)
+        {
+            return encodeArray(src, srcoff, length, dst, 0);
+        }
+
+        public int[] encodeArray(int[] src, int offset, int length)
+        {
+            return encodeArray(src, offset, length, new int[length], 0);
+        }
+
+        public int[] encodeArray(int[] src)
+        {
+            return encodeArray(src, 0, src.Length, new int[src.Length], 0);
+        }
+    }
+
+    public class Decoder : Context
+    {
+        public Decoder(int contextValue) : base(contextValue)
+        {
+        }
+
+        public int decodeInt(int value)
+        {
+            int n = (int)((uint)value >> 1) ^ ((value << 31) >> 31);
+            n += ContextValue;
+            ContextValue = n;
+            return n;
+        }
+
+        public int[] decodeArray(int[] src, int srcoff, int length,
+            int[] dst, int dstoff)
+        {
+            for (int i = 0; i < length; ++i)
             {
-                return decodeArray(src, 0, src.Length);
+                dst[dstoff + i] = decodeInt(src[srcoff + i]);
             }
+            return dst;
+        }
+
+        public int[] decodeArray(int[] src, int offset, int length)
+        {
+            return decodeArray(src, offset, length, new int[length], 0);
+        }
+
+        public int[] decodeArray(int[] src)
+        {
+            return decodeArray(src, 0, src.Length);
         }
     }
 }

--- a/src/CSharpFastPFOR/DeltaZigzagVariableByte.cs
+++ b/src/CSharpFastPFOR/DeltaZigzagVariableByte.cs
@@ -11,116 +11,115 @@
 
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class DeltaZigzagVariableByte : IntegerCODEC
 {
-    public class DeltaZigzagVariableByte : IntegerCODEC
+    public void compress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
     {
-        public void compress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
+        if (inLen == 0)
         {
-            if (inLen == 0)
-            {
-                return;
-            }
-
-            ByteBuffer byteBuf = ByteBuffer.allocateDirect(inLen * 5 + 3);
-            DeltaZigzagEncoding.Encoder ctx = new DeltaZigzagEncoding.Encoder(0);
-
-            // Delta+Zigzag+VariableByte encoding.
-            int ip = inPos.get();
-
-            int inPosLast = ip + inLen;
-            for (; ip < inPosLast; ++ip)
-            {
-                // Filter with delta+zigzag encoding.
-                int n = ctx.encodeInt(inBuf[ip]);
-                // Variable byte encoding.
-
-                //PORT NOTE: The following IF statements are ported from a switch. Fall through switches are not allowed in C#
-                int zeros = Integer.numberOfLeadingZeros(n);
-
-                if (zeros < 4)
-                {
-                    byteBuf.put((sbyte)(((int)((uint)n >> 28) & 0x7F) | 0x80));
-                }
-
-                if (zeros < 11)
-                {
-                    byteBuf.put((sbyte)(((int)((uint)n >> 21) & 0x7F) | 0x80));
-                }
-
-                if (zeros < 18)
-                {
-                    byteBuf.put((sbyte)(((int)((uint)n >> 14) & 0x7F) | 0x80));
-                }
-
-                if (zeros < 25)
-                {
-                    byteBuf.put((sbyte)(((int)((uint)n >> 7) & 0x7F) | 0x80));
-                }
-
-                byteBuf.put((sbyte)((uint)n & 0x7F));
-            }
-
-            // Padding buffer to considerable as IntBuffer.
-            for (int i = (4 - (byteBuf.position() % 4)) % 4; i > 0; --i)
-            {
-                unchecked
-                {
-                    byteBuf.put((sbyte)(0x80));
-                }
-            }
-
-            int outLen = byteBuf.position() / 4;
-            byteBuf.flip();
-            IntBuffer intBuf = byteBuf.asIntBuffer();
-            /*
-         * Console.WriteLine(String.format(
-         * "inLen=%d pos=%d limit=%d outLen=%d outBuf.len=%d", inLen,
-         * intBuf.position(), intBuf.limit(), outLen, outBuf.Length));
-         */
-            intBuf.get(outBuf, outPos.get(), outLen);
-            inPos.add(inLen);
-            outPos.add(outLen);
+            return;
         }
 
-        public void uncompress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
+        ByteBuffer byteBuf = ByteBuffer.allocateDirect(inLen * 5 + 3);
+        DeltaZigzagEncoding.Encoder ctx = new DeltaZigzagEncoding.Encoder(0);
+
+        // Delta+Zigzag+VariableByte encoding.
+        int ip = inPos.get();
+
+        int inPosLast = ip + inLen;
+        for (; ip < inPosLast; ++ip)
         {
-            DeltaZigzagEncoding.Decoder ctx = new DeltaZigzagEncoding.Decoder(0);
+            // Filter with delta+zigzag encoding.
+            int n = ctx.encodeInt(inBuf[ip]);
+            // Variable byte encoding.
 
-            int ip = inPos.get();
-            int op = outPos.get();
-            int vbcNum = 0, vbcShift = 24; // Varialbe Byte Context.
+            //PORT NOTE: The following IF statements are ported from a switch. Fall through switches are not allowed in C#
+            int zeros = Integer.numberOfLeadingZeros(n);
 
-            int inPosLast = ip + inLen;
-            while (ip < inPosLast)
+            if (zeros < 4)
             {
-                // Fetch a byte value.
-                int n = (int)((uint)inBuf[ip] >> vbcShift) & 0xFF;
-                if (vbcShift > 0)
-                {
-                    vbcShift -= 8;
-                }
-                else
-                {
-                    vbcShift = 24;
-                    ip++;
-                }
-                // Decode variable byte and delta+zigzag.
-                vbcNum = (vbcNum << 7) + (n & 0x7F);
-                if ((n & 0x80) == 0)
-                {
-                    outBuf[op++] = ctx.decodeInt(vbcNum);
-                    vbcNum = 0;
-                }
+                byteBuf.put((sbyte)(((int)((uint)n >> 28) & 0x7F) | 0x80));
             }
 
-            outPos.set(op);
-            inPos.set(inPosLast);
+            if (zeros < 11)
+            {
+                byteBuf.put((sbyte)(((int)((uint)n >> 21) & 0x7F) | 0x80));
+            }
+
+            if (zeros < 18)
+            {
+                byteBuf.put((sbyte)(((int)((uint)n >> 14) & 0x7F) | 0x80));
+            }
+
+            if (zeros < 25)
+            {
+                byteBuf.put((sbyte)(((int)((uint)n >> 7) & 0x7F) | 0x80));
+            }
+
+            byteBuf.put((sbyte)((uint)n & 0x7F));
         }
 
-        public override string ToString()
+        // Padding buffer to considerable as IntBuffer.
+        for (int i = (4 - (byteBuf.position() % 4)) % 4; i > 0; --i)
         {
-            return nameof(DeltaZigzagVariableByte);
+            unchecked
+            {
+                byteBuf.put((sbyte)(0x80));
+            }
         }
+
+        int outLen = byteBuf.position() / 4;
+        byteBuf.flip();
+        IntBuffer intBuf = byteBuf.asIntBuffer();
+        /*
+     * Console.WriteLine(String.format(
+     * "inLen=%d pos=%d limit=%d outLen=%d outBuf.len=%d", inLen,
+     * intBuf.position(), intBuf.limit(), outLen, outBuf.Length));
+     */
+        intBuf.get(outBuf, outPos.get(), outLen);
+        inPos.add(inLen);
+        outPos.add(outLen);
+    }
+
+    public void uncompress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
+    {
+        DeltaZigzagEncoding.Decoder ctx = new DeltaZigzagEncoding.Decoder(0);
+
+        int ip = inPos.get();
+        int op = outPos.get();
+        int vbcNum = 0, vbcShift = 24; // Varialbe Byte Context.
+
+        int inPosLast = ip + inLen;
+        while (ip < inPosLast)
+        {
+            // Fetch a byte value.
+            int n = (int)((uint)inBuf[ip] >> vbcShift) & 0xFF;
+            if (vbcShift > 0)
+            {
+                vbcShift -= 8;
+            }
+            else
+            {
+                vbcShift = 24;
+                ip++;
+            }
+            // Decode variable byte and delta+zigzag.
+            vbcNum = (vbcNum << 7) + (n & 0x7F);
+            if ((n & 0x80) == 0)
+            {
+                outBuf[op++] = ctx.decodeInt(vbcNum);
+                vbcNum = 0;
+            }
+        }
+
+        outPos.set(op);
+        inPos.set(inPosLast);
+    }
+
+    public override string ToString()
+    {
+        return nameof(DeltaZigzagVariableByte);
     }
 }

--- a/src/CSharpFastPFOR/DeltaZigzagVariableByte.cs
+++ b/src/CSharpFastPFOR/DeltaZigzagVariableByte.cs
@@ -23,7 +23,7 @@ public class DeltaZigzagVariableByte : IntegerCODEC
         }
 
         ByteBuffer byteBuf = ByteBuffer.allocateDirect(inLen * 5 + 3);
-        DeltaZigzagEncoding.Encoder ctx = new DeltaZigzagEncoding.Encoder(0);
+        var ctx = new DeltaZigzagEncoding.Encoder(0);
 
         // Delta+Zigzag+VariableByte encoding.
         int ip = inPos.get();
@@ -85,7 +85,7 @@ public class DeltaZigzagVariableByte : IntegerCODEC
 
     public void uncompress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
     {
-        DeltaZigzagEncoding.Decoder ctx = new DeltaZigzagEncoding.Decoder(0);
+        var ctx = new DeltaZigzagEncoding.Decoder(0);
 
         int ip = inPos.get();
         int op = outPos.get();

--- a/src/CSharpFastPFOR/Differential/Delta.cs
+++ b/src/CSharpFastPFOR/Differential/Delta.cs
@@ -11,154 +11,153 @@
  * @author Daniel Lemire
  * 
  */
-namespace Genbox.CSharpFastPFOR.Differential
+namespace Genbox.CSharpFastPFOR.Differential;
+
+public class Delta
 {
-    public class Delta
+    /**
+     * Apply differential coding (in-place).
+     * 
+     * @param data
+     *                data to be modified
+     */
+    public static void delta(int[] data)
     {
-        /**
-         * Apply differential coding (in-place).
-         * 
-         * @param data
-         *                data to be modified
-         */
-        public static void delta(int[] data)
+        for (int i = data.Length - 1; i > 0; --i)
         {
-            for (int i = data.Length - 1; i > 0; --i)
+            data[i] -= data[i - 1];
+        }
+    }
+
+    /**
+     * Apply differential coding (in-place) given an initial value.
+     * 
+     * @param data
+     *                data to be modified
+     * @param start
+     *                starting index
+     * @param length
+     *                number of integers to process
+     * @param init
+     *                initial value
+     * @return next initial vale
+     */
+    public static int delta(int[] data, int start, int length, int init)
+    {
+        int nextinit = data[start + length - 1];
+        for (int i = length - 1; i > 0; --i)
+        {
+            data[start + i] -= data[start + i - 1];
+        }
+        data[start] -= init;
+        return nextinit;
+    }
+
+    /**
+     * Compute differential coding given an initial value. Output is written
+     * to a provided array: must have length "length" or better.
+     * 
+     * @param data
+     *                data to be modified
+     * @param start
+     *                starting index
+     * @param length
+     *                number of integers to process
+     * @param init
+     *                initial value
+     * @param out
+     *                output array
+     * @return next initial vale
+     */
+    public static int delta(int[] data, int start, int length, int init, int[] @out)
+    {
+        for (int i = length - 1; i > 0; --i)
+        {
+            @out[i] = data[start + i] - data[start + i - 1];
+        }
+        @out[0] = data[start] - init;
+        return data[start + length - 1];
+    }
+
+    /**
+     * Undo differential coding (in-place). Effectively computes a prefix
+     * sum.
+     * 
+     * @param data
+     *                to be modified.
+     */
+    public static void inverseDelta(int[] data)
+    {
+        for (int i = 1; i < data.Length; ++i)
+        {
+            data[i] += data[i - 1];
+        }
+    }
+
+    /**
+     * Undo differential coding (in-place). Effectively computes a prefix
+     * sum. Like inverseDelta, only faster.
+     * 
+     * @param data
+     *                to be modified
+     */
+    public static void fastinverseDelta(int[] data)
+    {
+        int sz0 = data.Length / 4 * 4;
+        int i = 1;
+        if (sz0 >= 4)
+        {
+            int a = data[0];
+            for (; i < sz0 - 4; i += 4)
             {
-                data[i] -= data[i - 1];
+                a = data[i] += a;
+                a = data[i + 1] += a;
+                a = data[i + 2] += a;
+                a = data[i + 3] += a;
             }
         }
 
-        /**
-         * Apply differential coding (in-place) given an initial value.
-         * 
-         * @param data
-         *                data to be modified
-         * @param start
-         *                starting index
-         * @param length
-         *                number of integers to process
-         * @param init
-         *                initial value
-         * @return next initial vale
-         */
-        public static int delta(int[] data, int start, int length, int init)
+        for (; i != data.Length; ++i)
         {
-            int nextinit = data[start + length - 1];
-            for (int i = length - 1; i > 0; --i)
-            {
-                data[start + i] -= data[start + i - 1];
-            }
-            data[start] -= init;
-            return nextinit;
+            data[i] += data[i - 1];
         }
+    }
 
-        /**
-         * Compute differential coding given an initial value. Output is written
-         * to a provided array: must have length "length" or better.
-         * 
-         * @param data
-         *                data to be modified
-         * @param start
-         *                starting index
-         * @param length
-         *                number of integers to process
-         * @param init
-         *                initial value
-         * @param out
-         *                output array
-         * @return next initial vale
-         */
-        public static int delta(int[] data, int start, int length, int init, int[] @out)
+    /**
+     * Undo differential coding (in-place). Effectively computes a prefix
+     * sum. Like inverseDelta, only faster. Uses an initial value.
+     * 
+     * @param data
+     *                to be modified
+     * @param start
+     *                starting index
+     * @param length
+     *                number of integers to process
+     * @param init
+     *                initial value
+     * @return next initial value
+     */
+    public static int fastinverseDelta(int[] data, int start, int length, int init)
+    {
+        data[start] += init;
+        int sz0 = length / 4 * 4;
+        int i = 1;
+        if (sz0 >= 4)
         {
-            for (int i = length - 1; i > 0; --i)
+            int a = data[start];
+            for (; i < sz0 - 4; i += 4)
             {
-                @out[i] = data[start + i] - data[start + i - 1];
-            }
-            @out[0] = data[start] - init;
-            return data[start + length - 1];
-        }
-
-        /**
-         * Undo differential coding (in-place). Effectively computes a prefix
-         * sum.
-         * 
-         * @param data
-         *                to be modified.
-         */
-        public static void inverseDelta(int[] data)
-        {
-            for (int i = 1; i < data.Length; ++i)
-            {
-                data[i] += data[i - 1];
+                a = data[start + i] += a;
+                a = data[start + i + 1] += a;
+                a = data[start + i + 2] += a;
+                a = data[start + i + 3] += a;
             }
         }
 
-        /**
-         * Undo differential coding (in-place). Effectively computes a prefix
-         * sum. Like inverseDelta, only faster.
-         * 
-         * @param data
-         *                to be modified
-         */
-        public static void fastinverseDelta(int[] data)
+        for (; i != length; ++i)
         {
-            int sz0 = data.Length / 4 * 4;
-            int i = 1;
-            if (sz0 >= 4)
-            {
-                int a = data[0];
-                for (; i < sz0 - 4; i += 4)
-                {
-                    a = data[i] += a;
-                    a = data[i + 1] += a;
-                    a = data[i + 2] += a;
-                    a = data[i + 3] += a;
-                }
-            }
-
-            for (; i != data.Length; ++i)
-            {
-                data[i] += data[i - 1];
-            }
+            data[start + i] += data[start + i - 1];
         }
-
-        /**
-         * Undo differential coding (in-place). Effectively computes a prefix
-         * sum. Like inverseDelta, only faster. Uses an initial value.
-         * 
-         * @param data
-         *                to be modified
-         * @param start
-         *                starting index
-         * @param length
-         *                number of integers to process
-         * @param init
-         *                initial value
-         * @return next initial value
-         */
-        public static int fastinverseDelta(int[] data, int start, int length, int init)
-        {
-            data[start] += init;
-            int sz0 = length / 4 * 4;
-            int i = 1;
-            if (sz0 >= 4)
-            {
-                int a = data[start];
-                for (; i < sz0 - 4; i += 4)
-                {
-                    a = data[start + i] += a;
-                    a = data[start + i + 1] += a;
-                    a = data[start + i + 2] += a;
-                    a = data[start + i + 3] += a;
-                }
-            }
-
-            for (; i != length; ++i)
-            {
-                data[start + i] += data[start + i - 1];
-            }
-            return data[start + length - 1];
-        }
+        return data[start + length - 1];
     }
 }

--- a/src/CSharpFastPFOR/Differential/IntegratedBinaryPacking.cs
+++ b/src/CSharpFastPFOR/Differential/IntegratedBinaryPacking.cs
@@ -41,129 +41,128 @@
  * 
  */
 
-namespace Genbox.CSharpFastPFOR.Differential
+namespace Genbox.CSharpFastPFOR.Differential;
+
+public class IntegratedBinaryPacking : IntegratedIntegerCODEC, SkippableIntegratedIntegerCODEC
 {
-    public class IntegratedBinaryPacking : IntegratedIntegerCODEC, SkippableIntegratedIntegerCODEC
+    private const int BLOCK_SIZE = 32;
+
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
     {
-        private const int BLOCK_SIZE = 32;
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos, new IntWrapper(0));
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength, new IntWrapper(0));
+    }
+
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, IntWrapper initvalue)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        int tmpoutpos = outpos.get();
+        int initoffset = initvalue.get();
+        initvalue.set(@in[inpos.get() + inlength - 1]);
+        int s = inpos.get();
+        for (; s + BLOCK_SIZE * 4 - 1 < inpos.get() + inlength; s += BLOCK_SIZE * 4)
         {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos, new IntWrapper(0));
+            int mbits1 = Util.maxdiffbits(initoffset, @in, s, BLOCK_SIZE);
+            int initoffset2 = @in[s + 31];
+            int mbits2 = Util.maxdiffbits(initoffset2, @in, s + BLOCK_SIZE, BLOCK_SIZE);
+            int initoffset3 = @in[s + BLOCK_SIZE + 31];
+            int mbits3 = Util
+                .maxdiffbits(initoffset3, @in, s + 2 * BLOCK_SIZE, BLOCK_SIZE);
+            int initoffset4 = @in[s + 2 * BLOCK_SIZE + 31];
+            int mbits4 = Util
+                .maxdiffbits(initoffset4, @in, s + 3 * BLOCK_SIZE, BLOCK_SIZE);
+            @out[tmpoutpos++] = (mbits1 << 24) | (mbits2 << 16) | (mbits3 << 8)
+                                | (mbits4);
+            IntegratedBitPacking.integratedpack(initoffset, @in, s, @out,
+                tmpoutpos, mbits1);
+            tmpoutpos += mbits1;
+            IntegratedBitPacking.integratedpack(initoffset2, @in, s + BLOCK_SIZE, @out,
+                tmpoutpos, mbits2);
+            tmpoutpos += mbits2;
+            IntegratedBitPacking.integratedpack(initoffset3, @in, s + 2 * BLOCK_SIZE,
+                @out, tmpoutpos, mbits3);
+            tmpoutpos += mbits3;
+            IntegratedBitPacking.integratedpack(initoffset4, @in, s + 3 * BLOCK_SIZE,
+                @out, tmpoutpos, mbits4);
+            tmpoutpos += mbits4;
+            initoffset = @in[s + 3 * BLOCK_SIZE + 31];
         }
-
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+        for (; s < inpos.get() + inlength; s += BLOCK_SIZE)
         {
-            if (inlength == 0)
-                return;
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength, new IntWrapper(0));
+            int mbits = Util.maxdiffbits(initoffset, @in, s, BLOCK_SIZE);
+            @out[tmpoutpos++] = mbits;
+            IntegratedBitPacking.integratedpack(initoffset, @in, s, @out,
+                tmpoutpos, mbits);
+            tmpoutpos += mbits;
+            initoffset = @in[s + 31];
         }
+        inpos.add(inlength);
+        outpos.set(tmpoutpos);
+    }
 
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, IntWrapper initvalue)
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num, IntWrapper initvalue)
+    {
+        int outlength = Util.greatestMultiple(num, BLOCK_SIZE);
+        int tmpinpos = inpos.get();
+        int initoffset = initvalue.get();
+        int s = outpos.get();
+        for (; s + BLOCK_SIZE * 4 - 1 < outpos.get() + outlength; s += BLOCK_SIZE * 4)
         {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            int tmpoutpos = outpos.get();
-            int initoffset = initvalue.get();
-            initvalue.set(@in[inpos.get() + inlength - 1]);
-            int s = inpos.get();
-            for (; s + BLOCK_SIZE * 4 - 1 < inpos.get() + inlength; s += BLOCK_SIZE * 4)
-            {
-                int mbits1 = Util.maxdiffbits(initoffset, @in, s, BLOCK_SIZE);
-                int initoffset2 = @in[s + 31];
-                int mbits2 = Util.maxdiffbits(initoffset2, @in, s + BLOCK_SIZE, BLOCK_SIZE);
-                int initoffset3 = @in[s + BLOCK_SIZE + 31];
-                int mbits3 = Util
-                    .maxdiffbits(initoffset3, @in, s + 2 * BLOCK_SIZE, BLOCK_SIZE);
-                int initoffset4 = @in[s + 2 * BLOCK_SIZE + 31];
-                int mbits4 = Util
-                    .maxdiffbits(initoffset4, @in, s + 3 * BLOCK_SIZE, BLOCK_SIZE);
-                @out[tmpoutpos++] = (mbits1 << 24) | (mbits2 << 16) | (mbits3 << 8)
-                                    | (mbits4);
-                IntegratedBitPacking.integratedpack(initoffset, @in, s, @out,
-                    tmpoutpos, mbits1);
-                tmpoutpos += mbits1;
-                IntegratedBitPacking.integratedpack(initoffset2, @in, s + BLOCK_SIZE, @out,
-                    tmpoutpos, mbits2);
-                tmpoutpos += mbits2;
-                IntegratedBitPacking.integratedpack(initoffset3, @in, s + 2 * BLOCK_SIZE,
-                    @out, tmpoutpos, mbits3);
-                tmpoutpos += mbits3;
-                IntegratedBitPacking.integratedpack(initoffset4, @in, s + 3 * BLOCK_SIZE,
-                    @out, tmpoutpos, mbits4);
-                tmpoutpos += mbits4;
-                initoffset = @in[s + 3 * BLOCK_SIZE + 31];
-            }
-            for (; s < inpos.get() + inlength; s += BLOCK_SIZE)
-            {
-                int mbits = Util.maxdiffbits(initoffset, @in, s, BLOCK_SIZE);
-                @out[tmpoutpos++] = mbits;
-                IntegratedBitPacking.integratedpack(initoffset, @in, s, @out,
-                    tmpoutpos, mbits);
-                tmpoutpos += mbits;
-                initoffset = @in[s + 31];
-            }
-            inpos.add(inlength);
-            outpos.set(tmpoutpos);
-        }
+            int mbits1 = (int)((uint)@in[tmpinpos] >> 24);
+            int mbits2 = (int)((uint)@in[tmpinpos] >> 16) & 0xFF;
+            int mbits3 = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
+            int mbits4 = (@in[tmpinpos]) & 0xFF;
 
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num, IntWrapper initvalue)
+            ++tmpinpos;
+            IntegratedBitPacking.integratedunpack(initoffset, @in, tmpinpos,
+                @out, s, mbits1);
+            tmpinpos += mbits1;
+            initoffset = @out[s + 31];
+            IntegratedBitPacking.integratedunpack(initoffset, @in, tmpinpos,
+                @out, s + BLOCK_SIZE, mbits2);
+            tmpinpos += mbits2;
+            initoffset = @out[s + BLOCK_SIZE + 31];
+            IntegratedBitPacking.integratedunpack(initoffset, @in, tmpinpos,
+                @out, s + 2 * BLOCK_SIZE, mbits3);
+            tmpinpos += mbits3;
+            initoffset = @out[s + 2 * BLOCK_SIZE + 31];
+            IntegratedBitPacking.integratedunpack(initoffset, @in, tmpinpos,
+                @out, s + 3 * BLOCK_SIZE, mbits4);
+            tmpinpos += mbits4;
+            initoffset = @out[s + 3 * BLOCK_SIZE + 31];
+        }
+        for (; s < outpos.get() + outlength; s += BLOCK_SIZE)
         {
-            int outlength = Util.greatestMultiple(num, BLOCK_SIZE);
-            int tmpinpos = inpos.get();
-            int initoffset = initvalue.get();
-            int s = outpos.get();
-            for (; s + BLOCK_SIZE * 4 - 1 < outpos.get() + outlength; s += BLOCK_SIZE * 4)
-            {
-                int mbits1 = (int)((uint)@in[tmpinpos] >> 24);
-                int mbits2 = (int)((uint)@in[tmpinpos] >> 16) & 0xFF;
-                int mbits3 = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
-                int mbits4 = (@in[tmpinpos]) & 0xFF;
+            int mbits = @in[tmpinpos];
+            ++tmpinpos;
+            IntegratedBitPacking.integratedunpack(initoffset, @in, tmpinpos,
+                @out, s, mbits);
+            initoffset = @out[s + 31];
 
-                ++tmpinpos;
-                IntegratedBitPacking.integratedunpack(initoffset, @in, tmpinpos,
-                    @out, s, mbits1);
-                tmpinpos += mbits1;
-                initoffset = @out[s + 31];
-                IntegratedBitPacking.integratedunpack(initoffset, @in, tmpinpos,
-                    @out, s + BLOCK_SIZE, mbits2);
-                tmpinpos += mbits2;
-                initoffset = @out[s + BLOCK_SIZE + 31];
-                IntegratedBitPacking.integratedunpack(initoffset, @in, tmpinpos,
-                    @out, s + 2 * BLOCK_SIZE, mbits3);
-                tmpinpos += mbits3;
-                initoffset = @out[s + 2 * BLOCK_SIZE + 31];
-                IntegratedBitPacking.integratedunpack(initoffset, @in, tmpinpos,
-                    @out, s + 3 * BLOCK_SIZE, mbits4);
-                tmpinpos += mbits4;
-                initoffset = @out[s + 3 * BLOCK_SIZE + 31];
-            }
-            for (; s < outpos.get() + outlength; s += BLOCK_SIZE)
-            {
-                int mbits = @in[tmpinpos];
-                ++tmpinpos;
-                IntegratedBitPacking.integratedunpack(initoffset, @in, tmpinpos,
-                    @out, s, mbits);
-                initoffset = @out[s + 31];
-
-                tmpinpos += mbits;
-            }
-            outpos.add(outlength);
-            initvalue.set(initoffset);
-            inpos.set(tmpinpos);
+            tmpinpos += mbits;
         }
+        outpos.add(outlength);
+        initvalue.set(initoffset);
+        inpos.set(tmpinpos);
+    }
 
-        public override string ToString()
-        {
-            return nameof(IntegratedBinaryPacking);
-        }
+    public override string ToString()
+    {
+        return nameof(IntegratedBinaryPacking);
     }
 }

--- a/src/CSharpFastPFOR/Differential/IntegratedBitPacking.cs
+++ b/src/CSharpFastPFOR/Differential/IntegratedBitPacking.cs
@@ -24,3894 +24,3893 @@
 using System;
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR.Differential
+namespace Genbox.CSharpFastPFOR.Differential;
+
+public class IntegratedBitPacking
 {
-    public class IntegratedBitPacking
+    /**
+     * Pack 32 integers as deltas with an initial value 
+     * 
+     * @param initoffset initial value (used to compute first delta)
+     * @param in input array
+     * @param inpos initial position in input array
+     * @param out output array
+     * @param outpos initial position in output array
+     * @param bit number of bits to use per integer
+     */
+    public static void integratedpack(int initoffset, int[] @in, int inpos, int[] @out, int outpos, int bit)
     {
-        /**
-         * Pack 32 integers as deltas with an initial value 
-         * 
-         * @param initoffset initial value (used to compute first delta)
-         * @param in input array
-         * @param inpos initial position in input array
-         * @param out output array
-         * @param outpos initial position in output array
-         * @param bit number of bits to use per integer
-         */
-        public static void integratedpack(int initoffset, int[] @in, int inpos, int[] @out, int outpos, int bit)
-        {
-            switch (bit)
-            {
-                case 0:
-                    integratedpack0(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 1:
-                    integratedpack1(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 2:
-                    integratedpack2(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 3:
-                    integratedpack3(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 4:
-                    integratedpack4(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 5:
-                    integratedpack5(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 6:
-                    integratedpack6(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 7:
-                    integratedpack7(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 8:
-                    integratedpack8(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 9:
-                    integratedpack9(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 10:
-                    integratedpack10(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 11:
-                    integratedpack11(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 12:
-                    integratedpack12(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 13:
-                    integratedpack13(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 14:
-                    integratedpack14(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 15:
-                    integratedpack15(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 16:
-                    integratedpack16(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 17:
-                    integratedpack17(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 18:
-                    integratedpack18(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 19:
-                    integratedpack19(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 20:
-                    integratedpack20(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 21:
-                    integratedpack21(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 22:
-                    integratedpack22(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 23:
-                    integratedpack23(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 24:
-                    integratedpack24(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 25:
-                    integratedpack25(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 26:
-                    integratedpack26(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 27:
-                    integratedpack27(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 28:
-                    integratedpack28(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 29:
-                    integratedpack29(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 30:
-                    integratedpack30(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 31:
-                    integratedpack31(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 32:
-                    integratedpack32(initoffset, @in, inpos, @out, outpos);
-                    break;
-                default:
-                    throw new Exception(
-                        "Unsupported bit width.");
-            }
-        }
-
-        protected static void integratedpack0(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            // nothing
-        }
-
-        protected static void integratedpack1(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 1)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 2)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 3)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 4)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 5)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 6)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 7)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 9)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 10)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 11)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 12)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 13)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 14)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 15)
-                               | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 17)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 18)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 19)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 20)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 21)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 22)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 23)
-                               | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24)
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 25)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 26)
-                               | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 27)
-                               | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 28)
-                               | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 29)
-                               | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 30)
-                               | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 31);
-        }
-
-        protected static void integratedpack10(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 10)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 20)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 30);
-            @out[1 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (10 - 8)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 8)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 18)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 28);
-            @out[2 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (10 - 6)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 6)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 26);
-            @out[3 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (10 - 4)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 4)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 14)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 24);
-            @out[4 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (10 - 2)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 2)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 12)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 22);
-            @out[5 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 10)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 20)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 30);
-            @out[6 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (10 - 8)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 8)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 18)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 28);
-            @out[7 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (10 - 6)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 6)
-                               | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16)
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 26);
-            @out[8 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (10 - 4)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 4)
-                               | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 14)
-                               | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 24);
-            @out[9 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (10 - 2)
-                               | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 2)
-                               | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 12)
-                               | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 22);
-        }
-
-        protected static void integratedpack11(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 11)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 22);
-            @out[1 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (11 - 1)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 1)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 12)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 23);
-            @out[2 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (11 - 2)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 2)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 13)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
-            @out[3 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (11 - 3)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 3)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 14)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 25);
-            @out[4 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (11 - 4)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 4)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 15)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 26);
-            @out[5 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (11 - 5)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 5)
-                               | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 27);
-            @out[6 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (11 - 6)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 6)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 17)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 28);
-            @out[7 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (11 - 7)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 7)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 18)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 29);
-            @out[8 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (11 - 8)
-                               | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 19)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 30);
-            @out[9 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (11 - 9)
-                               | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 9)
-                               | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 20)
-                               | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 31);
-            @out[10 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (11 - 10)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 10)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 21);
-        }
-
-        protected static void integratedpack12(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 12)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 24);
-            @out[1 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (12 - 4)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 4)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 16)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 28);
-            @out[2 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (12 - 8)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 8)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 20);
-            @out[3 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 12)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 24);
-            @out[4 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (12 - 4)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 4)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 16)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 28);
-            @out[5 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (12 - 8)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 8)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 20);
-            @out[6 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 12)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 24);
-            @out[7 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (12 - 4)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 4)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 16)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 28);
-            @out[8 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (12 - 8)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 8)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 20);
-            @out[9 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 12)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 24);
-            @out[10 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (12 - 4)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 4)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 16)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 28);
-            @out[11 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (12 - 8)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 8)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 20);
-        }
-
-        protected static void integratedpack13(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 13)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 26);
-            @out[1 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (13 - 7)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 7)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 20);
-            @out[2 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (13 - 1)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 1)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 14)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 27);
-            @out[3 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (13 - 8)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 21);
-            @out[4 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (13 - 2)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 2)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 15)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 28);
-            @out[5 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (13 - 9)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 9)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 22);
-            @out[6 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (13 - 3)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 3)
-                               | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 29);
-            @out[7 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (13 - 10)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 10)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 23);
-            @out[8 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (13 - 4)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 4)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 17)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 30);
-            @out[9 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (13 - 11)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 11)
-                               | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
-            @out[10 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (13 - 5)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 5)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 18)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 31);
-            @out[11 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (13 - 12)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 12)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 25);
-            @out[12 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (13 - 6)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 6)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 19);
-        }
-
-        protected static void integratedpack14(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 14)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 28);
-            @out[1 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (14 - 10)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 10)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 24);
-            @out[2 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (14 - 6)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 6)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 20);
-            @out[3 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (14 - 2)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 2)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 30);
-            @out[4 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (14 - 12)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 12)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 26);
-            @out[5 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (14 - 8)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 8)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 22);
-            @out[6 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (14 - 4)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 4)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 18);
-            @out[7 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 14)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 28);
-            @out[8 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (14 - 10)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 10)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 24);
-            @out[9 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (14 - 6)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 6)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 20);
-            @out[10 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (14 - 2)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 2)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 30);
-            @out[11 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (14 - 12)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 12)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 26);
-            @out[12 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (14 - 8)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 8)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 22);
-            @out[13 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (14 - 4)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 4)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 18);
-        }
-
-        protected static void integratedpack15(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 15)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 30);
-            @out[1 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (15 - 13)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 13)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 28);
-            @out[2 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (15 - 11)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 11)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 26);
-            @out[3 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (15 - 9)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 9)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
-            @out[4 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (15 - 7)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 7)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 22);
-            @out[5 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (15 - 5)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 5)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 20);
-            @out[6 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (15 - 3)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 3)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 18);
-            @out[7 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (15 - 1)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 1)
-                               | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 31);
-            @out[8 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (15 - 14)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 14)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 29);
-            @out[9 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (15 - 12)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 12)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 27);
-            @out[10 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (15 - 10)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 10)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 25);
-            @out[11 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (15 - 8)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 23);
-            @out[12 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (15 - 6)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 6)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 21);
-            @out[13 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (15 - 4)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 4)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 19);
-            @out[14 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (15 - 2)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 2)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 17);
-        }
-
-        protected static void integratedpack16(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 16);
-            @out[1 + outpos] = (@in[2 + inpos] - @in[2 + inpos - 1])
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 16);
-            @out[2 + outpos] = (@in[4 + inpos] - @in[4 + inpos - 1])
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 16);
-            @out[3 + outpos] = (@in[6 + inpos] - @in[6 + inpos - 1])
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 16);
-            @out[4 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 16);
-            @out[5 + outpos] = (@in[10 + inpos] - @in[10 + inpos - 1])
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 16);
-            @out[6 + outpos] = (@in[12 + inpos] - @in[12 + inpos - 1])
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 16);
-            @out[7 + outpos] = (@in[14 + inpos] - @in[14 + inpos - 1])
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 16);
-            @out[8 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 16);
-            @out[9 + outpos] = (@in[18 + inpos] - @in[18 + inpos - 1])
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 16);
-            @out[10 + outpos] = (@in[20 + inpos] - @in[20 + inpos - 1])
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 16);
-            @out[11 + outpos] = (@in[22 + inpos] - @in[22 + inpos - 1])
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 16);
-            @out[12 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 16);
-            @out[13 + outpos] = (@in[26 + inpos] - @in[26 + inpos - 1])
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 16);
-            @out[14 + outpos] = (@in[28 + inpos] - @in[28 + inpos - 1])
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 16);
-            @out[15 + outpos] = (@in[30 + inpos] - @in[30 + inpos - 1])
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 16);
-        }
-
-        protected static void integratedpack17(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 17);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (17 - 2)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 2)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 19);
-            @out[2 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (17 - 4)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 4)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 21);
-            @out[3 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (17 - 6)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 6)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 23);
-            @out[4 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (17 - 8)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 25);
-            @out[5 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (17 - 10)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 10)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 27);
-            @out[6 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (17 - 12)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 12)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 29);
-            @out[7 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (17 - 14)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 14)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 31);
-            @out[8 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (17 - 16)
-                               | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
-            @out[9 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (17 - 1)
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 1)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 18);
-            @out[10 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (17 - 3)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 3)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 20);
-            @out[11 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (17 - 5)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 5)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 22);
-            @out[12 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (17 - 7)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 7)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
-            @out[13 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (17 - 9)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 9)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 26);
-            @out[14 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (17 - 11)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 11)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 28);
-            @out[15 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (17 - 13)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 13)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 30);
-            @out[16 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (17 - 15)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 15);
-        }
-
-        protected static void integratedpack18(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 18);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (18 - 4)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 4)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 22);
-            @out[2 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (18 - 8)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 8)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 26);
-            @out[3 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (18 - 12)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 12)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 30);
-            @out[4 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (18 - 16)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16);
-            @out[5 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (18 - 2)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 2)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 20);
-            @out[6 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (18 - 6)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 6)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 24);
-            @out[7 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (18 - 10)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 10)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 28);
-            @out[8 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (18 - 14)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 14);
-            @out[9 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 18);
-            @out[10 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (18 - 4)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 4)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 22);
-            @out[11 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (18 - 8)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 8)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 26);
-            @out[12 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (18 - 12)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 12)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 30);
-            @out[13 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (18 - 16)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16);
-            @out[14 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (18 - 2)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 2)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 20);
-            @out[15 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (18 - 6)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 6)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 24);
-            @out[16 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (18 - 10)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 10)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 28);
-            @out[17 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (18 - 14)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 14);
-        }
-
-        protected static void integratedpack19(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 19);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (19 - 6)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 6)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 25);
-            @out[2 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (19 - 12)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 12)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 31);
-            @out[3 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (19 - 18)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 18);
-            @out[4 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (19 - 5)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 5)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
-            @out[5 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (19 - 11)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 11)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 30);
-            @out[6 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (19 - 17)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 17);
-            @out[7 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (19 - 4)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 4)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 23);
-            @out[8 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (19 - 10)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 10)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 29);
-            @out[9 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (19 - 16)
-                               | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
-            @out[10 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (19 - 3)
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 3)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 22);
-            @out[11 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (19 - 9)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 9)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 28);
-            @out[12 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (19 - 15)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 15);
-            @out[13 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (19 - 2)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 2)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 21);
-            @out[14 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (19 - 8)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 27);
-            @out[15 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (19 - 14)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 14);
-            @out[16 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (19 - 1)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 1)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 20);
-            @out[17 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (19 - 7)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 7)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 26);
-            @out[18 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (19 - 13)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 13);
-        }
-
-        protected static void integratedpack2(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 2)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 4)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 6)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 8)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 10)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 12)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 14)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 18)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 20)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 22)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 24)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 26)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 28)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 30);
-            @out[1 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 2)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 4)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 6)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 8)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 10)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 12)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 14)
-                               | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16)
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 18)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 20)
-                               | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 22)
-                               | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 24)
-                               | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 26)
-                               | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 28)
-                               | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 30);
-        }
-
-        protected static void integratedpack20(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 20);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (20 - 8)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 8)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 28);
-            @out[2 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (20 - 16)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 16);
-            @out[3 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (20 - 4)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 4)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 24);
-            @out[4 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (20 - 12)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 12);
-            @out[5 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 20);
-            @out[6 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (20 - 8)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 8)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 28);
-            @out[7 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (20 - 16)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 16);
-            @out[8 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (20 - 4)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 4)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 24);
-            @out[9 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (20 - 12)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 12);
-            @out[10 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 20);
-            @out[11 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (20 - 8)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 8)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 28);
-            @out[12 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (20 - 16)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 16);
-            @out[13 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (20 - 4)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 4)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 24);
-            @out[14 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (20 - 12)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 12);
-            @out[15 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 20);
-            @out[16 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (20 - 8)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 8)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 28);
-            @out[17 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (20 - 16)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 16);
-            @out[18 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (20 - 4)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 4)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 24);
-            @out[19 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (20 - 12)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 12);
-        }
-
-        protected static void integratedpack21(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 21);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (21 - 10)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 10)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 31);
-            @out[2 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (21 - 20)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 20);
-            @out[3 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (21 - 9)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 9)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 30);
-            @out[4 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (21 - 19)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 19);
-            @out[5 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (21 - 8)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 29);
-            @out[6 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (21 - 18)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 18);
-            @out[7 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (21 - 7)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 7)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 28);
-            @out[8 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (21 - 17)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 17);
-            @out[9 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (21 - 6)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 6)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 27);
-            @out[10 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (21 - 16)
-                                | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
-            @out[11 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (21 - 5)
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 5)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 26);
-            @out[12 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (21 - 15)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 15);
-            @out[13 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (21 - 4)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 4)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 25);
-            @out[14 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (21 - 14)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 14);
-            @out[15 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (21 - 3)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 3)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
-            @out[16 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (21 - 13)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 13);
-            @out[17 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (21 - 2)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 2)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 23);
-            @out[18 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (21 - 12)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 12);
-            @out[19 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (21 - 1)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 1)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 22);
-            @out[20 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (21 - 11)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 11);
-        }
-
-        protected static void integratedpack22(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 22);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (22 - 12)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 12);
-            @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (22 - 2)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 2)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 24);
-            @out[3 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (22 - 14)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 14);
-            @out[4 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (22 - 4)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 4)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 26);
-            @out[5 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (22 - 16)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16);
-            @out[6 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (22 - 6)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 6)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 28);
-            @out[7 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (22 - 18)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 18);
-            @out[8 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (22 - 8)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 8)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 30);
-            @out[9 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (22 - 20)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 20);
-            @out[10 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (22 - 10)
-                                | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 10);
-            @out[11 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 22);
-            @out[12 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (22 - 12)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 12);
-            @out[13 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (22 - 2)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 2)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 24);
-            @out[14 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (22 - 14)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 14);
-            @out[15 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (22 - 4)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 4)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 26);
-            @out[16 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (22 - 16)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16);
-            @out[17 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (22 - 6)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 6)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 28);
-            @out[18 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (22 - 18)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 18);
-            @out[19 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (22 - 8)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 8)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 30);
-            @out[20 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (22 - 20)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 20);
-            @out[21 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (22 - 10)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 10);
-        }
-
-        protected static void integratedpack23(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 23);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (23 - 14)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 14);
-            @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (23 - 5)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 5)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 28);
-            @out[3 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (23 - 19)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 19);
-            @out[4 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (23 - 10)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 10);
-            @out[5 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (23 - 1)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 1)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
-            @out[6 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (23 - 15)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 15);
-            @out[7 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (23 - 6)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 6)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 29);
-            @out[8 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (23 - 20)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 20);
-            @out[9 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (23 - 11)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 11);
-            @out[10 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (23 - 2)
-                                | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 2)
-                                | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 25);
-            @out[11 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (23 - 16)
-                                | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
-            @out[12 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (23 - 7)
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 7)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 30);
-            @out[13 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (23 - 21)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 21);
-            @out[14 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (23 - 12)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 12);
-            @out[15 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (23 - 3)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 3)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 26);
-            @out[16 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (23 - 17)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 17);
-            @out[17 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (23 - 8)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 31);
-            @out[18 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (23 - 22)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 22);
-            @out[19 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (23 - 13)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 13);
-            @out[20 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (23 - 4)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 4)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 27);
-            @out[21 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (23 - 18)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 18);
-            @out[22 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (23 - 9)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 9);
-        }
-
-        protected static void integratedpack24(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 24);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (24 - 16)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 16);
-            @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (24 - 8)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 8);
-            @out[3 + outpos] = (@in[4 + inpos] - @in[4 + inpos - 1])
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 24);
-            @out[4 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (24 - 16)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 16);
-            @out[5 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (24 - 8)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 8);
-            @out[6 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 24);
-            @out[7 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (24 - 16)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 16);
-            @out[8 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (24 - 8)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 8);
-            @out[9 + outpos] = (@in[12 + inpos] - @in[12 + inpos - 1])
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 24);
-            @out[10 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (24 - 16)
-                                | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 16);
-            @out[11 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (24 - 8)
-                                | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 8);
-            @out[12 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 24);
-            @out[13 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (24 - 16)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 16);
-            @out[14 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (24 - 8)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 8);
-            @out[15 + outpos] = (@in[20 + inpos] - @in[20 + inpos - 1])
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 24);
-            @out[16 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (24 - 16)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 16);
-            @out[17 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (24 - 8)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 8);
-            @out[18 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 24);
-            @out[19 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (24 - 16)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 16);
-            @out[20 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (24 - 8)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 8);
-            @out[21 + outpos] = (@in[28 + inpos] - @in[28 + inpos - 1])
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 24);
-            @out[22 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (24 - 16)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 16);
-            @out[23 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (24 - 8)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 8);
-        }
-
-        protected static void integratedpack25(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 25);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (25 - 18)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 18);
-            @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (25 - 11)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 11);
-            @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (25 - 4)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 4)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 29);
-            @out[4 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (25 - 22)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 22);
-            @out[5 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (25 - 15)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 15);
-            @out[6 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (25 - 8)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8);
-            @out[7 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (25 - 1)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 1)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 26);
-            @out[8 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (25 - 19)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 19);
-            @out[9 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (25 - 12)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 12);
-            @out[10 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (25 - 5)
-                                | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 5)
-                                | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 30);
-            @out[11 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (25 - 23)
-                                | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 23);
-            @out[12 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (25 - 16)
-                                | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
-            @out[13 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (25 - 9)
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 9);
-            @out[14 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (25 - 2)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 2)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 27);
-            @out[15 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (25 - 20)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 20);
-            @out[16 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (25 - 13)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 13);
-            @out[17 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (25 - 6)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 6)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 31);
-            @out[18 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (25 - 24)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
-            @out[19 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (25 - 17)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 17);
-            @out[20 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (25 - 10)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 10);
-            @out[21 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (25 - 3)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 3)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 28);
-            @out[22 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (25 - 21)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 21);
-            @out[23 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (25 - 14)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 14);
-            @out[24 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (25 - 7)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 7);
-        }
-
-        protected static void integratedpack26(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 26);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (26 - 20)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 20);
-            @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (26 - 14)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 14);
-            @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (26 - 8)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 8);
-            @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (26 - 2)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 2)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 28);
-            @out[5 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (26 - 22)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 22);
-            @out[6 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (26 - 16)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16);
-            @out[7 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (26 - 10)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 10);
-            @out[8 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (26 - 4)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 4)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 30);
-            @out[9 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (26 - 24)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 24);
-            @out[10 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (26 - 18)
-                                | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 18);
-            @out[11 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (26 - 12)
-                                | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 12);
-            @out[12 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (26 - 6)
-                                | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 6);
-            @out[13 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 26);
-            @out[14 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (26 - 20)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 20);
-            @out[15 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (26 - 14)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 14);
-            @out[16 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (26 - 8)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 8);
-            @out[17 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (26 - 2)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 2)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 28);
-            @out[18 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (26 - 22)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 22);
-            @out[19 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (26 - 16)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16);
-            @out[20 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (26 - 10)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 10);
-            @out[21 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (26 - 4)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 4)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 30);
-            @out[22 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (26 - 24)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 24);
-            @out[23 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (26 - 18)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 18);
-            @out[24 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (26 - 12)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 12);
-            @out[25 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (26 - 6)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 6);
-        }
-
-        protected static void integratedpack27(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 27);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (27 - 22)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 22);
-            @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (27 - 17)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 17);
-            @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (27 - 12)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 12);
-            @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (27 - 7)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 7);
-            @out[5 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (27 - 2)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 2)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 29);
-            @out[6 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (27 - 24)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
-            @out[7 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (27 - 19)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 19);
-            @out[8 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (27 - 14)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 14);
-            @out[9 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (27 - 9)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 9);
-            @out[10 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (27 - 4)
-                                | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 4)
-                                | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 31);
-            @out[11 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (27 - 26)
-                                | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 26);
-            @out[12 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (27 - 21)
-                                | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 21);
-            @out[13 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (27 - 16)
-                                | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
-            @out[14 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (27 - 11)
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 11);
-            @out[15 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (27 - 6)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 6);
-            @out[16 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (27 - 1)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 1)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 28);
-            @out[17 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (27 - 23)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 23);
-            @out[18 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (27 - 18)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 18);
-            @out[19 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (27 - 13)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 13);
-            @out[20 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (27 - 8)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8);
-            @out[21 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (27 - 3)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 3)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 30);
-            @out[22 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (27 - 25)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 25);
-            @out[23 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (27 - 20)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 20);
-            @out[24 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (27 - 15)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 15);
-            @out[25 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (27 - 10)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 10);
-            @out[26 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (27 - 5)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 5);
-        }
-
-        protected static void integratedpack28(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 28);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (28 - 24)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 24);
-            @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (28 - 20)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 20);
-            @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (28 - 16)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 16);
-            @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (28 - 12)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 12);
-            @out[5 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (28 - 8)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 8);
-            @out[6 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (28 - 4)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 4);
-            @out[7 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 28);
-            @out[8 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (28 - 24)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 24);
-            @out[9 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (28 - 20)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 20);
-            @out[10 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (28 - 16)
-                                | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 16);
-            @out[11 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (28 - 12)
-                                | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 12);
-            @out[12 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (28 - 8)
-                                | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 8);
-            @out[13 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (28 - 4)
-                                | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 4);
-            @out[14 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 28);
-            @out[15 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (28 - 24)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 24);
-            @out[16 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (28 - 20)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 20);
-            @out[17 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (28 - 16)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 16);
-            @out[18 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (28 - 12)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 12);
-            @out[19 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (28 - 8)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 8);
-            @out[20 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (28 - 4)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 4);
-            @out[21 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 28);
-            @out[22 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (28 - 24)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 24);
-            @out[23 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (28 - 20)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 20);
-            @out[24 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (28 - 16)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 16);
-            @out[25 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (28 - 12)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 12);
-            @out[26 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (28 - 8)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 8);
-            @out[27 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (28 - 4)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 4);
-        }
-
-        protected static void integratedpack29(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 29);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (29 - 26)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 26);
-            @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (29 - 23)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 23);
-            @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (29 - 20)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 20);
-            @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (29 - 17)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 17);
-            @out[5 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (29 - 14)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 14);
-            @out[6 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (29 - 11)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 11);
-            @out[7 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (29 - 8)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8);
-            @out[8 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (29 - 5)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 5);
-            @out[9 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (29 - 2)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 2)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 31);
-            @out[10 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (29 - 28)
-                                | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 28);
-            @out[11 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (29 - 25)
-                                | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 25);
-            @out[12 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (29 - 22)
-                                | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 22);
-            @out[13 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (29 - 19)
-                                | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 19);
-            @out[14 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (29 - 16)
-                                | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
-            @out[15 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (29 - 13)
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 13);
-            @out[16 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (29 - 10)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 10);
-            @out[17 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (29 - 7)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 7);
-            @out[18 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (29 - 4)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 4);
-            @out[19 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (29 - 1)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 1)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 30);
-            @out[20 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (29 - 27)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 27);
-            @out[21 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (29 - 24)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
-            @out[22 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (29 - 21)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 21);
-            @out[23 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (29 - 18)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 18);
-            @out[24 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (29 - 15)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 15);
-            @out[25 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (29 - 12)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 12);
-            @out[26 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (29 - 9)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 9);
-            @out[27 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (29 - 6)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 6);
-            @out[28 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (29 - 3)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 3);
-        }
-
-        protected static void integratedpack3(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 3)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 6)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 9)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 12)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 15)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 18)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 21)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 27)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 30);
-            @out[1 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (3 - 1)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 1)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 4)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 7)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 10)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 13)
-                               | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 19)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 22)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 25)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 28)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 31);
-            @out[2 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (3 - 2)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 2)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 5)
-                               | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 11)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 14)
-                               | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 17)
-                               | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 20)
-                               | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 23)
-                               | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 26)
-                               | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 29);
-        }
-
-        protected static void integratedpack30(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 30);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (30 - 28)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 28);
-            @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (30 - 26)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 26);
-            @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (30 - 24)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 24);
-            @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (30 - 22)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 22);
-            @out[5 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (30 - 20)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 20);
-            @out[6 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (30 - 18)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 18);
-            @out[7 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (30 - 16)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16);
-            @out[8 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (30 - 14)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 14);
-            @out[9 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (30 - 12)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 12);
-            @out[10 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (30 - 10)
-                                | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 10);
-            @out[11 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (30 - 8)
-                                | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 8);
-            @out[12 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (30 - 6)
-                                | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 6);
-            @out[13 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (30 - 4)
-                                | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 4);
-            @out[14 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (30 - 2)
-                                | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 2);
-            @out[15 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 30);
-            @out[16 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (30 - 28)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 28);
-            @out[17 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (30 - 26)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 26);
-            @out[18 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (30 - 24)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 24);
-            @out[19 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (30 - 22)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 22);
-            @out[20 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (30 - 20)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 20);
-            @out[21 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (30 - 18)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 18);
-            @out[22 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (30 - 16)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16);
-            @out[23 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (30 - 14)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 14);
-            @out[24 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (30 - 12)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 12);
-            @out[25 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (30 - 10)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 10);
-            @out[26 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (30 - 8)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 8);
-            @out[27 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (30 - 6)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 6);
-            @out[28 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (30 - 4)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 4);
-            @out[29 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (30 - 2)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 2);
-        }
-
-        protected static void integratedpack31(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 31);
-            @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (31 - 30)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 30);
-            @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (31 - 29)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 29);
-            @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (31 - 28)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 28);
-            @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (31 - 27)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 27);
-            @out[5 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (31 - 26)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 26);
-            @out[6 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (31 - 25)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 25);
-            @out[7 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (31 - 24)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
-            @out[8 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (31 - 23)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 23);
-            @out[9 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (31 - 22)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 22);
-            @out[10 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (31 - 21)
-                                | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 21);
-            @out[11 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (31 - 20)
-                                | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 20);
-            @out[12 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (31 - 19)
-                                | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 19);
-            @out[13 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (31 - 18)
-                                | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 18);
-            @out[14 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (31 - 17)
-                                | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 17);
-            @out[15 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (31 - 16)
-                                | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
-            @out[16 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (31 - 15)
-                                | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 15);
-            @out[17 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (31 - 14)
-                                | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 14);
-            @out[18 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (31 - 13)
-                                | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 13);
-            @out[19 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (31 - 12)
-                                | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 12);
-            @out[20 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (31 - 11)
-                                | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 11);
-            @out[21 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (31 - 10)
-                                | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 10);
-            @out[22 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (31 - 9)
-                                | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 9);
-            @out[23 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (31 - 8)
-                                | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8);
-            @out[24 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (31 - 7)
-                                | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 7);
-            @out[25 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (31 - 6)
-                                | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 6);
-            @out[26 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (31 - 5)
-                                | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 5);
-            @out[27 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (31 - 4)
-                                | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 4);
-            @out[28 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (31 - 3)
-                                | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 3);
-            @out[29 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (31 - 2)
-                                | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 2);
-            @out[30 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (31 - 1)
-                                | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 1);
-        }
-
-        protected static void integratedpack32(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            Array.Copy(@in, inpos, @out, outpos, 32); // no sense in
-                                                      // doing delta
-                                                      // coding
-        }
-
-        protected static void integratedpack4(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 4)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 8)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 12)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 16)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 20)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 24)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 28);
-            @out[1 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 4)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 8)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 12)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 16)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 20)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 24)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 28);
-            @out[2 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 4)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 8)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 12)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 16)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 20)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 24)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 28);
-            @out[3 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 4)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 8)
-                               | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 12)
-                               | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 16)
-                               | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 20)
-                               | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 24)
-                               | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 28);
-        }
-
-        protected static void integratedpack5(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 5)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 10)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 15)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 20)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 25)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 30);
-            @out[1 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (5 - 3)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 3)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 13)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 18)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 23)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 28);
-            @out[2 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (5 - 1)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 1)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 6)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 11)
-                               | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 21)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 26)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 31);
-            @out[3 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (5 - 4)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 4)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 9)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 14)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 19)
-                               | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24)
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 29);
-            @out[4 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (5 - 2)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 2)
-                               | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 7)
-                               | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 12)
-                               | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 17)
-                               | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 22)
-                               | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 27);
-        }
-
-        protected static void integratedpack6(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 6)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 12)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 18)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 24)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 30);
-            @out[1 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (6 - 4)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 4)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 10)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 22)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 28);
-            @out[2 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (6 - 2)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 2)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 8)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 14)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 20)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 26);
-            @out[3 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 6)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 12)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 18)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 24)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 30);
-            @out[4 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (6 - 4)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 4)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 10)
-                               | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16)
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 22)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 28);
-            @out[5 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (6 - 2)
-                               | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 2)
-                               | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 8)
-                               | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 14)
-                               | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 20)
-                               | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 26);
-        }
-
-        protected static void integratedpack7(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 7)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 14)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 21)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 28);
-            @out[1 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (7 - 3)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 3)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 10)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 17)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 31);
-            @out[2 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (7 - 6)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 6)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 13)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 20)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 27);
-            @out[3 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (7 - 2)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 2)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 9)
-                               | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 23)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 30);
-            @out[4 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (7 - 5)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 5)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 12)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 19)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 26);
-            @out[5 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (7 - 1)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 1)
-                               | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 15)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 22)
-                               | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 29);
-            @out[6 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (7 - 4)
-                               | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 4)
-                               | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 11)
-                               | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 18)
-                               | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 25);
-        }
-
-        protected static void integratedpack8(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 8)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 16)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 24);
-            @out[1 + outpos] = (@in[4 + inpos] - @in[4 + inpos - 1])
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 8)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 16)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 24);
-            @out[2 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 8)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 16)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 24);
-            @out[3 + outpos] = (@in[12 + inpos] - @in[12 + inpos - 1])
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 8)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 16)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 24);
-            @out[4 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 8)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 16)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 24);
-            @out[5 + outpos] = (@in[20 + inpos] - @in[20 + inpos - 1])
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 8)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 16)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 24);
-            @out[6 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 8)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 16)
-                               | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 24);
-            @out[7 + outpos] = (@in[28 + inpos] - @in[28 + inpos - 1])
-                               | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 8)
-                               | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 16)
-                               | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 24);
-        }
-
-        protected static void integratedpack9(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (@in[0 + inpos] - initoffset)
-                               | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 9)
-                               | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 18)
-                               | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 27);
-            @out[1 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (9 - 4)
-                               | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 4)
-                               | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 13)
-                               | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 22)
-                               | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 31);
-            @out[2 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (9 - 8)
-                               | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
-                               | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 17)
-                               | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 26);
-            @out[3 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (9 - 3)
-                               | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 3)
-                               | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 12)
-                               | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 21)
-                               | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 30);
-            @out[4 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (9 - 7)
-                               | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 7)
-                               | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
-                               | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 25);
-            @out[5 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (9 - 2)
-                               | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 2)
-                               | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 11)
-                               | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 20)
-                               | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 29);
-            @out[6 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (9 - 6)
-                               | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 6)
-                               | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 15)
-                               | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
-            @out[7 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (9 - 1)
-                               | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 1)
-                               | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 10)
-                               | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 19)
-                               | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 28);
-            @out[8 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (9 - 5)
-                               | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 5)
-                               | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 14)
-                               | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 23);
-        }
-
-        /**
-         * Unpack 32 integers along with prefix sum computation
-         * 
-         * @param initoffset value to add to all outputted values
-         * @param in source array
-         * @param inpos initial position in source array
-         * @param out output array
-         * @param outpos initial position in output array
-         * @param bit number of bits to use per integer
-         */
-        public static void integratedunpack(int initoffset, int[] @in, int inpos, int[] @out, int outpos, int bit)
-        {
-            switch (bit)
-            {
-                case 0:
-                    integratedunpack0(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 1:
-                    integratedunpack1(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 2:
-                    integratedunpack2(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 3:
-                    integratedunpack3(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 4:
-                    integratedunpack4(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 5:
-                    integratedunpack5(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 6:
-                    integratedunpack6(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 7:
-                    integratedunpack7(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 8:
-                    integratedunpack8(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 9:
-                    integratedunpack9(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 10:
-                    integratedunpack10(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 11:
-                    integratedunpack11(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 12:
-                    integratedunpack12(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 13:
-                    integratedunpack13(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 14:
-                    integratedunpack14(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 15:
-                    integratedunpack15(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 16:
-                    integratedunpack16(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 17:
-                    integratedunpack17(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 18:
-                    integratedunpack18(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 19:
-                    integratedunpack19(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 20:
-                    integratedunpack20(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 21:
-                    integratedunpack21(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 22:
-                    integratedunpack22(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 23:
-                    integratedunpack23(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 24:
-                    integratedunpack24(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 25:
-                    integratedunpack25(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 26:
-                    integratedunpack26(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 27:
-                    integratedunpack27(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 28:
-                    integratedunpack28(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 29:
-                    integratedunpack29(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 30:
-                    integratedunpack30(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 31:
-                    integratedunpack31(initoffset, @in, inpos, @out, outpos);
-                    break;
-                case 32:
-                    integratedunpack32(initoffset, @in, inpos, @out, outpos);
-                    break;
-                default:
-                    throw new ArgumentException(
-                        "Unsupported bit width.");
-            }
-        }
-
-        protected static void integratedunpack0(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            Arrays.fill(@out, outpos, outpos + 32, initoffset);
-        }
-
-        protected static void integratedunpack1(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 1)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 1) & 1))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 2) & 1))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 3) & 1))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 4) & 1))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[0 + inpos] >> 5) & 1))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[0 + inpos] >> 6) & 1))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[0 + inpos] >> 7) & 1))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[0 + inpos] >> 8) & 1))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[0 + inpos] >> 9) & 1))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[0 + inpos] >> 10) & 1))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[0 + inpos] >> 11) & 1))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 1))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[0 + inpos] >> 13) & 1))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[0 + inpos] >> 14) & 1))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = (((int)((uint)@in[0 + inpos] >> 15) & 1))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[0 + inpos] >> 16) & 1))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[0 + inpos] >> 17) & 1))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[0 + inpos] >> 18) & 1))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[0 + inpos] >> 19) & 1))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[0 + inpos] >> 20) & 1))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[0 + inpos] >> 21) & 1))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[0 + inpos] >> 22) & 1))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[0 + inpos] >> 23) & 1))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[0 + inpos] >> 24) & 1))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[0 + inpos] >> 25) & 1))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[0 + inpos] >> 26) & 1))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[0 + inpos] >> 27) & 1))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[0 + inpos] >> 28) & 1))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[0 + inpos] >> 29) & 1))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[0 + inpos] >> 30) & 1))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[0 + inpos] >> 31))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack10(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 1023)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 10) & 1023))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 20) & 1023))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 255) << (10 - 8)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 1023))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[1 + inpos] >> 18) & 1023))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 63) << (10 - 6)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[2 + inpos] >> 6) & 1023))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[2 + inpos] >> 16) & 1023))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[2 + inpos] >> 26) | ((@in[3 + inpos] & 15) << (10 - 4)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[3 + inpos] >> 4) & 1023))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[3 + inpos] >> 14) & 1023))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 3) << (10 - 2)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[4 + inpos] >> 2) & 1023))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[4 + inpos] >> 12) & 1023))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[4 + inpos] >> 22))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[5 + inpos] >> 0) & 1023))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[5 + inpos] >> 10) & 1023))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[5 + inpos] >> 20) & 1023))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[5 + inpos] >> 30) | ((@in[6 + inpos] & 255) << (10 - 8)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[6 + inpos] >> 8) & 1023))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[6 + inpos] >> 18) & 1023))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[6 + inpos] >> 28) | ((@in[7 + inpos] & 63) << (10 - 6)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[7 + inpos] >> 6) & 1023))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[7 + inpos] >> 16) & 1023))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[7 + inpos] >> 26) | ((@in[8 + inpos] & 15) << (10 - 4)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[8 + inpos] >> 4) & 1023))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[8 + inpos] >> 14) & 1023))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[8 + inpos] >> 24) | ((@in[9 + inpos] & 3) << (10 - 2)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[9 + inpos] >> 2) & 1023))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[9 + inpos] >> 12) & 1023))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[9 + inpos] >> 22))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack11(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 2047)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 11) & 2047))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[0 + inpos] >> 22) | ((@in[1 + inpos] & 1) << (11 - 1)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[1 + inpos] >> 1) & 2047))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[1 + inpos] >> 12) & 2047))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[1 + inpos] >> 23) | ((@in[2 + inpos] & 3) << (11 - 2)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[2 + inpos] >> 2) & 2047))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[2 + inpos] >> 13) & 2047))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[2 + inpos] >> 24) | ((@in[3 + inpos] & 7) << (11 - 3)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[3 + inpos] >> 3) & 2047))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[3 + inpos] >> 14) & 2047))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[3 + inpos] >> 25) | ((@in[4 + inpos] & 15) << (11 - 4)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[4 + inpos] >> 4) & 2047))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[4 + inpos] >> 15) & 2047))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[4 + inpos] >> 26) | ((@in[5 + inpos] & 31) << (11 - 5)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = (((int)((uint)@in[5 + inpos] >> 5) & 2047))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[5 + inpos] >> 16) & 2047))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[5 + inpos] >> 27) | ((@in[6 + inpos] & 63) << (11 - 6)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[6 + inpos] >> 6) & 2047))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[6 + inpos] >> 17) & 2047))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[6 + inpos] >> 28) | ((@in[7 + inpos] & 127) << (11 - 7)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[7 + inpos] >> 7) & 2047))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[7 + inpos] >> 18) & 2047))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[7 + inpos] >> 29) | ((@in[8 + inpos] & 255) << (11 - 8)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[8 + inpos] >> 8) & 2047))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[8 + inpos] >> 19) & 2047))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[8 + inpos] >> 30) | ((@in[9 + inpos] & 511) << (11 - 9)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[9 + inpos] >> 9) & 2047))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[9 + inpos] >> 20) & 2047))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[9 + inpos] >> 31) | ((@in[10 + inpos] & 1023) << (11 - 10)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[10 + inpos] >> 10) & 2047))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[10 + inpos] >> 21))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack12(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 4095)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 4095))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[0 + inpos] >> 24) | ((@in[1 + inpos] & 15) << (12 - 4)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 4095))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 4095))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 255) << (12 - 8)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 4095))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[2 + inpos] >> 20))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 4095))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[3 + inpos] >> 12) & 4095))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 15) << (12 - 4)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[4 + inpos] >> 4) & 4095))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[4 + inpos] >> 16) & 4095))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[4 + inpos] >> 28) | ((@in[5 + inpos] & 255) << (12 - 8)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 4095))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[5 + inpos] >> 20))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[6 + inpos] >> 0) & 4095))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[6 + inpos] >> 12) & 4095))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[6 + inpos] >> 24) | ((@in[7 + inpos] & 15) << (12 - 4)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[7 + inpos] >> 4) & 4095))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[7 + inpos] >> 16) & 4095))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 255) << (12 - 8)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[8 + inpos] >> 8) & 4095))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[8 + inpos] >> 20))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[9 + inpos] >> 0) & 4095))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[9 + inpos] >> 12) & 4095))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[9 + inpos] >> 24) | ((@in[10 + inpos] & 15) << (12 - 4)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[10 + inpos] >> 4) & 4095))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[10 + inpos] >> 16) & 4095))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[10 + inpos] >> 28) | ((@in[11 + inpos] & 255) << (12 - 8)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[11 + inpos] >> 8) & 4095))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[11 + inpos] >> 20))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack13(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 8191)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 13) & 8191))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[0 + inpos] >> 26) | ((@in[1 + inpos] & 127) << (13 - 7)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[1 + inpos] >> 7) & 8191))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[1 + inpos] >> 20) | ((@in[2 + inpos] & 1) << (13 - 1)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[2 + inpos] >> 1) & 8191))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[2 + inpos] >> 14) & 8191))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[2 + inpos] >> 27) | ((@in[3 + inpos] & 255) << (13 - 8)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[3 + inpos] >> 8) & 8191))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[3 + inpos] >> 21) | ((@in[4 + inpos] & 3) << (13 - 2)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[4 + inpos] >> 2) & 8191))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[4 + inpos] >> 15) & 8191))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[4 + inpos] >> 28) | ((@in[5 + inpos] & 511) << (13 - 9)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[5 + inpos] >> 9) & 8191))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[5 + inpos] >> 22) | ((@in[6 + inpos] & 7) << (13 - 3)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = (((int)((uint)@in[6 + inpos] >> 3) & 8191))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[6 + inpos] >> 16) & 8191))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[6 + inpos] >> 29) | ((@in[7 + inpos] & 1023) << (13 - 10)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[7 + inpos] >> 10) & 8191))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[7 + inpos] >> 23) | ((@in[8 + inpos] & 15) << (13 - 4)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[8 + inpos] >> 4) & 8191))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[8 + inpos] >> 17) & 8191))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[8 + inpos] >> 30) | ((@in[9 + inpos] & 2047) << (13 - 11)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[9 + inpos] >> 11) & 8191))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[9 + inpos] >> 24) | ((@in[10 + inpos] & 31) << (13 - 5)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[10 + inpos] >> 5) & 8191))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[10 + inpos] >> 18) & 8191))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[10 + inpos] >> 31) | ((@in[11 + inpos] & 4095) << (13 - 12)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[11 + inpos] >> 12) & 8191))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[11 + inpos] >> 25) | ((@in[12 + inpos] & 63) << (13 - 6)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[12 + inpos] >> 6) & 8191))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[12 + inpos] >> 19))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack14(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 16383))
-                               + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 14) & 16383))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[0 + inpos] >> 28) | ((@in[1 + inpos] & 1023) << (14 - 10)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 16383))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[1 + inpos] >> 24) | ((@in[2 + inpos] & 63) << (14 - 6)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[2 + inpos] >> 6) & 16383))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[2 + inpos] >> 20) | ((@in[3 + inpos] & 3) << (14 - 2)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[3 + inpos] >> 2) & 16383))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[3 + inpos] >> 16) & 16383))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 4095) << (14 - 12)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[4 + inpos] >> 12) & 16383))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[4 + inpos] >> 26) | ((@in[5 + inpos] & 255) << (14 - 8)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 16383))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[5 + inpos] >> 22) | ((@in[6 + inpos] & 15) << (14 - 4)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[6 + inpos] >> 4) & 16383))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[6 + inpos] >> 18))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[7 + inpos] >> 0) & 16383))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[7 + inpos] >> 14) & 16383))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 1023) << (14 - 10)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[8 + inpos] >> 10) & 16383))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[8 + inpos] >> 24) | ((@in[9 + inpos] & 63) << (14 - 6)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[9 + inpos] >> 6) & 16383))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[9 + inpos] >> 20) | ((@in[10 + inpos] & 3) << (14 - 2)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[10 + inpos] >> 2) & 16383))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[10 + inpos] >> 16) & 16383))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[10 + inpos] >> 30) | ((@in[11 + inpos] & 4095) << (14 - 12)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[11 + inpos] >> 12) & 16383))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[11 + inpos] >> 26) | ((@in[12 + inpos] & 255) << (14 - 8)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[12 + inpos] >> 8) & 16383))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[12 + inpos] >> 22) | ((@in[13 + inpos] & 15) << (14 - 4)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[13 + inpos] >> 4) & 16383))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[13 + inpos] >> 18))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack15(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 32767))
-                               + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 15) & 32767))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 8191) << (15 - 13)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[1 + inpos] >> 13) & 32767))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 2047) << (15 - 11)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[2 + inpos] >> 11) & 32767))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[2 + inpos] >> 26) | ((@in[3 + inpos] & 511) << (15 - 9)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[3 + inpos] >> 9) & 32767))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 127) << (15 - 7)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[4 + inpos] >> 7) & 32767))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[4 + inpos] >> 22) | ((@in[5 + inpos] & 31) << (15 - 5)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[5 + inpos] >> 5) & 32767))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[5 + inpos] >> 20) | ((@in[6 + inpos] & 7) << (15 - 3)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[6 + inpos] >> 3) & 32767))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[6 + inpos] >> 18) | ((@in[7 + inpos] & 1) << (15 - 1)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = (((int)((uint)@in[7 + inpos] >> 1) & 32767))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[7 + inpos] >> 16) & 32767))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[7 + inpos] >> 31) | ((@in[8 + inpos] & 16383) << (15 - 14)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[8 + inpos] >> 14) & 32767))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[8 + inpos] >> 29) | ((@in[9 + inpos] & 4095) << (15 - 12)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[9 + inpos] >> 12) & 32767))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[9 + inpos] >> 27) | ((@in[10 + inpos] & 1023) << (15 - 10)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[10 + inpos] >> 10) & 32767))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[10 + inpos] >> 25) | ((@in[11 + inpos] & 255) << (15 - 8)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[11 + inpos] >> 8) & 32767))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[11 + inpos] >> 23) | ((@in[12 + inpos] & 63) << (15 - 6)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[12 + inpos] >> 6) & 32767))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[12 + inpos] >> 21) | ((@in[13 + inpos] & 15) << (15 - 4)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[13 + inpos] >> 4) & 32767))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[13 + inpos] >> 19) | ((@in[14 + inpos] & 3) << (15 - 2)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[14 + inpos] >> 2) & 32767))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[14 + inpos] >> 17))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack16(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 65535))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 16))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 0) & 65535))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 16))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[2 + inpos] >> 0) & 65535))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[2 + inpos] >> 16))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 65535))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[3 + inpos] >> 16))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[4 + inpos] >> 0) & 65535))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[4 + inpos] >> 16))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[5 + inpos] >> 0) & 65535))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[5 + inpos] >> 16))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[6 + inpos] >> 0) & 65535))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[6 + inpos] >> 16))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[7 + inpos] >> 0) & 65535))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[7 + inpos] >> 16))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[8 + inpos] >> 0) & 65535))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[8 + inpos] >> 16))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[9 + inpos] >> 0) & 65535))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[9 + inpos] >> 16))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[10 + inpos] >> 0) & 65535))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[10 + inpos] >> 16))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[11 + inpos] >> 0) & 65535))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[11 + inpos] >> 16))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[12 + inpos] >> 0) & 65535))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[12 + inpos] >> 16))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[13 + inpos] >> 0) & 65535))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[13 + inpos] >> 16))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[14 + inpos] >> 0) & 65535))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[14 + inpos] >> 16))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[15 + inpos] >> 0) & 65535))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[15 + inpos] >> 16))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack17(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 131071))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 17) | ((@in[1 + inpos] & 3) << (17 - 2)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 2) & 131071))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 19) | ((@in[2 + inpos] & 15) << (17 - 4)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[2 + inpos] >> 4) & 131071))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[2 + inpos] >> 21) | ((@in[3 + inpos] & 63) << (17 - 6)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[3 + inpos] >> 6) & 131071))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[3 + inpos] >> 23) | ((@in[4 + inpos] & 255) << (17 - 8)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[4 + inpos] >> 8) & 131071))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[4 + inpos] >> 25) | ((@in[5 + inpos] & 1023) << (17 - 10)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[5 + inpos] >> 10) & 131071))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[5 + inpos] >> 27) | ((@in[6 + inpos] & 4095) << (17 - 12)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[6 + inpos] >> 12) & 131071))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[6 + inpos] >> 29) | ((@in[7 + inpos] & 16383) << (17 - 14)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[7 + inpos] >> 14) & 131071))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[7 + inpos] >> 31) | ((@in[8 + inpos] & 65535) << (17 - 16)))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = ((int)((uint)@in[8 + inpos] >> 16) | ((@in[9 + inpos] & 1) << (17 - 1)))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[9 + inpos] >> 1) & 131071))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[9 + inpos] >> 18) | ((@in[10 + inpos] & 7) << (17 - 3)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[10 + inpos] >> 3) & 131071))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[10 + inpos] >> 20) | ((@in[11 + inpos] & 31) << (17 - 5)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[11 + inpos] >> 5) & 131071))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[11 + inpos] >> 22) | ((@in[12 + inpos] & 127) << (17 - 7)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[12 + inpos] >> 7) & 131071))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[12 + inpos] >> 24) | ((@in[13 + inpos] & 511) << (17 - 9)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[13 + inpos] >> 9) & 131071))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[13 + inpos] >> 26) | ((@in[14 + inpos] & 2047) << (17 - 11)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[14 + inpos] >> 11) & 131071))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[14 + inpos] >> 28) | ((@in[15 + inpos] & 8191) << (17 - 13)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[15 + inpos] >> 13) & 131071))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[15 + inpos] >> 30) | ((@in[16 + inpos] & 32767) << (17 - 15)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[16 + inpos] >> 15))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack18(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 262143))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 18) | ((@in[1 + inpos] & 15) << (18 - 4)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 262143))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 22) | ((@in[2 + inpos] & 255) << (18 - 8)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 262143))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[2 + inpos] >> 26) | ((@in[3 + inpos] & 4095) << (18 - 12)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[3 + inpos] >> 12) & 262143))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 65535) << (18 - 16)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[4 + inpos] >> 16) | ((@in[5 + inpos] & 3) << (18 - 2)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[5 + inpos] >> 2) & 262143))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[5 + inpos] >> 20) | ((@in[6 + inpos] & 63) << (18 - 6)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[6 + inpos] >> 6) & 262143))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[6 + inpos] >> 24) | ((@in[7 + inpos] & 1023) << (18 - 10)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[7 + inpos] >> 10) & 262143))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 16383) << (18 - 14)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[8 + inpos] >> 14))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[9 + inpos] >> 0) & 262143))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[9 + inpos] >> 18) | ((@in[10 + inpos] & 15) << (18 - 4)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[10 + inpos] >> 4) & 262143))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[10 + inpos] >> 22) | ((@in[11 + inpos] & 255) << (18 - 8)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[11 + inpos] >> 8) & 262143))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[11 + inpos] >> 26) | ((@in[12 + inpos] & 4095) << (18 - 12)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[12 + inpos] >> 12) & 262143))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[12 + inpos] >> 30) | ((@in[13 + inpos] & 65535) << (18 - 16)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[13 + inpos] >> 16) | ((@in[14 + inpos] & 3) << (18 - 2)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[14 + inpos] >> 2) & 262143))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[14 + inpos] >> 20) | ((@in[15 + inpos] & 63) << (18 - 6)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[15 + inpos] >> 6) & 262143))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[15 + inpos] >> 24) | ((@in[16 + inpos] & 1023) << (18 - 10)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[16 + inpos] >> 10) & 262143))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[16 + inpos] >> 28) | ((@in[17 + inpos] & 16383) << (18 - 14)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[17 + inpos] >> 14))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack19(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 524287))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 19) | ((@in[1 + inpos] & 63) << (19 - 6)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 6) & 524287))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 25) | ((@in[2 + inpos] & 4095) << (19 - 12)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[2 + inpos] >> 12) & 524287))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[2 + inpos] >> 31) | ((@in[3 + inpos] & 262143) << (19 - 18)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[3 + inpos] >> 18) | ((@in[4 + inpos] & 31) << (19 - 5)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[4 + inpos] >> 5) & 524287))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[4 + inpos] >> 24) | ((@in[5 + inpos] & 2047) << (19 - 11)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[5 + inpos] >> 11) & 524287))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[5 + inpos] >> 30) | ((@in[6 + inpos] & 131071) << (19 - 17)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[6 + inpos] >> 17) | ((@in[7 + inpos] & 15) << (19 - 4)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[7 + inpos] >> 4) & 524287))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[7 + inpos] >> 23) | ((@in[8 + inpos] & 1023) << (19 - 10)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[8 + inpos] >> 10) & 524287))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[8 + inpos] >> 29) | ((@in[9 + inpos] & 65535) << (19 - 16)))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = ((int)((uint)@in[9 + inpos] >> 16) | ((@in[10 + inpos] & 7) << (19 - 3)))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[10 + inpos] >> 3) & 524287))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[10 + inpos] >> 22) | ((@in[11 + inpos] & 511) << (19 - 9)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[11 + inpos] >> 9) & 524287))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[11 + inpos] >> 28) | ((@in[12 + inpos] & 32767) << (19 - 15)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[12 + inpos] >> 15) | ((@in[13 + inpos] & 3) << (19 - 2)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[13 + inpos] >> 2) & 524287))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[13 + inpos] >> 21) | ((@in[14 + inpos] & 255) << (19 - 8)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[14 + inpos] >> 8) & 524287))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[14 + inpos] >> 27) | ((@in[15 + inpos] & 16383) << (19 - 14)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[15 + inpos] >> 14) | ((@in[16 + inpos] & 1) << (19 - 1)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[16 + inpos] >> 1) & 524287))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[16 + inpos] >> 20) | ((@in[17 + inpos] & 127) << (19 - 7)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[17 + inpos] >> 7) & 524287))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[17 + inpos] >> 26) | ((@in[18 + inpos] & 8191) << (19 - 13)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[18 + inpos] >> 13))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack2(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 3)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 2) & 3))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 4) & 3))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 6) & 3))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 8) & 3))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[0 + inpos] >> 10) & 3))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 3))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[0 + inpos] >> 14) & 3))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[0 + inpos] >> 16) & 3))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[0 + inpos] >> 18) & 3))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[0 + inpos] >> 20) & 3))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[0 + inpos] >> 22) & 3))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[0 + inpos] >> 24) & 3))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[0 + inpos] >> 26) & 3))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[0 + inpos] >> 28) & 3))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[0 + inpos] >> 30))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[1 + inpos] >> 0) & 3))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[1 + inpos] >> 2) & 3))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 3))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[1 + inpos] >> 6) & 3))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 3))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 3))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[1 + inpos] >> 12) & 3))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[1 + inpos] >> 14) & 3))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 3))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[1 + inpos] >> 18) & 3))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[1 + inpos] >> 20) & 3))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[1 + inpos] >> 22) & 3))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[1 + inpos] >> 24) & 3))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[1 + inpos] >> 26) & 3))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[1 + inpos] >> 28) & 3))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[1 + inpos] >> 30))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack20(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 1048575))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 20) | ((@in[1 + inpos] & 255) << (20 - 8)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 1048575))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 65535) << (20 - 16)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[2 + inpos] >> 16) | ((@in[3 + inpos] & 15) << (20 - 4)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[3 + inpos] >> 4) & 1048575))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 4095) << (20 - 12)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[4 + inpos] >> 12))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[5 + inpos] >> 0) & 1048575))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[5 + inpos] >> 20) | ((@in[6 + inpos] & 255) << (20 - 8)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[6 + inpos] >> 8) & 1048575))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[6 + inpos] >> 28) | ((@in[7 + inpos] & 65535) << (20 - 16)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[7 + inpos] >> 16) | ((@in[8 + inpos] & 15) << (20 - 4)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[8 + inpos] >> 4) & 1048575))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[8 + inpos] >> 24) | ((@in[9 + inpos] & 4095) << (20 - 12)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[9 + inpos] >> 12))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[10 + inpos] >> 0) & 1048575))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[10 + inpos] >> 20) | ((@in[11 + inpos] & 255) << (20 - 8)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[11 + inpos] >> 8) & 1048575))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[11 + inpos] >> 28) | ((@in[12 + inpos] & 65535) << (20 - 16)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[12 + inpos] >> 16) | ((@in[13 + inpos] & 15) << (20 - 4)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[13 + inpos] >> 4) & 1048575))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[13 + inpos] >> 24) | ((@in[14 + inpos] & 4095) << (20 - 12)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[14 + inpos] >> 12))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[15 + inpos] >> 0) & 1048575))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[15 + inpos] >> 20) | ((@in[16 + inpos] & 255) << (20 - 8)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[16 + inpos] >> 8) & 1048575))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[16 + inpos] >> 28) | ((@in[17 + inpos] & 65535) << (20 - 16)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[17 + inpos] >> 16) | ((@in[18 + inpos] & 15) << (20 - 4)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[18 + inpos] >> 4) & 1048575))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[18 + inpos] >> 24) | ((@in[19 + inpos] & 4095) << (20 - 12)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[19 + inpos] >> 12))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack21(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 2097151))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 21) | ((@in[1 + inpos] & 1023) << (21 - 10)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 2097151))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 31) | ((@in[2 + inpos] & 1048575) << (21 - 20)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[2 + inpos] >> 20) | ((@in[3 + inpos] & 511) << (21 - 9)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[3 + inpos] >> 9) & 2097151))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 524287) << (21 - 19)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[4 + inpos] >> 19) | ((@in[5 + inpos] & 255) << (21 - 8)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 2097151))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[5 + inpos] >> 29) | ((@in[6 + inpos] & 262143) << (21 - 18)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[6 + inpos] >> 18) | ((@in[7 + inpos] & 127) << (21 - 7)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[7 + inpos] >> 7) & 2097151))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 131071) << (21 - 17)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[8 + inpos] >> 17) | ((@in[9 + inpos] & 63) << (21 - 6)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[9 + inpos] >> 6) & 2097151))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[9 + inpos] >> 27) | ((@in[10 + inpos] & 65535) << (21 - 16)))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = ((int)((uint)@in[10 + inpos] >> 16) | ((@in[11 + inpos] & 31) << (21 - 5)))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[11 + inpos] >> 5) & 2097151))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[11 + inpos] >> 26) | ((@in[12 + inpos] & 32767) << (21 - 15)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[12 + inpos] >> 15) | ((@in[13 + inpos] & 15) << (21 - 4)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[13 + inpos] >> 4) & 2097151))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[13 + inpos] >> 25) | ((@in[14 + inpos] & 16383) << (21 - 14)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[14 + inpos] >> 14) | ((@in[15 + inpos] & 7) << (21 - 3)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[15 + inpos] >> 3) & 2097151))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[15 + inpos] >> 24) | ((@in[16 + inpos] & 8191) << (21 - 13)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[16 + inpos] >> 13) | ((@in[17 + inpos] & 3) << (21 - 2)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[17 + inpos] >> 2) & 2097151))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[17 + inpos] >> 23) | ((@in[18 + inpos] & 4095) << (21 - 12)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[18 + inpos] >> 12) | ((@in[19 + inpos] & 1) << (21 - 1)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[19 + inpos] >> 1) & 2097151))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[19 + inpos] >> 22) | ((@in[20 + inpos] & 2047) << (21 - 11)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[20 + inpos] >> 11))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack22(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 4194303))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 22) | ((@in[1 + inpos] & 4095) << (22 - 12)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 12) | ((@in[2 + inpos] & 3) << (22 - 2)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[2 + inpos] >> 2) & 4194303))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[2 + inpos] >> 24) | ((@in[3 + inpos] & 16383) << (22 - 14)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[3 + inpos] >> 14) | ((@in[4 + inpos] & 15) << (22 - 4)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[4 + inpos] >> 4) & 4194303))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[4 + inpos] >> 26) | ((@in[5 + inpos] & 65535) << (22 - 16)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[5 + inpos] >> 16) | ((@in[6 + inpos] & 63) << (22 - 6)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[6 + inpos] >> 6) & 4194303))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[6 + inpos] >> 28) | ((@in[7 + inpos] & 262143) << (22 - 18)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[7 + inpos] >> 18) | ((@in[8 + inpos] & 255) << (22 - 8)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[8 + inpos] >> 8) & 4194303))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[8 + inpos] >> 30) | ((@in[9 + inpos] & 1048575) << (22 - 20)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[9 + inpos] >> 20) | ((@in[10 + inpos] & 1023) << (22 - 10)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[10 + inpos] >> 10))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[11 + inpos] >> 0) & 4194303))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[11 + inpos] >> 22) | ((@in[12 + inpos] & 4095) << (22 - 12)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[12 + inpos] >> 12) | ((@in[13 + inpos] & 3) << (22 - 2)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[13 + inpos] >> 2) & 4194303))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[13 + inpos] >> 24) | ((@in[14 + inpos] & 16383) << (22 - 14)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[14 + inpos] >> 14) | ((@in[15 + inpos] & 15) << (22 - 4)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[15 + inpos] >> 4) & 4194303))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[15 + inpos] >> 26) | ((@in[16 + inpos] & 65535) << (22 - 16)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[16 + inpos] >> 16) | ((@in[17 + inpos] & 63) << (22 - 6)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[17 + inpos] >> 6) & 4194303))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[17 + inpos] >> 28) | ((@in[18 + inpos] & 262143) << (22 - 18)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[18 + inpos] >> 18) | ((@in[19 + inpos] & 255) << (22 - 8)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[19 + inpos] >> 8) & 4194303))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[19 + inpos] >> 30) | ((@in[20 + inpos] & 1048575) << (22 - 20)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[20 + inpos] >> 20) | ((@in[21 + inpos] & 1023) << (22 - 10)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[21 + inpos] >> 10))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack23(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 8388607))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 23) | ((@in[1 + inpos] & 16383) << (23 - 14)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 14) | ((@in[2 + inpos] & 31) << (23 - 5)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[2 + inpos] >> 5) & 8388607))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[2 + inpos] >> 28) | ((@in[3 + inpos] & 524287) << (23 - 19)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[3 + inpos] >> 19) | ((@in[4 + inpos] & 1023) << (23 - 10)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[4 + inpos] >> 10) | ((@in[5 + inpos] & 1) << (23 - 1)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[5 + inpos] >> 1) & 8388607))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[5 + inpos] >> 24) | ((@in[6 + inpos] & 32767) << (23 - 15)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[6 + inpos] >> 15) | ((@in[7 + inpos] & 63) << (23 - 6)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[7 + inpos] >> 6) & 8388607))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[7 + inpos] >> 29) | ((@in[8 + inpos] & 1048575) << (23 - 20)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[8 + inpos] >> 20) | ((@in[9 + inpos] & 2047) << (23 - 11)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[9 + inpos] >> 11) | ((@in[10 + inpos] & 3) << (23 - 2)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[10 + inpos] >> 2) & 8388607))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[10 + inpos] >> 25) | ((@in[11 + inpos] & 65535) << (23 - 16)))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = ((int)((uint)@in[11 + inpos] >> 16) | ((@in[12 + inpos] & 127) << (23 - 7)))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[12 + inpos] >> 7) & 8388607))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[12 + inpos] >> 30) | ((@in[13 + inpos] & 2097151) << (23 - 21)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[13 + inpos] >> 21) | ((@in[14 + inpos] & 4095) << (23 - 12)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[14 + inpos] >> 12) | ((@in[15 + inpos] & 7) << (23 - 3)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[15 + inpos] >> 3) & 8388607))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[15 + inpos] >> 26) | ((@in[16 + inpos] & 131071) << (23 - 17)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[16 + inpos] >> 17) | ((@in[17 + inpos] & 255) << (23 - 8)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[17 + inpos] >> 8) & 8388607))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[17 + inpos] >> 31) | ((@in[18 + inpos] & 4194303) << (23 - 22)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[18 + inpos] >> 22) | ((@in[19 + inpos] & 8191) << (23 - 13)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[19 + inpos] >> 13) | ((@in[20 + inpos] & 15) << (23 - 4)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[20 + inpos] >> 4) & 8388607))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[20 + inpos] >> 27) | ((@in[21 + inpos] & 262143) << (23 - 18)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[21 + inpos] >> 18) | ((@in[22 + inpos] & 511) << (23 - 9)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[22 + inpos] >> 9))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack24(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 16777215))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 24) | ((@in[1 + inpos] & 65535) << (24 - 16)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 16) | ((@in[2 + inpos] & 255) << (24 - 8)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 8)) + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 16777215))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 65535) << (24 - 16)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[4 + inpos] >> 16) | ((@in[5 + inpos] & 255) << (24 - 8)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[5 + inpos] >> 8)) + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[6 + inpos] >> 0) & 16777215))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[6 + inpos] >> 24) | ((@in[7 + inpos] & 65535) << (24 - 16)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[7 + inpos] >> 16) | ((@in[8 + inpos] & 255) << (24 - 8)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[8 + inpos] >> 8))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[9 + inpos] >> 0) & 16777215))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[9 + inpos] >> 24) | ((@in[10 + inpos] & 65535) << (24 - 16)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[10 + inpos] >> 16) | ((@in[11 + inpos] & 255) << (24 - 8)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[11 + inpos] >> 8))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[12 + inpos] >> 0) & 16777215))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[12 + inpos] >> 24) | ((@in[13 + inpos] & 65535) << (24 - 16)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[13 + inpos] >> 16) | ((@in[14 + inpos] & 255) << (24 - 8)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[14 + inpos] >> 8))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[15 + inpos] >> 0) & 16777215))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[15 + inpos] >> 24) | ((@in[16 + inpos] & 65535) << (24 - 16)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[16 + inpos] >> 16) | ((@in[17 + inpos] & 255) << (24 - 8)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[17 + inpos] >> 8))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[18 + inpos] >> 0) & 16777215))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[18 + inpos] >> 24) | ((@in[19 + inpos] & 65535) << (24 - 16)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[19 + inpos] >> 16) | ((@in[20 + inpos] & 255) << (24 - 8)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[20 + inpos] >> 8))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[21 + inpos] >> 0) & 16777215))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[21 + inpos] >> 24) | ((@in[22 + inpos] & 65535) << (24 - 16)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[22 + inpos] >> 16) | ((@in[23 + inpos] & 255) << (24 - 8)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[23 + inpos] >> 8))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack25(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 33554431))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 25) | ((@in[1 + inpos] & 262143) << (25 - 18)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 18) | ((@in[2 + inpos] & 2047) << (25 - 11)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 11) | ((@in[3 + inpos] & 15) << (25 - 4)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[3 + inpos] >> 4) & 33554431))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[3 + inpos] >> 29) | ((@in[4 + inpos] & 4194303) << (25 - 22)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[4 + inpos] >> 22) | ((@in[5 + inpos] & 32767) << (25 - 15)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[5 + inpos] >> 15) | ((@in[6 + inpos] & 255) << (25 - 8)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[6 + inpos] >> 8) | ((@in[7 + inpos] & 1) << (25 - 1)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[7 + inpos] >> 1) & 33554431))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[7 + inpos] >> 26) | ((@in[8 + inpos] & 524287) << (25 - 19)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[8 + inpos] >> 19) | ((@in[9 + inpos] & 4095) << (25 - 12)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[9 + inpos] >> 12) | ((@in[10 + inpos] & 31) << (25 - 5)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[10 + inpos] >> 5) & 33554431))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[10 + inpos] >> 30) | ((@in[11 + inpos] & 8388607) << (25 - 23)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[11 + inpos] >> 23) | ((@in[12 + inpos] & 65535) << (25 - 16)))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = ((int)((uint)@in[12 + inpos] >> 16) | ((@in[13 + inpos] & 511) << (25 - 9)))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[13 + inpos] >> 9) | ((@in[14 + inpos] & 3) << (25 - 2)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[14 + inpos] >> 2) & 33554431))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[14 + inpos] >> 27) | ((@in[15 + inpos] & 1048575) << (25 - 20)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[15 + inpos] >> 20) | ((@in[16 + inpos] & 8191) << (25 - 13)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[16 + inpos] >> 13) | ((@in[17 + inpos] & 63) << (25 - 6)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[17 + inpos] >> 6) & 33554431))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[17 + inpos] >> 31) | ((@in[18 + inpos] & 16777215) << (25 - 24)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[18 + inpos] >> 24) | ((@in[19 + inpos] & 131071) << (25 - 17)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[19 + inpos] >> 17) | ((@in[20 + inpos] & 1023) << (25 - 10)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[20 + inpos] >> 10) | ((@in[21 + inpos] & 7) << (25 - 3)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[21 + inpos] >> 3) & 33554431))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[21 + inpos] >> 28) | ((@in[22 + inpos] & 2097151) << (25 - 21)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[22 + inpos] >> 21) | ((@in[23 + inpos] & 16383) << (25 - 14)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[23 + inpos] >> 14) | ((@in[24 + inpos] & 127) << (25 - 7)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[24 + inpos] >> 7))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack26(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 67108863))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 26) | ((@in[1 + inpos] & 1048575) << (26 - 20)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 20) | ((@in[2 + inpos] & 16383) << (26 - 14)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 14) | ((@in[3 + inpos] & 255) << (26 - 8)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 8) | ((@in[4 + inpos] & 3) << (26 - 2)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[4 + inpos] >> 2) & 67108863))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[4 + inpos] >> 28) | ((@in[5 + inpos] & 4194303) << (26 - 22)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[5 + inpos] >> 22) | ((@in[6 + inpos] & 65535) << (26 - 16)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[6 + inpos] >> 16) | ((@in[7 + inpos] & 1023) << (26 - 10)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[7 + inpos] >> 10) | ((@in[8 + inpos] & 15) << (26 - 4)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[8 + inpos] >> 4) & 67108863))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[8 + inpos] >> 30) | ((@in[9 + inpos] & 16777215) << (26 - 24)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[9 + inpos] >> 24) | ((@in[10 + inpos] & 262143) << (26 - 18)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[10 + inpos] >> 18) | ((@in[11 + inpos] & 4095) << (26 - 12)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[11 + inpos] >> 12) | ((@in[12 + inpos] & 63) << (26 - 6)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[12 + inpos] >> 6))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[13 + inpos] >> 0) & 67108863))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[13 + inpos] >> 26) | ((@in[14 + inpos] & 1048575) << (26 - 20)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[14 + inpos] >> 20) | ((@in[15 + inpos] & 16383) << (26 - 14)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[15 + inpos] >> 14) | ((@in[16 + inpos] & 255) << (26 - 8)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[16 + inpos] >> 8) | ((@in[17 + inpos] & 3) << (26 - 2)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[17 + inpos] >> 2) & 67108863))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[17 + inpos] >> 28) | ((@in[18 + inpos] & 4194303) << (26 - 22)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[18 + inpos] >> 22) | ((@in[19 + inpos] & 65535) << (26 - 16)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[19 + inpos] >> 16) | ((@in[20 + inpos] & 1023) << (26 - 10)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[20 + inpos] >> 10) | ((@in[21 + inpos] & 15) << (26 - 4)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[21 + inpos] >> 4) & 67108863))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[21 + inpos] >> 30) | ((@in[22 + inpos] & 16777215) << (26 - 24)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[22 + inpos] >> 24) | ((@in[23 + inpos] & 262143) << (26 - 18)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[23 + inpos] >> 18) | ((@in[24 + inpos] & 4095) << (26 - 12)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[24 + inpos] >> 12) | ((@in[25 + inpos] & 63) << (26 - 6)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[25 + inpos] >> 6))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack27(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 134217727))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 27) | ((@in[1 + inpos] & 4194303) << (27 - 22)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 22) | ((@in[2 + inpos] & 131071) << (27 - 17)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 17) | ((@in[3 + inpos] & 4095) << (27 - 12)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 12) | ((@in[4 + inpos] & 127) << (27 - 7)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[4 + inpos] >> 7) | ((@in[5 + inpos] & 3) << (27 - 2)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[5 + inpos] >> 2) & 134217727))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[5 + inpos] >> 29) | ((@in[6 + inpos] & 16777215) << (27 - 24)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[6 + inpos] >> 24) | ((@in[7 + inpos] & 524287) << (27 - 19)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[7 + inpos] >> 19) | ((@in[8 + inpos] & 16383) << (27 - 14)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[8 + inpos] >> 14) | ((@in[9 + inpos] & 511) << (27 - 9)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[9 + inpos] >> 9) | ((@in[10 + inpos] & 15) << (27 - 4)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[10 + inpos] >> 4) & 134217727))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[10 + inpos] >> 31) | ((@in[11 + inpos] & 67108863) << (27 - 26)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[11 + inpos] >> 26) | ((@in[12 + inpos] & 2097151) << (27 - 21)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[12 + inpos] >> 21) | ((@in[13 + inpos] & 65535) << (27 - 16)))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = ((int)((uint)@in[13 + inpos] >> 16) | ((@in[14 + inpos] & 2047) << (27 - 11)))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[14 + inpos] >> 11) | ((@in[15 + inpos] & 63) << (27 - 6)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[15 + inpos] >> 6) | ((@in[16 + inpos] & 1) << (27 - 1)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[16 + inpos] >> 1) & 134217727))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[16 + inpos] >> 28) | ((@in[17 + inpos] & 8388607) << (27 - 23)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[17 + inpos] >> 23) | ((@in[18 + inpos] & 262143) << (27 - 18)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[18 + inpos] >> 18) | ((@in[19 + inpos] & 8191) << (27 - 13)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[19 + inpos] >> 13) | ((@in[20 + inpos] & 255) << (27 - 8)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[20 + inpos] >> 8) | ((@in[21 + inpos] & 7) << (27 - 3)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[21 + inpos] >> 3) & 134217727))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[21 + inpos] >> 30) | ((@in[22 + inpos] & 33554431) << (27 - 25)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[22 + inpos] >> 25) | ((@in[23 + inpos] & 1048575) << (27 - 20)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[23 + inpos] >> 20) | ((@in[24 + inpos] & 32767) << (27 - 15)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[24 + inpos] >> 15) | ((@in[25 + inpos] & 1023) << (27 - 10)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[25 + inpos] >> 10) | ((@in[26 + inpos] & 31) << (27 - 5)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[26 + inpos] >> 5))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack28(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 268435455))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 28) | ((@in[1 + inpos] & 16777215) << (28 - 24)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 24) | ((@in[2 + inpos] & 1048575) << (28 - 20)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 20) | ((@in[3 + inpos] & 65535) << (28 - 16)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 16) | ((@in[4 + inpos] & 4095) << (28 - 12)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[4 + inpos] >> 12) | ((@in[5 + inpos] & 255) << (28 - 8)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[5 + inpos] >> 8) | ((@in[6 + inpos] & 15) << (28 - 4)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[6 + inpos] >> 4)) + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[7 + inpos] >> 0) & 268435455))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 16777215) << (28 - 24)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[8 + inpos] >> 24) | ((@in[9 + inpos] & 1048575) << (28 - 20)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[9 + inpos] >> 20) | ((@in[10 + inpos] & 65535) << (28 - 16)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[10 + inpos] >> 16) | ((@in[11 + inpos] & 4095) << (28 - 12)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[11 + inpos] >> 12) | ((@in[12 + inpos] & 255) << (28 - 8)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[12 + inpos] >> 8) | ((@in[13 + inpos] & 15) << (28 - 4)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[13 + inpos] >> 4))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[14 + inpos] >> 0) & 268435455))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[14 + inpos] >> 28) | ((@in[15 + inpos] & 16777215) << (28 - 24)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[15 + inpos] >> 24) | ((@in[16 + inpos] & 1048575) << (28 - 20)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[16 + inpos] >> 20) | ((@in[17 + inpos] & 65535) << (28 - 16)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[17 + inpos] >> 16) | ((@in[18 + inpos] & 4095) << (28 - 12)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[18 + inpos] >> 12) | ((@in[19 + inpos] & 255) << (28 - 8)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[19 + inpos] >> 8) | ((@in[20 + inpos] & 15) << (28 - 4)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[20 + inpos] >> 4))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[21 + inpos] >> 0) & 268435455))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[21 + inpos] >> 28) | ((@in[22 + inpos] & 16777215) << (28 - 24)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[22 + inpos] >> 24) | ((@in[23 + inpos] & 1048575) << (28 - 20)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[23 + inpos] >> 20) | ((@in[24 + inpos] & 65535) << (28 - 16)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[24 + inpos] >> 16) | ((@in[25 + inpos] & 4095) << (28 - 12)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[25 + inpos] >> 12) | ((@in[26 + inpos] & 255) << (28 - 8)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[26 + inpos] >> 8) | ((@in[27 + inpos] & 15) << (28 - 4)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[27 + inpos] >> 4))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack29(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 536870911))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 29) | ((@in[1 + inpos] & 67108863) << (29 - 26)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 26) | ((@in[2 + inpos] & 8388607) << (29 - 23)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 23) | ((@in[3 + inpos] & 1048575) << (29 - 20)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 20) | ((@in[4 + inpos] & 131071) << (29 - 17)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[4 + inpos] >> 17) | ((@in[5 + inpos] & 16383) << (29 - 14)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[5 + inpos] >> 14) | ((@in[6 + inpos] & 2047) << (29 - 11)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[6 + inpos] >> 11) | ((@in[7 + inpos] & 255) << (29 - 8)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[7 + inpos] >> 8) | ((@in[8 + inpos] & 31) << (29 - 5)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[8 + inpos] >> 5) | ((@in[9 + inpos] & 3) << (29 - 2)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[9 + inpos] >> 2) & 536870911))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[9 + inpos] >> 31) | ((@in[10 + inpos] & 268435455) << (29 - 28)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[10 + inpos] >> 28) | ((@in[11 + inpos] & 33554431) << (29 - 25)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[11 + inpos] >> 25) | ((@in[12 + inpos] & 4194303) << (29 - 22)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[12 + inpos] >> 22) | ((@in[13 + inpos] & 524287) << (29 - 19)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[13 + inpos] >> 19) | ((@in[14 + inpos] & 65535) << (29 - 16)))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = ((int)((uint)@in[14 + inpos] >> 16) | ((@in[15 + inpos] & 8191) << (29 - 13)))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[15 + inpos] >> 13) | ((@in[16 + inpos] & 1023) << (29 - 10)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[16 + inpos] >> 10) | ((@in[17 + inpos] & 127) << (29 - 7)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[17 + inpos] >> 7) | ((@in[18 + inpos] & 15) << (29 - 4)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[18 + inpos] >> 4) | ((@in[19 + inpos] & 1) << (29 - 1)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[19 + inpos] >> 1) & 536870911))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[19 + inpos] >> 30) | ((@in[20 + inpos] & 134217727) << (29 - 27)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[20 + inpos] >> 27) | ((@in[21 + inpos] & 16777215) << (29 - 24)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[21 + inpos] >> 24) | ((@in[22 + inpos] & 2097151) << (29 - 21)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[22 + inpos] >> 21) | ((@in[23 + inpos] & 262143) << (29 - 18)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[23 + inpos] >> 18) | ((@in[24 + inpos] & 32767) << (29 - 15)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[24 + inpos] >> 15) | ((@in[25 + inpos] & 4095) << (29 - 12)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[25 + inpos] >> 12) | ((@in[26 + inpos] & 511) << (29 - 9)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[26 + inpos] >> 9) | ((@in[27 + inpos] & 63) << (29 - 6)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[27 + inpos] >> 6) | ((@in[28 + inpos] & 7) << (29 - 3)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[28 + inpos] >> 3))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack3(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 7)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 3) & 7))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 6) & 7))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 9) & 7))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 7))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[0 + inpos] >> 15) & 7))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[0 + inpos] >> 18) & 7))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[0 + inpos] >> 21) & 7))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[0 + inpos] >> 24) & 7))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[0 + inpos] >> 27) & 7))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 1) << (3 - 1)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[1 + inpos] >> 1) & 7))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 7))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[1 + inpos] >> 7) & 7))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 7))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = (((int)((uint)@in[1 + inpos] >> 13) & 7))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 7))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[1 + inpos] >> 19) & 7))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[1 + inpos] >> 22) & 7))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[1 + inpos] >> 25) & 7))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[1 + inpos] >> 28) & 7))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[1 + inpos] >> 31) | ((@in[2 + inpos] & 3) << (3 - 2)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[2 + inpos] >> 2) & 7))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[2 + inpos] >> 5) & 7))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 7))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[2 + inpos] >> 11) & 7))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[2 + inpos] >> 14) & 7))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[2 + inpos] >> 17) & 7))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[2 + inpos] >> 20) & 7))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[2 + inpos] >> 23) & 7))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[2 + inpos] >> 26) & 7))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[2 + inpos] >> 29))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack30(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 1073741823))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 268435455) << (30 - 28)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 67108863) << (30 - 26)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 26) | ((@in[3 + inpos] & 16777215) << (30 - 24)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 4194303) << (30 - 22)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[4 + inpos] >> 22) | ((@in[5 + inpos] & 1048575) << (30 - 20)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[5 + inpos] >> 20) | ((@in[6 + inpos] & 262143) << (30 - 18)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[6 + inpos] >> 18) | ((@in[7 + inpos] & 65535) << (30 - 16)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[7 + inpos] >> 16) | ((@in[8 + inpos] & 16383) << (30 - 14)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[8 + inpos] >> 14) | ((@in[9 + inpos] & 4095) << (30 - 12)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[9 + inpos] >> 12) | ((@in[10 + inpos] & 1023) << (30 - 10)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[10 + inpos] >> 10) | ((@in[11 + inpos] & 255) << (30 - 8)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[11 + inpos] >> 8) | ((@in[12 + inpos] & 63) << (30 - 6)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[12 + inpos] >> 6) | ((@in[13 + inpos] & 15) << (30 - 4)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[13 + inpos] >> 4) | ((@in[14 + inpos] & 3) << (30 - 2)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[14 + inpos] >> 2))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[15 + inpos] >> 0) & 1073741823))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[15 + inpos] >> 30) | ((@in[16 + inpos] & 268435455) << (30 - 28)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[16 + inpos] >> 28) | ((@in[17 + inpos] & 67108863) << (30 - 26)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[17 + inpos] >> 26) | ((@in[18 + inpos] & 16777215) << (30 - 24)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[18 + inpos] >> 24) | ((@in[19 + inpos] & 4194303) << (30 - 22)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[19 + inpos] >> 22) | ((@in[20 + inpos] & 1048575) << (30 - 20)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[20 + inpos] >> 20) | ((@in[21 + inpos] & 262143) << (30 - 18)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[21 + inpos] >> 18) | ((@in[22 + inpos] & 65535) << (30 - 16)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[22 + inpos] >> 16) | ((@in[23 + inpos] & 16383) << (30 - 14)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[23 + inpos] >> 14) | ((@in[24 + inpos] & 4095) << (30 - 12)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[24 + inpos] >> 12) | ((@in[25 + inpos] & 1023) << (30 - 10)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[25 + inpos] >> 10) | ((@in[26 + inpos] & 255) << (30 - 8)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[26 + inpos] >> 8) | ((@in[27 + inpos] & 63) << (30 - 6)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[27 + inpos] >> 6) | ((@in[28 + inpos] & 15) << (30 - 4)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[28 + inpos] >> 4) | ((@in[29 + inpos] & 3) << (30 - 2)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[29 + inpos] >> 2))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack31(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 2147483647))
-                               + initoffset;
-            @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 31) | ((@in[1 + inpos] & 1073741823) << (31 - 30)))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 30) | ((@in[2 + inpos] & 536870911) << (31 - 29)))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 29) | ((@in[3 + inpos] & 268435455) << (31 - 28)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 28) | ((@in[4 + inpos] & 134217727) << (31 - 27)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[4 + inpos] >> 27) | ((@in[5 + inpos] & 67108863) << (31 - 26)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[5 + inpos] >> 26) | ((@in[6 + inpos] & 33554431) << (31 - 25)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[6 + inpos] >> 25) | ((@in[7 + inpos] & 16777215) << (31 - 24)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = ((int)((uint)@in[7 + inpos] >> 24) | ((@in[8 + inpos] & 8388607) << (31 - 23)))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[8 + inpos] >> 23) | ((@in[9 + inpos] & 4194303) << (31 - 22)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[9 + inpos] >> 22) | ((@in[10 + inpos] & 2097151) << (31 - 21)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[10 + inpos] >> 21) | ((@in[11 + inpos] & 1048575) << (31 - 20)))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[11 + inpos] >> 20) | ((@in[12 + inpos] & 524287) << (31 - 19)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[12 + inpos] >> 19) | ((@in[13 + inpos] & 262143) << (31 - 18)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[13 + inpos] >> 18) | ((@in[14 + inpos] & 131071) << (31 - 17)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[14 + inpos] >> 17) | ((@in[15 + inpos] & 65535) << (31 - 16)))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = ((int)((uint)@in[15 + inpos] >> 16) | ((@in[16 + inpos] & 32767) << (31 - 15)))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[16 + inpos] >> 15) | ((@in[17 + inpos] & 16383) << (31 - 14)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[17 + inpos] >> 14) | ((@in[18 + inpos] & 8191) << (31 - 13)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[18 + inpos] >> 13) | ((@in[19 + inpos] & 4095) << (31 - 12)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = ((int)((uint)@in[19 + inpos] >> 12) | ((@in[20 + inpos] & 2047) << (31 - 11)))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[20 + inpos] >> 11) | ((@in[21 + inpos] & 1023) << (31 - 10)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[21 + inpos] >> 10) | ((@in[22 + inpos] & 511) << (31 - 9)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[22 + inpos] >> 9) | ((@in[23 + inpos] & 255) << (31 - 8)))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[23 + inpos] >> 8) | ((@in[24 + inpos] & 127) << (31 - 7)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[24 + inpos] >> 7) | ((@in[25 + inpos] & 63) << (31 - 6)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[25 + inpos] >> 6) | ((@in[26 + inpos] & 31) << (31 - 5)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[26 + inpos] >> 5) | ((@in[27 + inpos] & 15) << (31 - 4)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[27 + inpos] >> 4) | ((@in[28 + inpos] & 7) << (31 - 3)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = ((int)((uint)@in[28 + inpos] >> 3) | ((@in[29 + inpos] & 3) << (31 - 2)))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = ((int)((uint)@in[29 + inpos] >> 2) | ((@in[30 + inpos] & 1) << (31 - 1)))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[30 + inpos] >> 1))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack32(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            Array.Copy(@in, inpos, @out, outpos, 32);  // no sense in
-                                                       // doing delta
-                                                       // coding
-        }
-
-        protected static void integratedunpack4(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 15)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 4) & 15))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 8) & 15))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 15))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 16) & 15))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[0 + inpos] >> 20) & 15))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[0 + inpos] >> 24) & 15))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[0 + inpos] >> 28))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[1 + inpos] >> 0) & 15))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 15))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 15))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[1 + inpos] >> 12) & 15))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 15))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[1 + inpos] >> 20) & 15))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[1 + inpos] >> 24) & 15))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[1 + inpos] >> 28))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[2 + inpos] >> 0) & 15))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[2 + inpos] >> 4) & 15))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 15))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[2 + inpos] >> 12) & 15))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[2 + inpos] >> 16) & 15))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[2 + inpos] >> 20) & 15))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[2 + inpos] >> 24) & 15))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[2 + inpos] >> 28))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 15))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[3 + inpos] >> 4) & 15))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[3 + inpos] >> 8) & 15))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[3 + inpos] >> 12) & 15))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[3 + inpos] >> 16) & 15))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[3 + inpos] >> 20) & 15))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[3 + inpos] >> 24) & 15))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[3 + inpos] >> 28))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack5(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 31)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 5) & 31))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 10) & 31))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 15) & 31))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 20) & 31))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[0 + inpos] >> 25) & 31))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 7) << (5 - 3)))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[1 + inpos] >> 3) & 31))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 31))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[1 + inpos] >> 13) & 31))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[1 + inpos] >> 18) & 31))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[1 + inpos] >> 23) & 31))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 1) << (5 - 1)))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[2 + inpos] >> 1) & 31))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[2 + inpos] >> 6) & 31))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = (((int)((uint)@in[2 + inpos] >> 11) & 31))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[2 + inpos] >> 16) & 31))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[2 + inpos] >> 21) & 31))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[2 + inpos] >> 26) & 31))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[2 + inpos] >> 31) | ((@in[3 + inpos] & 15) << (5 - 4)))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[3 + inpos] >> 4) & 31))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[3 + inpos] >> 9) & 31))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[3 + inpos] >> 14) & 31))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[3 + inpos] >> 19) & 31))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[3 + inpos] >> 24) & 31))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = ((int)((uint)@in[3 + inpos] >> 29) | ((@in[4 + inpos] & 3) << (5 - 2)))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[4 + inpos] >> 2) & 31))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[4 + inpos] >> 7) & 31))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[4 + inpos] >> 12) & 31))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[4 + inpos] >> 17) & 31))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[4 + inpos] >> 22) & 31))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[4 + inpos] >> 27))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack6(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 63)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 6) & 63))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 63))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 18) & 63))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 24) & 63))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 15) << (6 - 4)))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 63))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 63))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 63))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[1 + inpos] >> 22) & 63))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 3) << (6 - 2)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[2 + inpos] >> 2) & 63))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 63))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[2 + inpos] >> 14) & 63))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[2 + inpos] >> 20) & 63))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[2 + inpos] >> 26))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 63))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[3 + inpos] >> 6) & 63))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[3 + inpos] >> 12) & 63))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[3 + inpos] >> 18) & 63))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[3 + inpos] >> 24) & 63))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 15) << (6 - 4)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[4 + inpos] >> 4) & 63))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[4 + inpos] >> 10) & 63))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[4 + inpos] >> 16) & 63))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[4 + inpos] >> 22) & 63))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = ((int)((uint)@in[4 + inpos] >> 28) | ((@in[5 + inpos] & 3) << (6 - 2)))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[5 + inpos] >> 2) & 63))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 63))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[5 + inpos] >> 14) & 63))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[5 + inpos] >> 20) & 63))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[5 + inpos] >> 26))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack7(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 127)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 7) & 127))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 14) & 127))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 21) & 127))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = ((int)((uint)@in[0 + inpos] >> 28) | ((@in[1 + inpos] & 7) << (7 - 3)))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[1 + inpos] >> 3) & 127))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 127))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = (((int)((uint)@in[1 + inpos] >> 17) & 127))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[1 + inpos] >> 24) & 127))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = ((int)((uint)@in[1 + inpos] >> 31) | ((@in[2 + inpos] & 63) << (7 - 6)))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[2 + inpos] >> 6) & 127))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[2 + inpos] >> 13) & 127))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[2 + inpos] >> 20) & 127))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = ((int)((uint)@in[2 + inpos] >> 27) | ((@in[3 + inpos] & 3) << (7 - 2)))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[3 + inpos] >> 2) & 127))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = (((int)((uint)@in[3 + inpos] >> 9) & 127))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[3 + inpos] >> 16) & 127))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[3 + inpos] >> 23) & 127))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 31) << (7 - 5)))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[4 + inpos] >> 5) & 127))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[4 + inpos] >> 12) & 127))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[4 + inpos] >> 19) & 127))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = ((int)((uint)@in[4 + inpos] >> 26) | ((@in[5 + inpos] & 1) << (7 - 1)))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[5 + inpos] >> 1) & 127))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 127))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[5 + inpos] >> 15) & 127))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[5 + inpos] >> 22) & 127))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[5 + inpos] >> 29) | ((@in[6 + inpos] & 15) << (7 - 4)))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[6 + inpos] >> 4) & 127))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[6 + inpos] >> 11) & 127))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[6 + inpos] >> 18) & 127))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[6 + inpos] >> 25))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack8(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 255)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 8) & 255))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 16) & 255))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[0 + inpos] >> 24))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[1 + inpos] >> 0) & 255))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 255))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 255))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[1 + inpos] >> 24))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[2 + inpos] >> 0) & 255))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 255))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = (((int)((uint)@in[2 + inpos] >> 16) & 255))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = ((int)((uint)@in[2 + inpos] >> 24))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 255))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[3 + inpos] >> 8) & 255))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = (((int)((uint)@in[3 + inpos] >> 16) & 255))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = ((int)((uint)@in[3 + inpos] >> 24))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[4 + inpos] >> 0) & 255))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = (((int)((uint)@in[4 + inpos] >> 8) & 255))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[4 + inpos] >> 16) & 255))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = ((int)((uint)@in[4 + inpos] >> 24))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[5 + inpos] >> 0) & 255))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 255))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[5 + inpos] >> 16) & 255))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = ((int)((uint)@in[5 + inpos] >> 24))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = (((int)((uint)@in[6 + inpos] >> 0) & 255))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[6 + inpos] >> 8) & 255))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[6 + inpos] >> 16) & 255))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = ((int)((uint)@in[6 + inpos] >> 24))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = (((int)((uint)@in[7 + inpos] >> 0) & 255))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[7 + inpos] >> 8) & 255))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[7 + inpos] >> 16) & 255))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[7 + inpos] >> 24))
-                                + @out[31 + outpos - 1];
-        }
-
-        protected static void integratedunpack9(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
-        {
-            @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 511)) + initoffset;
-            @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 9) & 511))
-                               + @out[1 + outpos - 1];
-            @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 18) & 511))
-                               + @out[2 + outpos - 1];
-            @out[3 + outpos] = ((int)((uint)@in[0 + inpos] >> 27) | ((@in[1 + inpos] & 15) << (9 - 4)))
-                               + @out[3 + outpos - 1];
-            @out[4 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 511))
-                               + @out[4 + outpos - 1];
-            @out[5 + outpos] = (((int)((uint)@in[1 + inpos] >> 13) & 511))
-                               + @out[5 + outpos - 1];
-            @out[6 + outpos] = (((int)((uint)@in[1 + inpos] >> 22) & 511))
-                               + @out[6 + outpos - 1];
-            @out[7 + outpos] = ((int)((uint)@in[1 + inpos] >> 31) | ((@in[2 + inpos] & 255) << (9 - 8)))
-                               + @out[7 + outpos - 1];
-            @out[8 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 511))
-                               + @out[8 + outpos - 1];
-            @out[9 + outpos] = (((int)((uint)@in[2 + inpos] >> 17) & 511))
-                               + @out[9 + outpos - 1];
-            @out[10 + outpos] = ((int)((uint)@in[2 + inpos] >> 26) | ((@in[3 + inpos] & 7) << (9 - 3)))
-                                + @out[10 + outpos - 1];
-            @out[11 + outpos] = (((int)((uint)@in[3 + inpos] >> 3) & 511))
-                                + @out[11 + outpos - 1];
-            @out[12 + outpos] = (((int)((uint)@in[3 + inpos] >> 12) & 511))
-                                + @out[12 + outpos - 1];
-            @out[13 + outpos] = (((int)((uint)@in[3 + inpos] >> 21) & 511))
-                                + @out[13 + outpos - 1];
-            @out[14 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 127) << (9 - 7)))
-                                + @out[14 + outpos - 1];
-            @out[15 + outpos] = (((int)((uint)@in[4 + inpos] >> 7) & 511))
-                                + @out[15 + outpos - 1];
-            @out[16 + outpos] = (((int)((uint)@in[4 + inpos] >> 16) & 511))
-                                + @out[16 + outpos - 1];
-            @out[17 + outpos] = ((int)((uint)@in[4 + inpos] >> 25) | ((@in[5 + inpos] & 3) << (9 - 2)))
-                                + @out[17 + outpos - 1];
-            @out[18 + outpos] = (((int)((uint)@in[5 + inpos] >> 2) & 511))
-                                + @out[18 + outpos - 1];
-            @out[19 + outpos] = (((int)((uint)@in[5 + inpos] >> 11) & 511))
-                                + @out[19 + outpos - 1];
-            @out[20 + outpos] = (((int)((uint)@in[5 + inpos] >> 20) & 511))
-                                + @out[20 + outpos - 1];
-            @out[21 + outpos] = ((int)((uint)@in[5 + inpos] >> 29) | ((@in[6 + inpos] & 63) << (9 - 6)))
-                                + @out[21 + outpos - 1];
-            @out[22 + outpos] = (((int)((uint)@in[6 + inpos] >> 6) & 511))
-                                + @out[22 + outpos - 1];
-            @out[23 + outpos] = (((int)((uint)@in[6 + inpos] >> 15) & 511))
-                                + @out[23 + outpos - 1];
-            @out[24 + outpos] = ((int)((uint)@in[6 + inpos] >> 24) | ((@in[7 + inpos] & 1) << (9 - 1)))
-                                + @out[24 + outpos - 1];
-            @out[25 + outpos] = (((int)((uint)@in[7 + inpos] >> 1) & 511))
-                                + @out[25 + outpos - 1];
-            @out[26 + outpos] = (((int)((uint)@in[7 + inpos] >> 10) & 511))
-                                + @out[26 + outpos - 1];
-            @out[27 + outpos] = (((int)((uint)@in[7 + inpos] >> 19) & 511))
-                                + @out[27 + outpos - 1];
-            @out[28 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 31) << (9 - 5)))
-                                + @out[28 + outpos - 1];
-            @out[29 + outpos] = (((int)((uint)@in[8 + inpos] >> 5) & 511))
-                                + @out[29 + outpos - 1];
-            @out[30 + outpos] = (((int)((uint)@in[8 + inpos] >> 14) & 511))
-                                + @out[30 + outpos - 1];
-            @out[31 + outpos] = ((int)((uint)@in[8 + inpos] >> 23))
-                                + @out[31 + outpos - 1];
-        }
+        switch (bit)
+        {
+            case 0:
+                integratedpack0(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 1:
+                integratedpack1(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 2:
+                integratedpack2(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 3:
+                integratedpack3(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 4:
+                integratedpack4(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 5:
+                integratedpack5(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 6:
+                integratedpack6(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 7:
+                integratedpack7(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 8:
+                integratedpack8(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 9:
+                integratedpack9(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 10:
+                integratedpack10(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 11:
+                integratedpack11(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 12:
+                integratedpack12(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 13:
+                integratedpack13(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 14:
+                integratedpack14(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 15:
+                integratedpack15(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 16:
+                integratedpack16(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 17:
+                integratedpack17(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 18:
+                integratedpack18(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 19:
+                integratedpack19(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 20:
+                integratedpack20(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 21:
+                integratedpack21(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 22:
+                integratedpack22(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 23:
+                integratedpack23(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 24:
+                integratedpack24(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 25:
+                integratedpack25(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 26:
+                integratedpack26(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 27:
+                integratedpack27(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 28:
+                integratedpack28(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 29:
+                integratedpack29(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 30:
+                integratedpack30(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 31:
+                integratedpack31(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 32:
+                integratedpack32(initoffset, @in, inpos, @out, outpos);
+                break;
+            default:
+                throw new Exception(
+                    "Unsupported bit width.");
+        }
+    }
+
+    protected static void integratedpack0(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        // nothing
+    }
+
+    protected static void integratedpack1(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 1)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 2)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 3)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 4)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 5)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 6)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 7)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 9)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 10)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 11)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 12)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 13)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 14)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 15)
+                           | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 17)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 18)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 19)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 20)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 21)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 22)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 23)
+                           | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24)
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 25)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 26)
+                           | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 27)
+                           | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 28)
+                           | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 29)
+                           | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 30)
+                           | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 31);
+    }
+
+    protected static void integratedpack10(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 10)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 20)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 30);
+        @out[1 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (10 - 8)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 8)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 18)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 28);
+        @out[2 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (10 - 6)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 6)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 26);
+        @out[3 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (10 - 4)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 4)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 14)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 24);
+        @out[4 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (10 - 2)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 2)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 12)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 22);
+        @out[5 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 10)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 20)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 30);
+        @out[6 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (10 - 8)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 8)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 18)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 28);
+        @out[7 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (10 - 6)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 6)
+                           | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16)
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 26);
+        @out[8 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (10 - 4)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 4)
+                           | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 14)
+                           | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 24);
+        @out[9 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (10 - 2)
+                           | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 2)
+                           | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 12)
+                           | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 22);
+    }
+
+    protected static void integratedpack11(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 11)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 22);
+        @out[1 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (11 - 1)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 1)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 12)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 23);
+        @out[2 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (11 - 2)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 2)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 13)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
+        @out[3 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (11 - 3)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 3)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 14)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 25);
+        @out[4 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (11 - 4)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 4)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 15)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 26);
+        @out[5 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (11 - 5)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 5)
+                           | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 27);
+        @out[6 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (11 - 6)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 6)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 17)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 28);
+        @out[7 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (11 - 7)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 7)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 18)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 29);
+        @out[8 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (11 - 8)
+                           | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 19)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 30);
+        @out[9 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (11 - 9)
+                           | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 9)
+                           | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 20)
+                           | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 31);
+        @out[10 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (11 - 10)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 10)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 21);
+    }
+
+    protected static void integratedpack12(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 12)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 24);
+        @out[1 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (12 - 4)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 4)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 16)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 28);
+        @out[2 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (12 - 8)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 8)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 20);
+        @out[3 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 12)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 24);
+        @out[4 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (12 - 4)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 4)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 16)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 28);
+        @out[5 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (12 - 8)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 8)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 20);
+        @out[6 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 12)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 24);
+        @out[7 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (12 - 4)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 4)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 16)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 28);
+        @out[8 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (12 - 8)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 8)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 20);
+        @out[9 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 12)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 24);
+        @out[10 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (12 - 4)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 4)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 16)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 28);
+        @out[11 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (12 - 8)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 8)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 20);
+    }
+
+    protected static void integratedpack13(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 13)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 26);
+        @out[1 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (13 - 7)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 7)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 20);
+        @out[2 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (13 - 1)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 1)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 14)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 27);
+        @out[3 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (13 - 8)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 21);
+        @out[4 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (13 - 2)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 2)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 15)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 28);
+        @out[5 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (13 - 9)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 9)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 22);
+        @out[6 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (13 - 3)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 3)
+                           | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 29);
+        @out[7 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (13 - 10)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 10)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 23);
+        @out[8 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (13 - 4)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 4)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 17)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 30);
+        @out[9 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (13 - 11)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 11)
+                           | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
+        @out[10 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (13 - 5)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 5)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 18)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 31);
+        @out[11 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (13 - 12)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 12)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 25);
+        @out[12 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (13 - 6)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 6)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 19);
+    }
+
+    protected static void integratedpack14(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 14)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 28);
+        @out[1 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (14 - 10)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 10)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 24);
+        @out[2 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (14 - 6)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 6)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 20);
+        @out[3 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (14 - 2)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 2)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 30);
+        @out[4 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (14 - 12)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 12)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 26);
+        @out[5 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (14 - 8)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 8)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 22);
+        @out[6 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (14 - 4)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 4)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 18);
+        @out[7 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 14)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 28);
+        @out[8 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (14 - 10)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 10)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 24);
+        @out[9 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (14 - 6)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 6)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 20);
+        @out[10 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (14 - 2)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 2)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 30);
+        @out[11 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (14 - 12)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 12)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 26);
+        @out[12 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (14 - 8)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 8)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 22);
+        @out[13 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (14 - 4)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 4)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 18);
+    }
+
+    protected static void integratedpack15(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 15)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 30);
+        @out[1 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (15 - 13)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 13)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 28);
+        @out[2 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (15 - 11)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 11)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 26);
+        @out[3 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (15 - 9)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 9)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
+        @out[4 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (15 - 7)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 7)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 22);
+        @out[5 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (15 - 5)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 5)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 20);
+        @out[6 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (15 - 3)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 3)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 18);
+        @out[7 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (15 - 1)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 1)
+                           | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 31);
+        @out[8 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (15 - 14)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 14)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 29);
+        @out[9 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (15 - 12)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 12)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 27);
+        @out[10 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (15 - 10)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 10)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 25);
+        @out[11 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (15 - 8)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 23);
+        @out[12 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (15 - 6)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 6)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 21);
+        @out[13 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (15 - 4)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 4)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 19);
+        @out[14 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (15 - 2)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 2)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 17);
+    }
+
+    protected static void integratedpack16(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 16);
+        @out[1 + outpos] = (@in[2 + inpos] - @in[2 + inpos - 1])
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 16);
+        @out[2 + outpos] = (@in[4 + inpos] - @in[4 + inpos - 1])
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 16);
+        @out[3 + outpos] = (@in[6 + inpos] - @in[6 + inpos - 1])
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 16);
+        @out[4 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 16);
+        @out[5 + outpos] = (@in[10 + inpos] - @in[10 + inpos - 1])
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 16);
+        @out[6 + outpos] = (@in[12 + inpos] - @in[12 + inpos - 1])
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 16);
+        @out[7 + outpos] = (@in[14 + inpos] - @in[14 + inpos - 1])
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 16);
+        @out[8 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 16);
+        @out[9 + outpos] = (@in[18 + inpos] - @in[18 + inpos - 1])
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 16);
+        @out[10 + outpos] = (@in[20 + inpos] - @in[20 + inpos - 1])
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 16);
+        @out[11 + outpos] = (@in[22 + inpos] - @in[22 + inpos - 1])
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 16);
+        @out[12 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 16);
+        @out[13 + outpos] = (@in[26 + inpos] - @in[26 + inpos - 1])
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 16);
+        @out[14 + outpos] = (@in[28 + inpos] - @in[28 + inpos - 1])
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 16);
+        @out[15 + outpos] = (@in[30 + inpos] - @in[30 + inpos - 1])
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 16);
+    }
+
+    protected static void integratedpack17(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 17);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (17 - 2)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 2)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 19);
+        @out[2 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (17 - 4)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 4)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 21);
+        @out[3 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (17 - 6)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 6)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 23);
+        @out[4 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (17 - 8)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 25);
+        @out[5 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (17 - 10)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 10)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 27);
+        @out[6 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (17 - 12)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 12)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 29);
+        @out[7 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (17 - 14)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 14)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 31);
+        @out[8 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (17 - 16)
+                           | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
+        @out[9 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (17 - 1)
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 1)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 18);
+        @out[10 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (17 - 3)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 3)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 20);
+        @out[11 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (17 - 5)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 5)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 22);
+        @out[12 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (17 - 7)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 7)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
+        @out[13 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (17 - 9)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 9)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 26);
+        @out[14 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (17 - 11)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 11)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 28);
+        @out[15 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (17 - 13)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 13)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 30);
+        @out[16 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (17 - 15)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 15);
+    }
+
+    protected static void integratedpack18(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 18);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (18 - 4)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 4)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 22);
+        @out[2 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (18 - 8)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 8)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 26);
+        @out[3 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (18 - 12)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 12)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 30);
+        @out[4 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (18 - 16)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16);
+        @out[5 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (18 - 2)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 2)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 20);
+        @out[6 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (18 - 6)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 6)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 24);
+        @out[7 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (18 - 10)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 10)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 28);
+        @out[8 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (18 - 14)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 14);
+        @out[9 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 18);
+        @out[10 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (18 - 4)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 4)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 22);
+        @out[11 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (18 - 8)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 8)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 26);
+        @out[12 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (18 - 12)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 12)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 30);
+        @out[13 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (18 - 16)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16);
+        @out[14 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (18 - 2)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 2)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 20);
+        @out[15 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (18 - 6)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 6)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 24);
+        @out[16 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (18 - 10)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 10)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 28);
+        @out[17 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (18 - 14)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 14);
+    }
+
+    protected static void integratedpack19(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 19);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (19 - 6)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 6)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 25);
+        @out[2 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (19 - 12)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 12)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 31);
+        @out[3 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (19 - 18)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 18);
+        @out[4 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (19 - 5)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 5)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
+        @out[5 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (19 - 11)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 11)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 30);
+        @out[6 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (19 - 17)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 17);
+        @out[7 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (19 - 4)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 4)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 23);
+        @out[8 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (19 - 10)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 10)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 29);
+        @out[9 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (19 - 16)
+                           | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
+        @out[10 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (19 - 3)
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 3)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 22);
+        @out[11 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (19 - 9)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 9)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 28);
+        @out[12 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (19 - 15)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 15);
+        @out[13 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (19 - 2)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 2)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 21);
+        @out[14 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (19 - 8)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 27);
+        @out[15 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (19 - 14)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 14);
+        @out[16 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (19 - 1)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 1)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 20);
+        @out[17 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (19 - 7)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 7)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 26);
+        @out[18 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (19 - 13)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 13);
+    }
+
+    protected static void integratedpack2(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 2)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 4)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 6)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 8)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 10)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 12)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 14)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 18)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 20)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 22)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 24)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 26)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 28)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 30);
+        @out[1 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 2)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 4)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 6)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 8)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 10)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 12)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 14)
+                           | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16)
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 18)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 20)
+                           | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 22)
+                           | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 24)
+                           | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 26)
+                           | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 28)
+                           | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 30);
+    }
+
+    protected static void integratedpack20(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 20);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (20 - 8)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 8)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 28);
+        @out[2 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (20 - 16)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 16);
+        @out[3 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (20 - 4)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 4)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 24);
+        @out[4 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (20 - 12)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 12);
+        @out[5 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 20);
+        @out[6 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (20 - 8)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 8)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 28);
+        @out[7 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (20 - 16)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 16);
+        @out[8 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (20 - 4)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 4)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 24);
+        @out[9 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (20 - 12)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 12);
+        @out[10 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 20);
+        @out[11 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (20 - 8)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 8)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 28);
+        @out[12 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (20 - 16)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 16);
+        @out[13 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (20 - 4)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 4)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 24);
+        @out[14 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (20 - 12)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 12);
+        @out[15 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 20);
+        @out[16 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (20 - 8)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 8)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 28);
+        @out[17 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (20 - 16)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 16);
+        @out[18 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (20 - 4)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 4)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 24);
+        @out[19 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (20 - 12)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 12);
+    }
+
+    protected static void integratedpack21(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 21);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (21 - 10)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 10)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 31);
+        @out[2 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (21 - 20)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 20);
+        @out[3 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (21 - 9)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 9)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 30);
+        @out[4 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (21 - 19)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 19);
+        @out[5 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (21 - 8)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 29);
+        @out[6 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (21 - 18)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 18);
+        @out[7 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (21 - 7)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 7)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 28);
+        @out[8 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (21 - 17)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 17);
+        @out[9 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (21 - 6)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 6)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 27);
+        @out[10 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (21 - 16)
+                            | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
+        @out[11 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (21 - 5)
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 5)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 26);
+        @out[12 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (21 - 15)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 15);
+        @out[13 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (21 - 4)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 4)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 25);
+        @out[14 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (21 - 14)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 14);
+        @out[15 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (21 - 3)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 3)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
+        @out[16 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (21 - 13)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 13);
+        @out[17 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (21 - 2)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 2)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 23);
+        @out[18 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (21 - 12)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 12);
+        @out[19 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (21 - 1)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 1)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 22);
+        @out[20 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (21 - 11)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 11);
+    }
+
+    protected static void integratedpack22(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 22);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (22 - 12)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 12);
+        @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (22 - 2)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 2)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 24);
+        @out[3 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (22 - 14)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 14);
+        @out[4 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (22 - 4)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 4)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 26);
+        @out[5 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (22 - 16)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16);
+        @out[6 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (22 - 6)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 6)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 28);
+        @out[7 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (22 - 18)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 18);
+        @out[8 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (22 - 8)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 8)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 30);
+        @out[9 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (22 - 20)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 20);
+        @out[10 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (22 - 10)
+                            | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 10);
+        @out[11 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 22);
+        @out[12 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (22 - 12)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 12);
+        @out[13 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (22 - 2)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 2)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 24);
+        @out[14 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (22 - 14)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 14);
+        @out[15 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (22 - 4)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 4)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 26);
+        @out[16 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (22 - 16)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16);
+        @out[17 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (22 - 6)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 6)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 28);
+        @out[18 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (22 - 18)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 18);
+        @out[19 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (22 - 8)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 8)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 30);
+        @out[20 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (22 - 20)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 20);
+        @out[21 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (22 - 10)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 10);
+    }
+
+    protected static void integratedpack23(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 23);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (23 - 14)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 14);
+        @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (23 - 5)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 5)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 28);
+        @out[3 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (23 - 19)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 19);
+        @out[4 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (23 - 10)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 10);
+        @out[5 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (23 - 1)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 1)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
+        @out[6 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (23 - 15)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 15);
+        @out[7 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (23 - 6)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 6)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 29);
+        @out[8 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (23 - 20)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 20);
+        @out[9 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (23 - 11)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 11);
+        @out[10 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (23 - 2)
+                            | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 2)
+                            | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 25);
+        @out[11 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (23 - 16)
+                            | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
+        @out[12 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (23 - 7)
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 7)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 30);
+        @out[13 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (23 - 21)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 21);
+        @out[14 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (23 - 12)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 12);
+        @out[15 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (23 - 3)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 3)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 26);
+        @out[16 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (23 - 17)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 17);
+        @out[17 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (23 - 8)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 31);
+        @out[18 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (23 - 22)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 22);
+        @out[19 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (23 - 13)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 13);
+        @out[20 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (23 - 4)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 4)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 27);
+        @out[21 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (23 - 18)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 18);
+        @out[22 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (23 - 9)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 9);
+    }
+
+    protected static void integratedpack24(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 24);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (24 - 16)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 16);
+        @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (24 - 8)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 8);
+        @out[3 + outpos] = (@in[4 + inpos] - @in[4 + inpos - 1])
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 24);
+        @out[4 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (24 - 16)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 16);
+        @out[5 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (24 - 8)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 8);
+        @out[6 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 24);
+        @out[7 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (24 - 16)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 16);
+        @out[8 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (24 - 8)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 8);
+        @out[9 + outpos] = (@in[12 + inpos] - @in[12 + inpos - 1])
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 24);
+        @out[10 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (24 - 16)
+                            | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 16);
+        @out[11 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (24 - 8)
+                            | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 8);
+        @out[12 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 24);
+        @out[13 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (24 - 16)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 16);
+        @out[14 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (24 - 8)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 8);
+        @out[15 + outpos] = (@in[20 + inpos] - @in[20 + inpos - 1])
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 24);
+        @out[16 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (24 - 16)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 16);
+        @out[17 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (24 - 8)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 8);
+        @out[18 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 24);
+        @out[19 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (24 - 16)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 16);
+        @out[20 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (24 - 8)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 8);
+        @out[21 + outpos] = (@in[28 + inpos] - @in[28 + inpos - 1])
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 24);
+        @out[22 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (24 - 16)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 16);
+        @out[23 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (24 - 8)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 8);
+    }
+
+    protected static void integratedpack25(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 25);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (25 - 18)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 18);
+        @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (25 - 11)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 11);
+        @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (25 - 4)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 4)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 29);
+        @out[4 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (25 - 22)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 22);
+        @out[5 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (25 - 15)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 15);
+        @out[6 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (25 - 8)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8);
+        @out[7 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (25 - 1)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 1)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 26);
+        @out[8 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (25 - 19)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 19);
+        @out[9 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (25 - 12)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 12);
+        @out[10 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (25 - 5)
+                            | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 5)
+                            | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 30);
+        @out[11 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (25 - 23)
+                            | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 23);
+        @out[12 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (25 - 16)
+                            | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
+        @out[13 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (25 - 9)
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 9);
+        @out[14 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (25 - 2)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 2)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 27);
+        @out[15 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (25 - 20)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 20);
+        @out[16 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (25 - 13)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 13);
+        @out[17 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (25 - 6)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 6)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 31);
+        @out[18 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (25 - 24)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
+        @out[19 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (25 - 17)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 17);
+        @out[20 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (25 - 10)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 10);
+        @out[21 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (25 - 3)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 3)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 28);
+        @out[22 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (25 - 21)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 21);
+        @out[23 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (25 - 14)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 14);
+        @out[24 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (25 - 7)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 7);
+    }
+
+    protected static void integratedpack26(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 26);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (26 - 20)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 20);
+        @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (26 - 14)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 14);
+        @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (26 - 8)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 8);
+        @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (26 - 2)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 2)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 28);
+        @out[5 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (26 - 22)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 22);
+        @out[6 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (26 - 16)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16);
+        @out[7 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (26 - 10)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 10);
+        @out[8 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (26 - 4)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 4)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 30);
+        @out[9 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (26 - 24)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 24);
+        @out[10 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (26 - 18)
+                            | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 18);
+        @out[11 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (26 - 12)
+                            | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 12);
+        @out[12 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (26 - 6)
+                            | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 6);
+        @out[13 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 26);
+        @out[14 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (26 - 20)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 20);
+        @out[15 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (26 - 14)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 14);
+        @out[16 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (26 - 8)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 8);
+        @out[17 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (26 - 2)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 2)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 28);
+        @out[18 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (26 - 22)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 22);
+        @out[19 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (26 - 16)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16);
+        @out[20 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (26 - 10)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 10);
+        @out[21 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (26 - 4)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 4)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 30);
+        @out[22 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (26 - 24)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 24);
+        @out[23 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (26 - 18)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 18);
+        @out[24 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (26 - 12)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 12);
+        @out[25 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (26 - 6)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 6);
+    }
+
+    protected static void integratedpack27(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 27);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (27 - 22)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 22);
+        @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (27 - 17)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 17);
+        @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (27 - 12)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 12);
+        @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (27 - 7)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 7);
+        @out[5 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (27 - 2)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 2)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 29);
+        @out[6 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (27 - 24)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
+        @out[7 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (27 - 19)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 19);
+        @out[8 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (27 - 14)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 14);
+        @out[9 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (27 - 9)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 9);
+        @out[10 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (27 - 4)
+                            | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 4)
+                            | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 31);
+        @out[11 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (27 - 26)
+                            | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 26);
+        @out[12 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (27 - 21)
+                            | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 21);
+        @out[13 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (27 - 16)
+                            | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
+        @out[14 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (27 - 11)
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 11);
+        @out[15 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (27 - 6)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 6);
+        @out[16 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (27 - 1)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 1)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 28);
+        @out[17 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (27 - 23)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 23);
+        @out[18 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (27 - 18)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 18);
+        @out[19 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (27 - 13)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 13);
+        @out[20 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (27 - 8)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8);
+        @out[21 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (27 - 3)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 3)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 30);
+        @out[22 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (27 - 25)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 25);
+        @out[23 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (27 - 20)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 20);
+        @out[24 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (27 - 15)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 15);
+        @out[25 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (27 - 10)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 10);
+        @out[26 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (27 - 5)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 5);
+    }
+
+    protected static void integratedpack28(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 28);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (28 - 24)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 24);
+        @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (28 - 20)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 20);
+        @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (28 - 16)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 16);
+        @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (28 - 12)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 12);
+        @out[5 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (28 - 8)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 8);
+        @out[6 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (28 - 4)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 4);
+        @out[7 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 28);
+        @out[8 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (28 - 24)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 24);
+        @out[9 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (28 - 20)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 20);
+        @out[10 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (28 - 16)
+                            | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 16);
+        @out[11 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (28 - 12)
+                            | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 12);
+        @out[12 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (28 - 8)
+                            | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 8);
+        @out[13 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (28 - 4)
+                            | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 4);
+        @out[14 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 28);
+        @out[15 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (28 - 24)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 24);
+        @out[16 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (28 - 20)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 20);
+        @out[17 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (28 - 16)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 16);
+        @out[18 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (28 - 12)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 12);
+        @out[19 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (28 - 8)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 8);
+        @out[20 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (28 - 4)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 4);
+        @out[21 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 28);
+        @out[22 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (28 - 24)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 24);
+        @out[23 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (28 - 20)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 20);
+        @out[24 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (28 - 16)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 16);
+        @out[25 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (28 - 12)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 12);
+        @out[26 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (28 - 8)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 8);
+        @out[27 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (28 - 4)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 4);
+    }
+
+    protected static void integratedpack29(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 29);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (29 - 26)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 26);
+        @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (29 - 23)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 23);
+        @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (29 - 20)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 20);
+        @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (29 - 17)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 17);
+        @out[5 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (29 - 14)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 14);
+        @out[6 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (29 - 11)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 11);
+        @out[7 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (29 - 8)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8);
+        @out[8 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (29 - 5)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 5);
+        @out[9 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (29 - 2)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 2)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 31);
+        @out[10 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (29 - 28)
+                            | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 28);
+        @out[11 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (29 - 25)
+                            | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 25);
+        @out[12 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (29 - 22)
+                            | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 22);
+        @out[13 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (29 - 19)
+                            | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 19);
+        @out[14 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (29 - 16)
+                            | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
+        @out[15 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (29 - 13)
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 13);
+        @out[16 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (29 - 10)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 10);
+        @out[17 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (29 - 7)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 7);
+        @out[18 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (29 - 4)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 4);
+        @out[19 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (29 - 1)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 1)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 30);
+        @out[20 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (29 - 27)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 27);
+        @out[21 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (29 - 24)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
+        @out[22 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (29 - 21)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 21);
+        @out[23 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (29 - 18)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 18);
+        @out[24 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (29 - 15)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 15);
+        @out[25 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (29 - 12)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 12);
+        @out[26 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (29 - 9)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 9);
+        @out[27 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (29 - 6)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 6);
+        @out[28 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (29 - 3)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 3);
+    }
+
+    protected static void integratedpack3(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 3)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 6)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 9)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 12)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 15)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 18)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 21)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 27)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 30);
+        @out[1 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (3 - 1)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 1)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 4)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 7)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 10)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 13)
+                           | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 19)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 22)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 25)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 28)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 31);
+        @out[2 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (3 - 2)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 2)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 5)
+                           | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 11)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 14)
+                           | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 17)
+                           | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 20)
+                           | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 23)
+                           | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 26)
+                           | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 29);
+    }
+
+    protected static void integratedpack30(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 30);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (30 - 28)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 28);
+        @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (30 - 26)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 26);
+        @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (30 - 24)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 24);
+        @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (30 - 22)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 22);
+        @out[5 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (30 - 20)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 20);
+        @out[6 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (30 - 18)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 18);
+        @out[7 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (30 - 16)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16);
+        @out[8 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (30 - 14)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 14);
+        @out[9 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (30 - 12)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 12);
+        @out[10 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (30 - 10)
+                            | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 10);
+        @out[11 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (30 - 8)
+                            | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 8);
+        @out[12 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (30 - 6)
+                            | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 6);
+        @out[13 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (30 - 4)
+                            | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 4);
+        @out[14 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (30 - 2)
+                            | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 2);
+        @out[15 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 30);
+        @out[16 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (30 - 28)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 28);
+        @out[17 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (30 - 26)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 26);
+        @out[18 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (30 - 24)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 24);
+        @out[19 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (30 - 22)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 22);
+        @out[20 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (30 - 20)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 20);
+        @out[21 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (30 - 18)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 18);
+        @out[22 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (30 - 16)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16);
+        @out[23 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (30 - 14)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 14);
+        @out[24 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (30 - 12)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 12);
+        @out[25 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (30 - 10)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 10);
+        @out[26 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (30 - 8)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 8);
+        @out[27 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (30 - 6)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 6);
+        @out[28 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (30 - 4)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 4);
+        @out[29 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (30 - 2)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 2);
+    }
+
+    protected static void integratedpack31(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 31);
+        @out[1 + outpos] = (int)((uint)@in[1 + inpos] - @in[1 + inpos - 1]) >> (31 - 30)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 30);
+        @out[2 + outpos] = (int)((uint)@in[2 + inpos] - @in[2 + inpos - 1]) >> (31 - 29)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 29);
+        @out[3 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (31 - 28)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 28);
+        @out[4 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (31 - 27)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 27);
+        @out[5 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (31 - 26)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 26);
+        @out[6 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (31 - 25)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 25);
+        @out[7 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (31 - 24)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24);
+        @out[8 + outpos] = (int)((uint)@in[8 + inpos] - @in[8 + inpos - 1]) >> (31 - 23)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 23);
+        @out[9 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (31 - 22)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 22);
+        @out[10 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (31 - 21)
+                            | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 21);
+        @out[11 + outpos] = (int)((uint)@in[11 + inpos] - @in[11 + inpos - 1]) >> (31 - 20)
+                            | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 20);
+        @out[12 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (31 - 19)
+                            | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 19);
+        @out[13 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (31 - 18)
+                            | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 18);
+        @out[14 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (31 - 17)
+                            | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 17);
+        @out[15 + outpos] = (int)((uint)@in[15 + inpos] - @in[15 + inpos - 1]) >> (31 - 16)
+                            | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16);
+        @out[16 + outpos] = (int)((uint)@in[16 + inpos] - @in[16 + inpos - 1]) >> (31 - 15)
+                            | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 15);
+        @out[17 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (31 - 14)
+                            | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 14);
+        @out[18 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (31 - 13)
+                            | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 13);
+        @out[19 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (31 - 12)
+                            | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 12);
+        @out[20 + outpos] = (int)((uint)@in[20 + inpos] - @in[20 + inpos - 1]) >> (31 - 11)
+                            | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 11);
+        @out[21 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (31 - 10)
+                            | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 10);
+        @out[22 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (31 - 9)
+                            | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 9);
+        @out[23 + outpos] = (int)((uint)@in[23 + inpos] - @in[23 + inpos - 1]) >> (31 - 8)
+                            | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8);
+        @out[24 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (31 - 7)
+                            | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 7);
+        @out[25 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (31 - 6)
+                            | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 6);
+        @out[26 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (31 - 5)
+                            | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 5);
+        @out[27 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (31 - 4)
+                            | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 4);
+        @out[28 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (31 - 3)
+                            | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 3);
+        @out[29 + outpos] = (int)((uint)@in[29 + inpos] - @in[29 + inpos - 1]) >> (31 - 2)
+                            | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 2);
+        @out[30 + outpos] = (int)((uint)@in[30 + inpos] - @in[30 + inpos - 1]) >> (31 - 1)
+                            | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 1);
+    }
+
+    protected static void integratedpack32(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        Array.Copy(@in, inpos, @out, outpos, 32); // no sense in
+                                                  // doing delta
+                                                  // coding
+    }
+
+    protected static void integratedpack4(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 4)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 8)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 12)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 16)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 20)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 24)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 28);
+        @out[1 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 4)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 8)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 12)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 16)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 20)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 24)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 28);
+        @out[2 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 4)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 8)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 12)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 16)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 20)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 24)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 28);
+        @out[3 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 4)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 8)
+                           | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 12)
+                           | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 16)
+                           | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 20)
+                           | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 24)
+                           | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 28);
+    }
+
+    protected static void integratedpack5(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 5)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 10)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 15)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 20)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 25)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 30);
+        @out[1 + outpos] = (int)((uint)@in[6 + inpos] - @in[6 + inpos - 1]) >> (5 - 3)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 3)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 13)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 18)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 23)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 28);
+        @out[2 + outpos] = (int)((uint)@in[12 + inpos] - @in[12 + inpos - 1]) >> (5 - 1)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 1)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 6)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 11)
+                           | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 21)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 26)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 31);
+        @out[3 + outpos] = (int)((uint)@in[19 + inpos] - @in[19 + inpos - 1]) >> (5 - 4)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 4)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 9)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 14)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 19)
+                           | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24)
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 29);
+        @out[4 + outpos] = (int)((uint)@in[25 + inpos] - @in[25 + inpos - 1]) >> (5 - 2)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 2)
+                           | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 7)
+                           | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 12)
+                           | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 17)
+                           | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 22)
+                           | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 27);
+    }
+
+    protected static void integratedpack6(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 6)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 12)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 18)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 24)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 30);
+        @out[1 + outpos] = (int)((uint)@in[5 + inpos] - @in[5 + inpos - 1]) >> (6 - 4)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 4)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 10)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 16)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 22)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 28);
+        @out[2 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (6 - 2)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 2)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 8)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 14)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 20)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 26);
+        @out[3 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 6)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 12)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 18)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 24)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 30);
+        @out[4 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (6 - 4)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 4)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 10)
+                           | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 16)
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 22)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 28);
+        @out[5 + outpos] = (int)((uint)@in[26 + inpos] - @in[26 + inpos - 1]) >> (6 - 2)
+                           | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 2)
+                           | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 8)
+                           | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 14)
+                           | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 20)
+                           | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 26);
+    }
+
+    protected static void integratedpack7(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 7)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 14)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 21)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 28);
+        @out[1 + outpos] = (int)((uint)@in[4 + inpos] - @in[4 + inpos - 1]) >> (7 - 3)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 3)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 10)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 17)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 24)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 31);
+        @out[2 + outpos] = (int)((uint)@in[9 + inpos] - @in[9 + inpos - 1]) >> (7 - 6)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 6)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 13)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 20)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 27);
+        @out[3 + outpos] = (int)((uint)@in[13 + inpos] - @in[13 + inpos - 1]) >> (7 - 2)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 2)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 9)
+                           | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 23)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 30);
+        @out[4 + outpos] = (int)((uint)@in[18 + inpos] - @in[18 + inpos - 1]) >> (7 - 5)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 5)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 12)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 19)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 26);
+        @out[5 + outpos] = (int)((uint)@in[22 + inpos] - @in[22 + inpos - 1]) >> (7 - 1)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 1)
+                           | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 8)
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 15)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 22)
+                           | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 29);
+        @out[6 + outpos] = (int)((uint)@in[27 + inpos] - @in[27 + inpos - 1]) >> (7 - 4)
+                           | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 4)
+                           | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 11)
+                           | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 18)
+                           | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 25);
+    }
+
+    protected static void integratedpack8(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 8)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 16)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 24);
+        @out[1 + outpos] = (@in[4 + inpos] - @in[4 + inpos - 1])
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 8)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 16)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 24);
+        @out[2 + outpos] = (@in[8 + inpos] - @in[8 + inpos - 1])
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 8)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 16)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 24);
+        @out[3 + outpos] = (@in[12 + inpos] - @in[12 + inpos - 1])
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 8)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 16)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 24);
+        @out[4 + outpos] = (@in[16 + inpos] - @in[16 + inpos - 1])
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 8)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 16)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 24);
+        @out[5 + outpos] = (@in[20 + inpos] - @in[20 + inpos - 1])
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 8)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 16)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 24);
+        @out[6 + outpos] = (@in[24 + inpos] - @in[24 + inpos - 1])
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 8)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 16)
+                           | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 24);
+        @out[7 + outpos] = (@in[28 + inpos] - @in[28 + inpos - 1])
+                           | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 8)
+                           | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 16)
+                           | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 24);
+    }
+
+    protected static void integratedpack9(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (@in[0 + inpos] - initoffset)
+                           | ((@in[1 + inpos] - @in[1 + inpos - 1]) << 9)
+                           | ((@in[2 + inpos] - @in[2 + inpos - 1]) << 18)
+                           | ((@in[3 + inpos] - @in[3 + inpos - 1]) << 27);
+        @out[1 + outpos] = (int)((uint)@in[3 + inpos] - @in[3 + inpos - 1]) >> (9 - 4)
+                           | ((@in[4 + inpos] - @in[4 + inpos - 1]) << 4)
+                           | ((@in[5 + inpos] - @in[5 + inpos - 1]) << 13)
+                           | ((@in[6 + inpos] - @in[6 + inpos - 1]) << 22)
+                           | ((@in[7 + inpos] - @in[7 + inpos - 1]) << 31);
+        @out[2 + outpos] = (int)((uint)@in[7 + inpos] - @in[7 + inpos - 1]) >> (9 - 8)
+                           | ((@in[8 + inpos] - @in[8 + inpos - 1]) << 8)
+                           | ((@in[9 + inpos] - @in[9 + inpos - 1]) << 17)
+                           | ((@in[10 + inpos] - @in[10 + inpos - 1]) << 26);
+        @out[3 + outpos] = (int)((uint)@in[10 + inpos] - @in[10 + inpos - 1]) >> (9 - 3)
+                           | ((@in[11 + inpos] - @in[11 + inpos - 1]) << 3)
+                           | ((@in[12 + inpos] - @in[12 + inpos - 1]) << 12)
+                           | ((@in[13 + inpos] - @in[13 + inpos - 1]) << 21)
+                           | ((@in[14 + inpos] - @in[14 + inpos - 1]) << 30);
+        @out[4 + outpos] = (int)((uint)@in[14 + inpos] - @in[14 + inpos - 1]) >> (9 - 7)
+                           | ((@in[15 + inpos] - @in[15 + inpos - 1]) << 7)
+                           | ((@in[16 + inpos] - @in[16 + inpos - 1]) << 16)
+                           | ((@in[17 + inpos] - @in[17 + inpos - 1]) << 25);
+        @out[5 + outpos] = (int)((uint)@in[17 + inpos] - @in[17 + inpos - 1]) >> (9 - 2)
+                           | ((@in[18 + inpos] - @in[18 + inpos - 1]) << 2)
+                           | ((@in[19 + inpos] - @in[19 + inpos - 1]) << 11)
+                           | ((@in[20 + inpos] - @in[20 + inpos - 1]) << 20)
+                           | ((@in[21 + inpos] - @in[21 + inpos - 1]) << 29);
+        @out[6 + outpos] = (int)((uint)@in[21 + inpos] - @in[21 + inpos - 1]) >> (9 - 6)
+                           | ((@in[22 + inpos] - @in[22 + inpos - 1]) << 6)
+                           | ((@in[23 + inpos] - @in[23 + inpos - 1]) << 15)
+                           | ((@in[24 + inpos] - @in[24 + inpos - 1]) << 24);
+        @out[7 + outpos] = (int)((uint)@in[24 + inpos] - @in[24 + inpos - 1]) >> (9 - 1)
+                           | ((@in[25 + inpos] - @in[25 + inpos - 1]) << 1)
+                           | ((@in[26 + inpos] - @in[26 + inpos - 1]) << 10)
+                           | ((@in[27 + inpos] - @in[27 + inpos - 1]) << 19)
+                           | ((@in[28 + inpos] - @in[28 + inpos - 1]) << 28);
+        @out[8 + outpos] = (int)((uint)@in[28 + inpos] - @in[28 + inpos - 1]) >> (9 - 5)
+                           | ((@in[29 + inpos] - @in[29 + inpos - 1]) << 5)
+                           | ((@in[30 + inpos] - @in[30 + inpos - 1]) << 14)
+                           | ((@in[31 + inpos] - @in[31 + inpos - 1]) << 23);
+    }
+
+    /**
+     * Unpack 32 integers along with prefix sum computation
+     * 
+     * @param initoffset value to add to all outputted values
+     * @param in source array
+     * @param inpos initial position in source array
+     * @param out output array
+     * @param outpos initial position in output array
+     * @param bit number of bits to use per integer
+     */
+    public static void integratedunpack(int initoffset, int[] @in, int inpos, int[] @out, int outpos, int bit)
+    {
+        switch (bit)
+        {
+            case 0:
+                integratedunpack0(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 1:
+                integratedunpack1(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 2:
+                integratedunpack2(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 3:
+                integratedunpack3(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 4:
+                integratedunpack4(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 5:
+                integratedunpack5(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 6:
+                integratedunpack6(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 7:
+                integratedunpack7(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 8:
+                integratedunpack8(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 9:
+                integratedunpack9(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 10:
+                integratedunpack10(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 11:
+                integratedunpack11(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 12:
+                integratedunpack12(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 13:
+                integratedunpack13(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 14:
+                integratedunpack14(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 15:
+                integratedunpack15(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 16:
+                integratedunpack16(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 17:
+                integratedunpack17(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 18:
+                integratedunpack18(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 19:
+                integratedunpack19(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 20:
+                integratedunpack20(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 21:
+                integratedunpack21(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 22:
+                integratedunpack22(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 23:
+                integratedunpack23(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 24:
+                integratedunpack24(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 25:
+                integratedunpack25(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 26:
+                integratedunpack26(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 27:
+                integratedunpack27(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 28:
+                integratedunpack28(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 29:
+                integratedunpack29(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 30:
+                integratedunpack30(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 31:
+                integratedunpack31(initoffset, @in, inpos, @out, outpos);
+                break;
+            case 32:
+                integratedunpack32(initoffset, @in, inpos, @out, outpos);
+                break;
+            default:
+                throw new ArgumentException(
+                    "Unsupported bit width.");
+        }
+    }
+
+    protected static void integratedunpack0(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        Arrays.fill(@out, outpos, outpos + 32, initoffset);
+    }
+
+    protected static void integratedunpack1(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 1)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 1) & 1))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 2) & 1))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 3) & 1))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 4) & 1))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[0 + inpos] >> 5) & 1))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[0 + inpos] >> 6) & 1))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[0 + inpos] >> 7) & 1))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[0 + inpos] >> 8) & 1))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[0 + inpos] >> 9) & 1))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[0 + inpos] >> 10) & 1))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[0 + inpos] >> 11) & 1))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 1))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[0 + inpos] >> 13) & 1))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[0 + inpos] >> 14) & 1))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = (((int)((uint)@in[0 + inpos] >> 15) & 1))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[0 + inpos] >> 16) & 1))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[0 + inpos] >> 17) & 1))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[0 + inpos] >> 18) & 1))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[0 + inpos] >> 19) & 1))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[0 + inpos] >> 20) & 1))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[0 + inpos] >> 21) & 1))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[0 + inpos] >> 22) & 1))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[0 + inpos] >> 23) & 1))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[0 + inpos] >> 24) & 1))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[0 + inpos] >> 25) & 1))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[0 + inpos] >> 26) & 1))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[0 + inpos] >> 27) & 1))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[0 + inpos] >> 28) & 1))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[0 + inpos] >> 29) & 1))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[0 + inpos] >> 30) & 1))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[0 + inpos] >> 31))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack10(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 1023)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 10) & 1023))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 20) & 1023))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 255) << (10 - 8)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 1023))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[1 + inpos] >> 18) & 1023))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 63) << (10 - 6)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[2 + inpos] >> 6) & 1023))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[2 + inpos] >> 16) & 1023))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[2 + inpos] >> 26) | ((@in[3 + inpos] & 15) << (10 - 4)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[3 + inpos] >> 4) & 1023))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[3 + inpos] >> 14) & 1023))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 3) << (10 - 2)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[4 + inpos] >> 2) & 1023))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[4 + inpos] >> 12) & 1023))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[4 + inpos] >> 22))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[5 + inpos] >> 0) & 1023))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[5 + inpos] >> 10) & 1023))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[5 + inpos] >> 20) & 1023))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[5 + inpos] >> 30) | ((@in[6 + inpos] & 255) << (10 - 8)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[6 + inpos] >> 8) & 1023))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[6 + inpos] >> 18) & 1023))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[6 + inpos] >> 28) | ((@in[7 + inpos] & 63) << (10 - 6)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[7 + inpos] >> 6) & 1023))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[7 + inpos] >> 16) & 1023))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[7 + inpos] >> 26) | ((@in[8 + inpos] & 15) << (10 - 4)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[8 + inpos] >> 4) & 1023))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[8 + inpos] >> 14) & 1023))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[8 + inpos] >> 24) | ((@in[9 + inpos] & 3) << (10 - 2)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[9 + inpos] >> 2) & 1023))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[9 + inpos] >> 12) & 1023))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[9 + inpos] >> 22))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack11(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 2047)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 11) & 2047))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[0 + inpos] >> 22) | ((@in[1 + inpos] & 1) << (11 - 1)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[1 + inpos] >> 1) & 2047))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[1 + inpos] >> 12) & 2047))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[1 + inpos] >> 23) | ((@in[2 + inpos] & 3) << (11 - 2)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[2 + inpos] >> 2) & 2047))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[2 + inpos] >> 13) & 2047))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[2 + inpos] >> 24) | ((@in[3 + inpos] & 7) << (11 - 3)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[3 + inpos] >> 3) & 2047))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[3 + inpos] >> 14) & 2047))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[3 + inpos] >> 25) | ((@in[4 + inpos] & 15) << (11 - 4)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[4 + inpos] >> 4) & 2047))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[4 + inpos] >> 15) & 2047))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[4 + inpos] >> 26) | ((@in[5 + inpos] & 31) << (11 - 5)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = (((int)((uint)@in[5 + inpos] >> 5) & 2047))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[5 + inpos] >> 16) & 2047))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[5 + inpos] >> 27) | ((@in[6 + inpos] & 63) << (11 - 6)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[6 + inpos] >> 6) & 2047))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[6 + inpos] >> 17) & 2047))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[6 + inpos] >> 28) | ((@in[7 + inpos] & 127) << (11 - 7)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[7 + inpos] >> 7) & 2047))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[7 + inpos] >> 18) & 2047))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[7 + inpos] >> 29) | ((@in[8 + inpos] & 255) << (11 - 8)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[8 + inpos] >> 8) & 2047))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[8 + inpos] >> 19) & 2047))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[8 + inpos] >> 30) | ((@in[9 + inpos] & 511) << (11 - 9)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[9 + inpos] >> 9) & 2047))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[9 + inpos] >> 20) & 2047))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[9 + inpos] >> 31) | ((@in[10 + inpos] & 1023) << (11 - 10)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[10 + inpos] >> 10) & 2047))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[10 + inpos] >> 21))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack12(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 4095)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 4095))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[0 + inpos] >> 24) | ((@in[1 + inpos] & 15) << (12 - 4)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 4095))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 4095))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 255) << (12 - 8)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 4095))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[2 + inpos] >> 20))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 4095))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[3 + inpos] >> 12) & 4095))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 15) << (12 - 4)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[4 + inpos] >> 4) & 4095))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[4 + inpos] >> 16) & 4095))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[4 + inpos] >> 28) | ((@in[5 + inpos] & 255) << (12 - 8)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 4095))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[5 + inpos] >> 20))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[6 + inpos] >> 0) & 4095))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[6 + inpos] >> 12) & 4095))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[6 + inpos] >> 24) | ((@in[7 + inpos] & 15) << (12 - 4)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[7 + inpos] >> 4) & 4095))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[7 + inpos] >> 16) & 4095))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 255) << (12 - 8)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[8 + inpos] >> 8) & 4095))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[8 + inpos] >> 20))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[9 + inpos] >> 0) & 4095))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[9 + inpos] >> 12) & 4095))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[9 + inpos] >> 24) | ((@in[10 + inpos] & 15) << (12 - 4)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[10 + inpos] >> 4) & 4095))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[10 + inpos] >> 16) & 4095))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[10 + inpos] >> 28) | ((@in[11 + inpos] & 255) << (12 - 8)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[11 + inpos] >> 8) & 4095))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[11 + inpos] >> 20))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack13(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 8191)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 13) & 8191))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[0 + inpos] >> 26) | ((@in[1 + inpos] & 127) << (13 - 7)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[1 + inpos] >> 7) & 8191))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[1 + inpos] >> 20) | ((@in[2 + inpos] & 1) << (13 - 1)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[2 + inpos] >> 1) & 8191))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[2 + inpos] >> 14) & 8191))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[2 + inpos] >> 27) | ((@in[3 + inpos] & 255) << (13 - 8)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[3 + inpos] >> 8) & 8191))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[3 + inpos] >> 21) | ((@in[4 + inpos] & 3) << (13 - 2)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[4 + inpos] >> 2) & 8191))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[4 + inpos] >> 15) & 8191))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[4 + inpos] >> 28) | ((@in[5 + inpos] & 511) << (13 - 9)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[5 + inpos] >> 9) & 8191))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[5 + inpos] >> 22) | ((@in[6 + inpos] & 7) << (13 - 3)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = (((int)((uint)@in[6 + inpos] >> 3) & 8191))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[6 + inpos] >> 16) & 8191))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[6 + inpos] >> 29) | ((@in[7 + inpos] & 1023) << (13 - 10)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[7 + inpos] >> 10) & 8191))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[7 + inpos] >> 23) | ((@in[8 + inpos] & 15) << (13 - 4)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[8 + inpos] >> 4) & 8191))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[8 + inpos] >> 17) & 8191))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[8 + inpos] >> 30) | ((@in[9 + inpos] & 2047) << (13 - 11)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[9 + inpos] >> 11) & 8191))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[9 + inpos] >> 24) | ((@in[10 + inpos] & 31) << (13 - 5)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[10 + inpos] >> 5) & 8191))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[10 + inpos] >> 18) & 8191))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[10 + inpos] >> 31) | ((@in[11 + inpos] & 4095) << (13 - 12)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[11 + inpos] >> 12) & 8191))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[11 + inpos] >> 25) | ((@in[12 + inpos] & 63) << (13 - 6)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[12 + inpos] >> 6) & 8191))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[12 + inpos] >> 19))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack14(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 16383))
+                           + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 14) & 16383))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[0 + inpos] >> 28) | ((@in[1 + inpos] & 1023) << (14 - 10)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 16383))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[1 + inpos] >> 24) | ((@in[2 + inpos] & 63) << (14 - 6)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[2 + inpos] >> 6) & 16383))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[2 + inpos] >> 20) | ((@in[3 + inpos] & 3) << (14 - 2)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[3 + inpos] >> 2) & 16383))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[3 + inpos] >> 16) & 16383))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 4095) << (14 - 12)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[4 + inpos] >> 12) & 16383))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[4 + inpos] >> 26) | ((@in[5 + inpos] & 255) << (14 - 8)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 16383))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[5 + inpos] >> 22) | ((@in[6 + inpos] & 15) << (14 - 4)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[6 + inpos] >> 4) & 16383))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[6 + inpos] >> 18))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[7 + inpos] >> 0) & 16383))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[7 + inpos] >> 14) & 16383))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 1023) << (14 - 10)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[8 + inpos] >> 10) & 16383))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[8 + inpos] >> 24) | ((@in[9 + inpos] & 63) << (14 - 6)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[9 + inpos] >> 6) & 16383))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[9 + inpos] >> 20) | ((@in[10 + inpos] & 3) << (14 - 2)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[10 + inpos] >> 2) & 16383))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[10 + inpos] >> 16) & 16383))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[10 + inpos] >> 30) | ((@in[11 + inpos] & 4095) << (14 - 12)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[11 + inpos] >> 12) & 16383))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[11 + inpos] >> 26) | ((@in[12 + inpos] & 255) << (14 - 8)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[12 + inpos] >> 8) & 16383))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[12 + inpos] >> 22) | ((@in[13 + inpos] & 15) << (14 - 4)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[13 + inpos] >> 4) & 16383))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[13 + inpos] >> 18))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack15(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 32767))
+                           + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 15) & 32767))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 8191) << (15 - 13)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[1 + inpos] >> 13) & 32767))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 2047) << (15 - 11)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[2 + inpos] >> 11) & 32767))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[2 + inpos] >> 26) | ((@in[3 + inpos] & 511) << (15 - 9)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[3 + inpos] >> 9) & 32767))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 127) << (15 - 7)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[4 + inpos] >> 7) & 32767))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[4 + inpos] >> 22) | ((@in[5 + inpos] & 31) << (15 - 5)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[5 + inpos] >> 5) & 32767))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[5 + inpos] >> 20) | ((@in[6 + inpos] & 7) << (15 - 3)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[6 + inpos] >> 3) & 32767))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[6 + inpos] >> 18) | ((@in[7 + inpos] & 1) << (15 - 1)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = (((int)((uint)@in[7 + inpos] >> 1) & 32767))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[7 + inpos] >> 16) & 32767))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[7 + inpos] >> 31) | ((@in[8 + inpos] & 16383) << (15 - 14)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[8 + inpos] >> 14) & 32767))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[8 + inpos] >> 29) | ((@in[9 + inpos] & 4095) << (15 - 12)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[9 + inpos] >> 12) & 32767))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[9 + inpos] >> 27) | ((@in[10 + inpos] & 1023) << (15 - 10)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[10 + inpos] >> 10) & 32767))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[10 + inpos] >> 25) | ((@in[11 + inpos] & 255) << (15 - 8)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[11 + inpos] >> 8) & 32767))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[11 + inpos] >> 23) | ((@in[12 + inpos] & 63) << (15 - 6)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[12 + inpos] >> 6) & 32767))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[12 + inpos] >> 21) | ((@in[13 + inpos] & 15) << (15 - 4)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[13 + inpos] >> 4) & 32767))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[13 + inpos] >> 19) | ((@in[14 + inpos] & 3) << (15 - 2)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[14 + inpos] >> 2) & 32767))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[14 + inpos] >> 17))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack16(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 65535))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 16))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 0) & 65535))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 16))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[2 + inpos] >> 0) & 65535))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[2 + inpos] >> 16))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 65535))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[3 + inpos] >> 16))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[4 + inpos] >> 0) & 65535))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[4 + inpos] >> 16))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[5 + inpos] >> 0) & 65535))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[5 + inpos] >> 16))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[6 + inpos] >> 0) & 65535))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[6 + inpos] >> 16))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[7 + inpos] >> 0) & 65535))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[7 + inpos] >> 16))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[8 + inpos] >> 0) & 65535))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[8 + inpos] >> 16))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[9 + inpos] >> 0) & 65535))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[9 + inpos] >> 16))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[10 + inpos] >> 0) & 65535))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[10 + inpos] >> 16))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[11 + inpos] >> 0) & 65535))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[11 + inpos] >> 16))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[12 + inpos] >> 0) & 65535))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[12 + inpos] >> 16))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[13 + inpos] >> 0) & 65535))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[13 + inpos] >> 16))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[14 + inpos] >> 0) & 65535))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[14 + inpos] >> 16))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[15 + inpos] >> 0) & 65535))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[15 + inpos] >> 16))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack17(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 131071))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 17) | ((@in[1 + inpos] & 3) << (17 - 2)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 2) & 131071))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 19) | ((@in[2 + inpos] & 15) << (17 - 4)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[2 + inpos] >> 4) & 131071))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[2 + inpos] >> 21) | ((@in[3 + inpos] & 63) << (17 - 6)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[3 + inpos] >> 6) & 131071))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[3 + inpos] >> 23) | ((@in[4 + inpos] & 255) << (17 - 8)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[4 + inpos] >> 8) & 131071))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[4 + inpos] >> 25) | ((@in[5 + inpos] & 1023) << (17 - 10)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[5 + inpos] >> 10) & 131071))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[5 + inpos] >> 27) | ((@in[6 + inpos] & 4095) << (17 - 12)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[6 + inpos] >> 12) & 131071))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[6 + inpos] >> 29) | ((@in[7 + inpos] & 16383) << (17 - 14)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[7 + inpos] >> 14) & 131071))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[7 + inpos] >> 31) | ((@in[8 + inpos] & 65535) << (17 - 16)))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = ((int)((uint)@in[8 + inpos] >> 16) | ((@in[9 + inpos] & 1) << (17 - 1)))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[9 + inpos] >> 1) & 131071))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[9 + inpos] >> 18) | ((@in[10 + inpos] & 7) << (17 - 3)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[10 + inpos] >> 3) & 131071))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[10 + inpos] >> 20) | ((@in[11 + inpos] & 31) << (17 - 5)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[11 + inpos] >> 5) & 131071))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[11 + inpos] >> 22) | ((@in[12 + inpos] & 127) << (17 - 7)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[12 + inpos] >> 7) & 131071))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[12 + inpos] >> 24) | ((@in[13 + inpos] & 511) << (17 - 9)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[13 + inpos] >> 9) & 131071))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[13 + inpos] >> 26) | ((@in[14 + inpos] & 2047) << (17 - 11)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[14 + inpos] >> 11) & 131071))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[14 + inpos] >> 28) | ((@in[15 + inpos] & 8191) << (17 - 13)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[15 + inpos] >> 13) & 131071))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[15 + inpos] >> 30) | ((@in[16 + inpos] & 32767) << (17 - 15)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[16 + inpos] >> 15))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack18(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 262143))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 18) | ((@in[1 + inpos] & 15) << (18 - 4)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 262143))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 22) | ((@in[2 + inpos] & 255) << (18 - 8)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 262143))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[2 + inpos] >> 26) | ((@in[3 + inpos] & 4095) << (18 - 12)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[3 + inpos] >> 12) & 262143))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 65535) << (18 - 16)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[4 + inpos] >> 16) | ((@in[5 + inpos] & 3) << (18 - 2)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[5 + inpos] >> 2) & 262143))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[5 + inpos] >> 20) | ((@in[6 + inpos] & 63) << (18 - 6)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[6 + inpos] >> 6) & 262143))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[6 + inpos] >> 24) | ((@in[7 + inpos] & 1023) << (18 - 10)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[7 + inpos] >> 10) & 262143))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 16383) << (18 - 14)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[8 + inpos] >> 14))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[9 + inpos] >> 0) & 262143))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[9 + inpos] >> 18) | ((@in[10 + inpos] & 15) << (18 - 4)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[10 + inpos] >> 4) & 262143))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[10 + inpos] >> 22) | ((@in[11 + inpos] & 255) << (18 - 8)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[11 + inpos] >> 8) & 262143))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[11 + inpos] >> 26) | ((@in[12 + inpos] & 4095) << (18 - 12)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[12 + inpos] >> 12) & 262143))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[12 + inpos] >> 30) | ((@in[13 + inpos] & 65535) << (18 - 16)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[13 + inpos] >> 16) | ((@in[14 + inpos] & 3) << (18 - 2)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[14 + inpos] >> 2) & 262143))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[14 + inpos] >> 20) | ((@in[15 + inpos] & 63) << (18 - 6)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[15 + inpos] >> 6) & 262143))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[15 + inpos] >> 24) | ((@in[16 + inpos] & 1023) << (18 - 10)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[16 + inpos] >> 10) & 262143))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[16 + inpos] >> 28) | ((@in[17 + inpos] & 16383) << (18 - 14)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[17 + inpos] >> 14))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack19(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 524287))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 19) | ((@in[1 + inpos] & 63) << (19 - 6)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 6) & 524287))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 25) | ((@in[2 + inpos] & 4095) << (19 - 12)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[2 + inpos] >> 12) & 524287))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[2 + inpos] >> 31) | ((@in[3 + inpos] & 262143) << (19 - 18)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[3 + inpos] >> 18) | ((@in[4 + inpos] & 31) << (19 - 5)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[4 + inpos] >> 5) & 524287))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[4 + inpos] >> 24) | ((@in[5 + inpos] & 2047) << (19 - 11)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[5 + inpos] >> 11) & 524287))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[5 + inpos] >> 30) | ((@in[6 + inpos] & 131071) << (19 - 17)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[6 + inpos] >> 17) | ((@in[7 + inpos] & 15) << (19 - 4)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[7 + inpos] >> 4) & 524287))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[7 + inpos] >> 23) | ((@in[8 + inpos] & 1023) << (19 - 10)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[8 + inpos] >> 10) & 524287))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[8 + inpos] >> 29) | ((@in[9 + inpos] & 65535) << (19 - 16)))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = ((int)((uint)@in[9 + inpos] >> 16) | ((@in[10 + inpos] & 7) << (19 - 3)))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[10 + inpos] >> 3) & 524287))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[10 + inpos] >> 22) | ((@in[11 + inpos] & 511) << (19 - 9)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[11 + inpos] >> 9) & 524287))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[11 + inpos] >> 28) | ((@in[12 + inpos] & 32767) << (19 - 15)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[12 + inpos] >> 15) | ((@in[13 + inpos] & 3) << (19 - 2)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[13 + inpos] >> 2) & 524287))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[13 + inpos] >> 21) | ((@in[14 + inpos] & 255) << (19 - 8)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[14 + inpos] >> 8) & 524287))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[14 + inpos] >> 27) | ((@in[15 + inpos] & 16383) << (19 - 14)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[15 + inpos] >> 14) | ((@in[16 + inpos] & 1) << (19 - 1)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[16 + inpos] >> 1) & 524287))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[16 + inpos] >> 20) | ((@in[17 + inpos] & 127) << (19 - 7)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[17 + inpos] >> 7) & 524287))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[17 + inpos] >> 26) | ((@in[18 + inpos] & 8191) << (19 - 13)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[18 + inpos] >> 13))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack2(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 3)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 2) & 3))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 4) & 3))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 6) & 3))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 8) & 3))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[0 + inpos] >> 10) & 3))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 3))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[0 + inpos] >> 14) & 3))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[0 + inpos] >> 16) & 3))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[0 + inpos] >> 18) & 3))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[0 + inpos] >> 20) & 3))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[0 + inpos] >> 22) & 3))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[0 + inpos] >> 24) & 3))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[0 + inpos] >> 26) & 3))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[0 + inpos] >> 28) & 3))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[0 + inpos] >> 30))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[1 + inpos] >> 0) & 3))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[1 + inpos] >> 2) & 3))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 3))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[1 + inpos] >> 6) & 3))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 3))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 3))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[1 + inpos] >> 12) & 3))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[1 + inpos] >> 14) & 3))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 3))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[1 + inpos] >> 18) & 3))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[1 + inpos] >> 20) & 3))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[1 + inpos] >> 22) & 3))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[1 + inpos] >> 24) & 3))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[1 + inpos] >> 26) & 3))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[1 + inpos] >> 28) & 3))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[1 + inpos] >> 30))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack20(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 1048575))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 20) | ((@in[1 + inpos] & 255) << (20 - 8)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 1048575))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 65535) << (20 - 16)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[2 + inpos] >> 16) | ((@in[3 + inpos] & 15) << (20 - 4)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[3 + inpos] >> 4) & 1048575))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 4095) << (20 - 12)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[4 + inpos] >> 12))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[5 + inpos] >> 0) & 1048575))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[5 + inpos] >> 20) | ((@in[6 + inpos] & 255) << (20 - 8)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[6 + inpos] >> 8) & 1048575))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[6 + inpos] >> 28) | ((@in[7 + inpos] & 65535) << (20 - 16)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[7 + inpos] >> 16) | ((@in[8 + inpos] & 15) << (20 - 4)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[8 + inpos] >> 4) & 1048575))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[8 + inpos] >> 24) | ((@in[9 + inpos] & 4095) << (20 - 12)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[9 + inpos] >> 12))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[10 + inpos] >> 0) & 1048575))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[10 + inpos] >> 20) | ((@in[11 + inpos] & 255) << (20 - 8)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[11 + inpos] >> 8) & 1048575))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[11 + inpos] >> 28) | ((@in[12 + inpos] & 65535) << (20 - 16)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[12 + inpos] >> 16) | ((@in[13 + inpos] & 15) << (20 - 4)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[13 + inpos] >> 4) & 1048575))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[13 + inpos] >> 24) | ((@in[14 + inpos] & 4095) << (20 - 12)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[14 + inpos] >> 12))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[15 + inpos] >> 0) & 1048575))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[15 + inpos] >> 20) | ((@in[16 + inpos] & 255) << (20 - 8)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[16 + inpos] >> 8) & 1048575))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[16 + inpos] >> 28) | ((@in[17 + inpos] & 65535) << (20 - 16)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[17 + inpos] >> 16) | ((@in[18 + inpos] & 15) << (20 - 4)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[18 + inpos] >> 4) & 1048575))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[18 + inpos] >> 24) | ((@in[19 + inpos] & 4095) << (20 - 12)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[19 + inpos] >> 12))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack21(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 2097151))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 21) | ((@in[1 + inpos] & 1023) << (21 - 10)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 2097151))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[1 + inpos] >> 31) | ((@in[2 + inpos] & 1048575) << (21 - 20)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[2 + inpos] >> 20) | ((@in[3 + inpos] & 511) << (21 - 9)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[3 + inpos] >> 9) & 2097151))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 524287) << (21 - 19)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[4 + inpos] >> 19) | ((@in[5 + inpos] & 255) << (21 - 8)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 2097151))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[5 + inpos] >> 29) | ((@in[6 + inpos] & 262143) << (21 - 18)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[6 + inpos] >> 18) | ((@in[7 + inpos] & 127) << (21 - 7)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[7 + inpos] >> 7) & 2097151))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 131071) << (21 - 17)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[8 + inpos] >> 17) | ((@in[9 + inpos] & 63) << (21 - 6)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[9 + inpos] >> 6) & 2097151))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[9 + inpos] >> 27) | ((@in[10 + inpos] & 65535) << (21 - 16)))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = ((int)((uint)@in[10 + inpos] >> 16) | ((@in[11 + inpos] & 31) << (21 - 5)))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[11 + inpos] >> 5) & 2097151))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[11 + inpos] >> 26) | ((@in[12 + inpos] & 32767) << (21 - 15)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[12 + inpos] >> 15) | ((@in[13 + inpos] & 15) << (21 - 4)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[13 + inpos] >> 4) & 2097151))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[13 + inpos] >> 25) | ((@in[14 + inpos] & 16383) << (21 - 14)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[14 + inpos] >> 14) | ((@in[15 + inpos] & 7) << (21 - 3)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[15 + inpos] >> 3) & 2097151))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[15 + inpos] >> 24) | ((@in[16 + inpos] & 8191) << (21 - 13)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[16 + inpos] >> 13) | ((@in[17 + inpos] & 3) << (21 - 2)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[17 + inpos] >> 2) & 2097151))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[17 + inpos] >> 23) | ((@in[18 + inpos] & 4095) << (21 - 12)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[18 + inpos] >> 12) | ((@in[19 + inpos] & 1) << (21 - 1)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[19 + inpos] >> 1) & 2097151))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[19 + inpos] >> 22) | ((@in[20 + inpos] & 2047) << (21 - 11)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[20 + inpos] >> 11))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack22(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 4194303))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 22) | ((@in[1 + inpos] & 4095) << (22 - 12)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 12) | ((@in[2 + inpos] & 3) << (22 - 2)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[2 + inpos] >> 2) & 4194303))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[2 + inpos] >> 24) | ((@in[3 + inpos] & 16383) << (22 - 14)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[3 + inpos] >> 14) | ((@in[4 + inpos] & 15) << (22 - 4)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[4 + inpos] >> 4) & 4194303))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[4 + inpos] >> 26) | ((@in[5 + inpos] & 65535) << (22 - 16)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[5 + inpos] >> 16) | ((@in[6 + inpos] & 63) << (22 - 6)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[6 + inpos] >> 6) & 4194303))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[6 + inpos] >> 28) | ((@in[7 + inpos] & 262143) << (22 - 18)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[7 + inpos] >> 18) | ((@in[8 + inpos] & 255) << (22 - 8)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[8 + inpos] >> 8) & 4194303))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[8 + inpos] >> 30) | ((@in[9 + inpos] & 1048575) << (22 - 20)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[9 + inpos] >> 20) | ((@in[10 + inpos] & 1023) << (22 - 10)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[10 + inpos] >> 10))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[11 + inpos] >> 0) & 4194303))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[11 + inpos] >> 22) | ((@in[12 + inpos] & 4095) << (22 - 12)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[12 + inpos] >> 12) | ((@in[13 + inpos] & 3) << (22 - 2)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[13 + inpos] >> 2) & 4194303))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[13 + inpos] >> 24) | ((@in[14 + inpos] & 16383) << (22 - 14)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[14 + inpos] >> 14) | ((@in[15 + inpos] & 15) << (22 - 4)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[15 + inpos] >> 4) & 4194303))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[15 + inpos] >> 26) | ((@in[16 + inpos] & 65535) << (22 - 16)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[16 + inpos] >> 16) | ((@in[17 + inpos] & 63) << (22 - 6)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[17 + inpos] >> 6) & 4194303))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[17 + inpos] >> 28) | ((@in[18 + inpos] & 262143) << (22 - 18)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[18 + inpos] >> 18) | ((@in[19 + inpos] & 255) << (22 - 8)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[19 + inpos] >> 8) & 4194303))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[19 + inpos] >> 30) | ((@in[20 + inpos] & 1048575) << (22 - 20)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[20 + inpos] >> 20) | ((@in[21 + inpos] & 1023) << (22 - 10)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[21 + inpos] >> 10))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack23(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 8388607))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 23) | ((@in[1 + inpos] & 16383) << (23 - 14)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 14) | ((@in[2 + inpos] & 31) << (23 - 5)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[2 + inpos] >> 5) & 8388607))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[2 + inpos] >> 28) | ((@in[3 + inpos] & 524287) << (23 - 19)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[3 + inpos] >> 19) | ((@in[4 + inpos] & 1023) << (23 - 10)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[4 + inpos] >> 10) | ((@in[5 + inpos] & 1) << (23 - 1)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[5 + inpos] >> 1) & 8388607))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[5 + inpos] >> 24) | ((@in[6 + inpos] & 32767) << (23 - 15)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[6 + inpos] >> 15) | ((@in[7 + inpos] & 63) << (23 - 6)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[7 + inpos] >> 6) & 8388607))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[7 + inpos] >> 29) | ((@in[8 + inpos] & 1048575) << (23 - 20)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[8 + inpos] >> 20) | ((@in[9 + inpos] & 2047) << (23 - 11)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[9 + inpos] >> 11) | ((@in[10 + inpos] & 3) << (23 - 2)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[10 + inpos] >> 2) & 8388607))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[10 + inpos] >> 25) | ((@in[11 + inpos] & 65535) << (23 - 16)))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = ((int)((uint)@in[11 + inpos] >> 16) | ((@in[12 + inpos] & 127) << (23 - 7)))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[12 + inpos] >> 7) & 8388607))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[12 + inpos] >> 30) | ((@in[13 + inpos] & 2097151) << (23 - 21)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[13 + inpos] >> 21) | ((@in[14 + inpos] & 4095) << (23 - 12)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[14 + inpos] >> 12) | ((@in[15 + inpos] & 7) << (23 - 3)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[15 + inpos] >> 3) & 8388607))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[15 + inpos] >> 26) | ((@in[16 + inpos] & 131071) << (23 - 17)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[16 + inpos] >> 17) | ((@in[17 + inpos] & 255) << (23 - 8)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[17 + inpos] >> 8) & 8388607))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[17 + inpos] >> 31) | ((@in[18 + inpos] & 4194303) << (23 - 22)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[18 + inpos] >> 22) | ((@in[19 + inpos] & 8191) << (23 - 13)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[19 + inpos] >> 13) | ((@in[20 + inpos] & 15) << (23 - 4)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[20 + inpos] >> 4) & 8388607))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[20 + inpos] >> 27) | ((@in[21 + inpos] & 262143) << (23 - 18)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[21 + inpos] >> 18) | ((@in[22 + inpos] & 511) << (23 - 9)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[22 + inpos] >> 9))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack24(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 16777215))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 24) | ((@in[1 + inpos] & 65535) << (24 - 16)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 16) | ((@in[2 + inpos] & 255) << (24 - 8)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 8)) + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 16777215))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 65535) << (24 - 16)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[4 + inpos] >> 16) | ((@in[5 + inpos] & 255) << (24 - 8)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[5 + inpos] >> 8)) + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[6 + inpos] >> 0) & 16777215))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[6 + inpos] >> 24) | ((@in[7 + inpos] & 65535) << (24 - 16)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[7 + inpos] >> 16) | ((@in[8 + inpos] & 255) << (24 - 8)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[8 + inpos] >> 8))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[9 + inpos] >> 0) & 16777215))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[9 + inpos] >> 24) | ((@in[10 + inpos] & 65535) << (24 - 16)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[10 + inpos] >> 16) | ((@in[11 + inpos] & 255) << (24 - 8)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[11 + inpos] >> 8))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[12 + inpos] >> 0) & 16777215))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[12 + inpos] >> 24) | ((@in[13 + inpos] & 65535) << (24 - 16)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[13 + inpos] >> 16) | ((@in[14 + inpos] & 255) << (24 - 8)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[14 + inpos] >> 8))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[15 + inpos] >> 0) & 16777215))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[15 + inpos] >> 24) | ((@in[16 + inpos] & 65535) << (24 - 16)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[16 + inpos] >> 16) | ((@in[17 + inpos] & 255) << (24 - 8)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[17 + inpos] >> 8))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[18 + inpos] >> 0) & 16777215))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[18 + inpos] >> 24) | ((@in[19 + inpos] & 65535) << (24 - 16)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[19 + inpos] >> 16) | ((@in[20 + inpos] & 255) << (24 - 8)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[20 + inpos] >> 8))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[21 + inpos] >> 0) & 16777215))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[21 + inpos] >> 24) | ((@in[22 + inpos] & 65535) << (24 - 16)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[22 + inpos] >> 16) | ((@in[23 + inpos] & 255) << (24 - 8)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[23 + inpos] >> 8))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack25(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 33554431))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 25) | ((@in[1 + inpos] & 262143) << (25 - 18)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 18) | ((@in[2 + inpos] & 2047) << (25 - 11)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 11) | ((@in[3 + inpos] & 15) << (25 - 4)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[3 + inpos] >> 4) & 33554431))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[3 + inpos] >> 29) | ((@in[4 + inpos] & 4194303) << (25 - 22)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[4 + inpos] >> 22) | ((@in[5 + inpos] & 32767) << (25 - 15)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[5 + inpos] >> 15) | ((@in[6 + inpos] & 255) << (25 - 8)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[6 + inpos] >> 8) | ((@in[7 + inpos] & 1) << (25 - 1)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[7 + inpos] >> 1) & 33554431))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[7 + inpos] >> 26) | ((@in[8 + inpos] & 524287) << (25 - 19)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[8 + inpos] >> 19) | ((@in[9 + inpos] & 4095) << (25 - 12)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[9 + inpos] >> 12) | ((@in[10 + inpos] & 31) << (25 - 5)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[10 + inpos] >> 5) & 33554431))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[10 + inpos] >> 30) | ((@in[11 + inpos] & 8388607) << (25 - 23)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[11 + inpos] >> 23) | ((@in[12 + inpos] & 65535) << (25 - 16)))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = ((int)((uint)@in[12 + inpos] >> 16) | ((@in[13 + inpos] & 511) << (25 - 9)))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[13 + inpos] >> 9) | ((@in[14 + inpos] & 3) << (25 - 2)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[14 + inpos] >> 2) & 33554431))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[14 + inpos] >> 27) | ((@in[15 + inpos] & 1048575) << (25 - 20)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[15 + inpos] >> 20) | ((@in[16 + inpos] & 8191) << (25 - 13)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[16 + inpos] >> 13) | ((@in[17 + inpos] & 63) << (25 - 6)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[17 + inpos] >> 6) & 33554431))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[17 + inpos] >> 31) | ((@in[18 + inpos] & 16777215) << (25 - 24)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[18 + inpos] >> 24) | ((@in[19 + inpos] & 131071) << (25 - 17)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[19 + inpos] >> 17) | ((@in[20 + inpos] & 1023) << (25 - 10)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[20 + inpos] >> 10) | ((@in[21 + inpos] & 7) << (25 - 3)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[21 + inpos] >> 3) & 33554431))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[21 + inpos] >> 28) | ((@in[22 + inpos] & 2097151) << (25 - 21)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[22 + inpos] >> 21) | ((@in[23 + inpos] & 16383) << (25 - 14)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[23 + inpos] >> 14) | ((@in[24 + inpos] & 127) << (25 - 7)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[24 + inpos] >> 7))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack26(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 67108863))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 26) | ((@in[1 + inpos] & 1048575) << (26 - 20)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 20) | ((@in[2 + inpos] & 16383) << (26 - 14)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 14) | ((@in[3 + inpos] & 255) << (26 - 8)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 8) | ((@in[4 + inpos] & 3) << (26 - 2)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[4 + inpos] >> 2) & 67108863))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[4 + inpos] >> 28) | ((@in[5 + inpos] & 4194303) << (26 - 22)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[5 + inpos] >> 22) | ((@in[6 + inpos] & 65535) << (26 - 16)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[6 + inpos] >> 16) | ((@in[7 + inpos] & 1023) << (26 - 10)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[7 + inpos] >> 10) | ((@in[8 + inpos] & 15) << (26 - 4)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[8 + inpos] >> 4) & 67108863))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[8 + inpos] >> 30) | ((@in[9 + inpos] & 16777215) << (26 - 24)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[9 + inpos] >> 24) | ((@in[10 + inpos] & 262143) << (26 - 18)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[10 + inpos] >> 18) | ((@in[11 + inpos] & 4095) << (26 - 12)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[11 + inpos] >> 12) | ((@in[12 + inpos] & 63) << (26 - 6)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[12 + inpos] >> 6))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[13 + inpos] >> 0) & 67108863))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[13 + inpos] >> 26) | ((@in[14 + inpos] & 1048575) << (26 - 20)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[14 + inpos] >> 20) | ((@in[15 + inpos] & 16383) << (26 - 14)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[15 + inpos] >> 14) | ((@in[16 + inpos] & 255) << (26 - 8)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[16 + inpos] >> 8) | ((@in[17 + inpos] & 3) << (26 - 2)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[17 + inpos] >> 2) & 67108863))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[17 + inpos] >> 28) | ((@in[18 + inpos] & 4194303) << (26 - 22)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[18 + inpos] >> 22) | ((@in[19 + inpos] & 65535) << (26 - 16)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[19 + inpos] >> 16) | ((@in[20 + inpos] & 1023) << (26 - 10)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[20 + inpos] >> 10) | ((@in[21 + inpos] & 15) << (26 - 4)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[21 + inpos] >> 4) & 67108863))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[21 + inpos] >> 30) | ((@in[22 + inpos] & 16777215) << (26 - 24)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[22 + inpos] >> 24) | ((@in[23 + inpos] & 262143) << (26 - 18)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[23 + inpos] >> 18) | ((@in[24 + inpos] & 4095) << (26 - 12)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[24 + inpos] >> 12) | ((@in[25 + inpos] & 63) << (26 - 6)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[25 + inpos] >> 6))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack27(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 134217727))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 27) | ((@in[1 + inpos] & 4194303) << (27 - 22)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 22) | ((@in[2 + inpos] & 131071) << (27 - 17)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 17) | ((@in[3 + inpos] & 4095) << (27 - 12)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 12) | ((@in[4 + inpos] & 127) << (27 - 7)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[4 + inpos] >> 7) | ((@in[5 + inpos] & 3) << (27 - 2)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[5 + inpos] >> 2) & 134217727))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[5 + inpos] >> 29) | ((@in[6 + inpos] & 16777215) << (27 - 24)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[6 + inpos] >> 24) | ((@in[7 + inpos] & 524287) << (27 - 19)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[7 + inpos] >> 19) | ((@in[8 + inpos] & 16383) << (27 - 14)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[8 + inpos] >> 14) | ((@in[9 + inpos] & 511) << (27 - 9)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[9 + inpos] >> 9) | ((@in[10 + inpos] & 15) << (27 - 4)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[10 + inpos] >> 4) & 134217727))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[10 + inpos] >> 31) | ((@in[11 + inpos] & 67108863) << (27 - 26)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[11 + inpos] >> 26) | ((@in[12 + inpos] & 2097151) << (27 - 21)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[12 + inpos] >> 21) | ((@in[13 + inpos] & 65535) << (27 - 16)))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = ((int)((uint)@in[13 + inpos] >> 16) | ((@in[14 + inpos] & 2047) << (27 - 11)))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[14 + inpos] >> 11) | ((@in[15 + inpos] & 63) << (27 - 6)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[15 + inpos] >> 6) | ((@in[16 + inpos] & 1) << (27 - 1)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[16 + inpos] >> 1) & 134217727))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[16 + inpos] >> 28) | ((@in[17 + inpos] & 8388607) << (27 - 23)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[17 + inpos] >> 23) | ((@in[18 + inpos] & 262143) << (27 - 18)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[18 + inpos] >> 18) | ((@in[19 + inpos] & 8191) << (27 - 13)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[19 + inpos] >> 13) | ((@in[20 + inpos] & 255) << (27 - 8)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[20 + inpos] >> 8) | ((@in[21 + inpos] & 7) << (27 - 3)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[21 + inpos] >> 3) & 134217727))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[21 + inpos] >> 30) | ((@in[22 + inpos] & 33554431) << (27 - 25)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[22 + inpos] >> 25) | ((@in[23 + inpos] & 1048575) << (27 - 20)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[23 + inpos] >> 20) | ((@in[24 + inpos] & 32767) << (27 - 15)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[24 + inpos] >> 15) | ((@in[25 + inpos] & 1023) << (27 - 10)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[25 + inpos] >> 10) | ((@in[26 + inpos] & 31) << (27 - 5)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[26 + inpos] >> 5))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack28(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 268435455))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 28) | ((@in[1 + inpos] & 16777215) << (28 - 24)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 24) | ((@in[2 + inpos] & 1048575) << (28 - 20)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 20) | ((@in[3 + inpos] & 65535) << (28 - 16)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 16) | ((@in[4 + inpos] & 4095) << (28 - 12)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[4 + inpos] >> 12) | ((@in[5 + inpos] & 255) << (28 - 8)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[5 + inpos] >> 8) | ((@in[6 + inpos] & 15) << (28 - 4)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[6 + inpos] >> 4)) + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[7 + inpos] >> 0) & 268435455))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 16777215) << (28 - 24)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[8 + inpos] >> 24) | ((@in[9 + inpos] & 1048575) << (28 - 20)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[9 + inpos] >> 20) | ((@in[10 + inpos] & 65535) << (28 - 16)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[10 + inpos] >> 16) | ((@in[11 + inpos] & 4095) << (28 - 12)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[11 + inpos] >> 12) | ((@in[12 + inpos] & 255) << (28 - 8)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[12 + inpos] >> 8) | ((@in[13 + inpos] & 15) << (28 - 4)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[13 + inpos] >> 4))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[14 + inpos] >> 0) & 268435455))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[14 + inpos] >> 28) | ((@in[15 + inpos] & 16777215) << (28 - 24)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[15 + inpos] >> 24) | ((@in[16 + inpos] & 1048575) << (28 - 20)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[16 + inpos] >> 20) | ((@in[17 + inpos] & 65535) << (28 - 16)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[17 + inpos] >> 16) | ((@in[18 + inpos] & 4095) << (28 - 12)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[18 + inpos] >> 12) | ((@in[19 + inpos] & 255) << (28 - 8)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[19 + inpos] >> 8) | ((@in[20 + inpos] & 15) << (28 - 4)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[20 + inpos] >> 4))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[21 + inpos] >> 0) & 268435455))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[21 + inpos] >> 28) | ((@in[22 + inpos] & 16777215) << (28 - 24)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[22 + inpos] >> 24) | ((@in[23 + inpos] & 1048575) << (28 - 20)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[23 + inpos] >> 20) | ((@in[24 + inpos] & 65535) << (28 - 16)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[24 + inpos] >> 16) | ((@in[25 + inpos] & 4095) << (28 - 12)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[25 + inpos] >> 12) | ((@in[26 + inpos] & 255) << (28 - 8)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[26 + inpos] >> 8) | ((@in[27 + inpos] & 15) << (28 - 4)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[27 + inpos] >> 4))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack29(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 536870911))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 29) | ((@in[1 + inpos] & 67108863) << (29 - 26)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 26) | ((@in[2 + inpos] & 8388607) << (29 - 23)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 23) | ((@in[3 + inpos] & 1048575) << (29 - 20)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 20) | ((@in[4 + inpos] & 131071) << (29 - 17)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[4 + inpos] >> 17) | ((@in[5 + inpos] & 16383) << (29 - 14)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[5 + inpos] >> 14) | ((@in[6 + inpos] & 2047) << (29 - 11)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[6 + inpos] >> 11) | ((@in[7 + inpos] & 255) << (29 - 8)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[7 + inpos] >> 8) | ((@in[8 + inpos] & 31) << (29 - 5)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[8 + inpos] >> 5) | ((@in[9 + inpos] & 3) << (29 - 2)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[9 + inpos] >> 2) & 536870911))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[9 + inpos] >> 31) | ((@in[10 + inpos] & 268435455) << (29 - 28)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[10 + inpos] >> 28) | ((@in[11 + inpos] & 33554431) << (29 - 25)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[11 + inpos] >> 25) | ((@in[12 + inpos] & 4194303) << (29 - 22)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[12 + inpos] >> 22) | ((@in[13 + inpos] & 524287) << (29 - 19)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[13 + inpos] >> 19) | ((@in[14 + inpos] & 65535) << (29 - 16)))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = ((int)((uint)@in[14 + inpos] >> 16) | ((@in[15 + inpos] & 8191) << (29 - 13)))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[15 + inpos] >> 13) | ((@in[16 + inpos] & 1023) << (29 - 10)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[16 + inpos] >> 10) | ((@in[17 + inpos] & 127) << (29 - 7)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[17 + inpos] >> 7) | ((@in[18 + inpos] & 15) << (29 - 4)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[18 + inpos] >> 4) | ((@in[19 + inpos] & 1) << (29 - 1)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[19 + inpos] >> 1) & 536870911))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[19 + inpos] >> 30) | ((@in[20 + inpos] & 134217727) << (29 - 27)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[20 + inpos] >> 27) | ((@in[21 + inpos] & 16777215) << (29 - 24)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[21 + inpos] >> 24) | ((@in[22 + inpos] & 2097151) << (29 - 21)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[22 + inpos] >> 21) | ((@in[23 + inpos] & 262143) << (29 - 18)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[23 + inpos] >> 18) | ((@in[24 + inpos] & 32767) << (29 - 15)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[24 + inpos] >> 15) | ((@in[25 + inpos] & 4095) << (29 - 12)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[25 + inpos] >> 12) | ((@in[26 + inpos] & 511) << (29 - 9)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[26 + inpos] >> 9) | ((@in[27 + inpos] & 63) << (29 - 6)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[27 + inpos] >> 6) | ((@in[28 + inpos] & 7) << (29 - 3)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[28 + inpos] >> 3))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack3(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 7)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 3) & 7))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 6) & 7))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 9) & 7))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 7))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[0 + inpos] >> 15) & 7))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[0 + inpos] >> 18) & 7))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[0 + inpos] >> 21) & 7))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[0 + inpos] >> 24) & 7))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[0 + inpos] >> 27) & 7))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 1) << (3 - 1)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[1 + inpos] >> 1) & 7))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 7))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[1 + inpos] >> 7) & 7))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 7))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = (((int)((uint)@in[1 + inpos] >> 13) & 7))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 7))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[1 + inpos] >> 19) & 7))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[1 + inpos] >> 22) & 7))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[1 + inpos] >> 25) & 7))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[1 + inpos] >> 28) & 7))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[1 + inpos] >> 31) | ((@in[2 + inpos] & 3) << (3 - 2)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[2 + inpos] >> 2) & 7))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[2 + inpos] >> 5) & 7))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 7))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[2 + inpos] >> 11) & 7))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[2 + inpos] >> 14) & 7))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[2 + inpos] >> 17) & 7))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[2 + inpos] >> 20) & 7))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[2 + inpos] >> 23) & 7))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[2 + inpos] >> 26) & 7))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[2 + inpos] >> 29))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack30(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 1073741823))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 268435455) << (30 - 28)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 67108863) << (30 - 26)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 26) | ((@in[3 + inpos] & 16777215) << (30 - 24)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 24) | ((@in[4 + inpos] & 4194303) << (30 - 22)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[4 + inpos] >> 22) | ((@in[5 + inpos] & 1048575) << (30 - 20)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[5 + inpos] >> 20) | ((@in[6 + inpos] & 262143) << (30 - 18)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[6 + inpos] >> 18) | ((@in[7 + inpos] & 65535) << (30 - 16)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[7 + inpos] >> 16) | ((@in[8 + inpos] & 16383) << (30 - 14)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[8 + inpos] >> 14) | ((@in[9 + inpos] & 4095) << (30 - 12)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[9 + inpos] >> 12) | ((@in[10 + inpos] & 1023) << (30 - 10)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[10 + inpos] >> 10) | ((@in[11 + inpos] & 255) << (30 - 8)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[11 + inpos] >> 8) | ((@in[12 + inpos] & 63) << (30 - 6)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[12 + inpos] >> 6) | ((@in[13 + inpos] & 15) << (30 - 4)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[13 + inpos] >> 4) | ((@in[14 + inpos] & 3) << (30 - 2)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[14 + inpos] >> 2))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[15 + inpos] >> 0) & 1073741823))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[15 + inpos] >> 30) | ((@in[16 + inpos] & 268435455) << (30 - 28)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[16 + inpos] >> 28) | ((@in[17 + inpos] & 67108863) << (30 - 26)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[17 + inpos] >> 26) | ((@in[18 + inpos] & 16777215) << (30 - 24)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[18 + inpos] >> 24) | ((@in[19 + inpos] & 4194303) << (30 - 22)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[19 + inpos] >> 22) | ((@in[20 + inpos] & 1048575) << (30 - 20)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[20 + inpos] >> 20) | ((@in[21 + inpos] & 262143) << (30 - 18)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[21 + inpos] >> 18) | ((@in[22 + inpos] & 65535) << (30 - 16)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[22 + inpos] >> 16) | ((@in[23 + inpos] & 16383) << (30 - 14)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[23 + inpos] >> 14) | ((@in[24 + inpos] & 4095) << (30 - 12)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[24 + inpos] >> 12) | ((@in[25 + inpos] & 1023) << (30 - 10)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[25 + inpos] >> 10) | ((@in[26 + inpos] & 255) << (30 - 8)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[26 + inpos] >> 8) | ((@in[27 + inpos] & 63) << (30 - 6)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[27 + inpos] >> 6) | ((@in[28 + inpos] & 15) << (30 - 4)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[28 + inpos] >> 4) | ((@in[29 + inpos] & 3) << (30 - 2)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[29 + inpos] >> 2))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack31(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 2147483647))
+                           + initoffset;
+        @out[1 + outpos] = ((int)((uint)@in[0 + inpos] >> 31) | ((@in[1 + inpos] & 1073741823) << (31 - 30)))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = ((int)((uint)@in[1 + inpos] >> 30) | ((@in[2 + inpos] & 536870911) << (31 - 29)))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[2 + inpos] >> 29) | ((@in[3 + inpos] & 268435455) << (31 - 28)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[3 + inpos] >> 28) | ((@in[4 + inpos] & 134217727) << (31 - 27)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[4 + inpos] >> 27) | ((@in[5 + inpos] & 67108863) << (31 - 26)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[5 + inpos] >> 26) | ((@in[6 + inpos] & 33554431) << (31 - 25)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[6 + inpos] >> 25) | ((@in[7 + inpos] & 16777215) << (31 - 24)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = ((int)((uint)@in[7 + inpos] >> 24) | ((@in[8 + inpos] & 8388607) << (31 - 23)))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[8 + inpos] >> 23) | ((@in[9 + inpos] & 4194303) << (31 - 22)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[9 + inpos] >> 22) | ((@in[10 + inpos] & 2097151) << (31 - 21)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[10 + inpos] >> 21) | ((@in[11 + inpos] & 1048575) << (31 - 20)))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[11 + inpos] >> 20) | ((@in[12 + inpos] & 524287) << (31 - 19)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[12 + inpos] >> 19) | ((@in[13 + inpos] & 262143) << (31 - 18)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[13 + inpos] >> 18) | ((@in[14 + inpos] & 131071) << (31 - 17)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[14 + inpos] >> 17) | ((@in[15 + inpos] & 65535) << (31 - 16)))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = ((int)((uint)@in[15 + inpos] >> 16) | ((@in[16 + inpos] & 32767) << (31 - 15)))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[16 + inpos] >> 15) | ((@in[17 + inpos] & 16383) << (31 - 14)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[17 + inpos] >> 14) | ((@in[18 + inpos] & 8191) << (31 - 13)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[18 + inpos] >> 13) | ((@in[19 + inpos] & 4095) << (31 - 12)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = ((int)((uint)@in[19 + inpos] >> 12) | ((@in[20 + inpos] & 2047) << (31 - 11)))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[20 + inpos] >> 11) | ((@in[21 + inpos] & 1023) << (31 - 10)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[21 + inpos] >> 10) | ((@in[22 + inpos] & 511) << (31 - 9)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[22 + inpos] >> 9) | ((@in[23 + inpos] & 255) << (31 - 8)))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[23 + inpos] >> 8) | ((@in[24 + inpos] & 127) << (31 - 7)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[24 + inpos] >> 7) | ((@in[25 + inpos] & 63) << (31 - 6)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[25 + inpos] >> 6) | ((@in[26 + inpos] & 31) << (31 - 5)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[26 + inpos] >> 5) | ((@in[27 + inpos] & 15) << (31 - 4)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[27 + inpos] >> 4) | ((@in[28 + inpos] & 7) << (31 - 3)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = ((int)((uint)@in[28 + inpos] >> 3) | ((@in[29 + inpos] & 3) << (31 - 2)))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = ((int)((uint)@in[29 + inpos] >> 2) | ((@in[30 + inpos] & 1) << (31 - 1)))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[30 + inpos] >> 1))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack32(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        Array.Copy(@in, inpos, @out, outpos, 32);  // no sense in
+                                                   // doing delta
+                                                   // coding
+    }
+
+    protected static void integratedunpack4(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 15)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 4) & 15))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 8) & 15))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 15))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 16) & 15))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[0 + inpos] >> 20) & 15))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[0 + inpos] >> 24) & 15))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[0 + inpos] >> 28))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[1 + inpos] >> 0) & 15))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 15))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 15))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[1 + inpos] >> 12) & 15))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 15))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[1 + inpos] >> 20) & 15))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[1 + inpos] >> 24) & 15))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[1 + inpos] >> 28))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[2 + inpos] >> 0) & 15))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[2 + inpos] >> 4) & 15))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 15))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[2 + inpos] >> 12) & 15))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[2 + inpos] >> 16) & 15))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[2 + inpos] >> 20) & 15))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[2 + inpos] >> 24) & 15))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[2 + inpos] >> 28))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 15))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[3 + inpos] >> 4) & 15))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[3 + inpos] >> 8) & 15))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[3 + inpos] >> 12) & 15))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[3 + inpos] >> 16) & 15))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[3 + inpos] >> 20) & 15))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[3 + inpos] >> 24) & 15))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[3 + inpos] >> 28))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack5(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 31)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 5) & 31))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 10) & 31))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 15) & 31))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 20) & 31))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[0 + inpos] >> 25) & 31))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 7) << (5 - 3)))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[1 + inpos] >> 3) & 31))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 31))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[1 + inpos] >> 13) & 31))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[1 + inpos] >> 18) & 31))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[1 + inpos] >> 23) & 31))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 1) << (5 - 1)))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[2 + inpos] >> 1) & 31))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[2 + inpos] >> 6) & 31))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = (((int)((uint)@in[2 + inpos] >> 11) & 31))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[2 + inpos] >> 16) & 31))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[2 + inpos] >> 21) & 31))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[2 + inpos] >> 26) & 31))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[2 + inpos] >> 31) | ((@in[3 + inpos] & 15) << (5 - 4)))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[3 + inpos] >> 4) & 31))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[3 + inpos] >> 9) & 31))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[3 + inpos] >> 14) & 31))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[3 + inpos] >> 19) & 31))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[3 + inpos] >> 24) & 31))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = ((int)((uint)@in[3 + inpos] >> 29) | ((@in[4 + inpos] & 3) << (5 - 2)))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[4 + inpos] >> 2) & 31))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[4 + inpos] >> 7) & 31))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[4 + inpos] >> 12) & 31))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[4 + inpos] >> 17) & 31))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[4 + inpos] >> 22) & 31))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[4 + inpos] >> 27))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack6(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 63)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 6) & 63))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 12) & 63))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 18) & 63))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[0 + inpos] >> 24) & 63))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = ((int)((uint)@in[0 + inpos] >> 30) | ((@in[1 + inpos] & 15) << (6 - 4)))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 63))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 63))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 63))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[1 + inpos] >> 22) & 63))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[1 + inpos] >> 28) | ((@in[2 + inpos] & 3) << (6 - 2)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[2 + inpos] >> 2) & 63))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 63))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[2 + inpos] >> 14) & 63))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[2 + inpos] >> 20) & 63))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[2 + inpos] >> 26))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 63))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[3 + inpos] >> 6) & 63))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[3 + inpos] >> 12) & 63))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[3 + inpos] >> 18) & 63))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[3 + inpos] >> 24) & 63))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 15) << (6 - 4)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[4 + inpos] >> 4) & 63))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[4 + inpos] >> 10) & 63))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[4 + inpos] >> 16) & 63))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[4 + inpos] >> 22) & 63))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = ((int)((uint)@in[4 + inpos] >> 28) | ((@in[5 + inpos] & 3) << (6 - 2)))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[5 + inpos] >> 2) & 63))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 63))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[5 + inpos] >> 14) & 63))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[5 + inpos] >> 20) & 63))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[5 + inpos] >> 26))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack7(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 127)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 7) & 127))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 14) & 127))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = (((int)((uint)@in[0 + inpos] >> 21) & 127))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = ((int)((uint)@in[0 + inpos] >> 28) | ((@in[1 + inpos] & 7) << (7 - 3)))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[1 + inpos] >> 3) & 127))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[1 + inpos] >> 10) & 127))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = (((int)((uint)@in[1 + inpos] >> 17) & 127))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[1 + inpos] >> 24) & 127))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = ((int)((uint)@in[1 + inpos] >> 31) | ((@in[2 + inpos] & 63) << (7 - 6)))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[2 + inpos] >> 6) & 127))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[2 + inpos] >> 13) & 127))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[2 + inpos] >> 20) & 127))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = ((int)((uint)@in[2 + inpos] >> 27) | ((@in[3 + inpos] & 3) << (7 - 2)))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[3 + inpos] >> 2) & 127))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = (((int)((uint)@in[3 + inpos] >> 9) & 127))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[3 + inpos] >> 16) & 127))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[3 + inpos] >> 23) & 127))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 31) << (7 - 5)))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[4 + inpos] >> 5) & 127))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[4 + inpos] >> 12) & 127))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[4 + inpos] >> 19) & 127))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = ((int)((uint)@in[4 + inpos] >> 26) | ((@in[5 + inpos] & 1) << (7 - 1)))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[5 + inpos] >> 1) & 127))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 127))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[5 + inpos] >> 15) & 127))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[5 + inpos] >> 22) & 127))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[5 + inpos] >> 29) | ((@in[6 + inpos] & 15) << (7 - 4)))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[6 + inpos] >> 4) & 127))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[6 + inpos] >> 11) & 127))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[6 + inpos] >> 18) & 127))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[6 + inpos] >> 25))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack8(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 255)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 8) & 255))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 16) & 255))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[0 + inpos] >> 24))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[1 + inpos] >> 0) & 255))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[1 + inpos] >> 8) & 255))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[1 + inpos] >> 16) & 255))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[1 + inpos] >> 24))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[2 + inpos] >> 0) & 255))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 255))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = (((int)((uint)@in[2 + inpos] >> 16) & 255))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = ((int)((uint)@in[2 + inpos] >> 24))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[3 + inpos] >> 0) & 255))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[3 + inpos] >> 8) & 255))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = (((int)((uint)@in[3 + inpos] >> 16) & 255))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = ((int)((uint)@in[3 + inpos] >> 24))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[4 + inpos] >> 0) & 255))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = (((int)((uint)@in[4 + inpos] >> 8) & 255))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[4 + inpos] >> 16) & 255))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = ((int)((uint)@in[4 + inpos] >> 24))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[5 + inpos] >> 0) & 255))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = (((int)((uint)@in[5 + inpos] >> 8) & 255))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[5 + inpos] >> 16) & 255))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = ((int)((uint)@in[5 + inpos] >> 24))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = (((int)((uint)@in[6 + inpos] >> 0) & 255))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[6 + inpos] >> 8) & 255))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[6 + inpos] >> 16) & 255))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = ((int)((uint)@in[6 + inpos] >> 24))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = (((int)((uint)@in[7 + inpos] >> 0) & 255))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[7 + inpos] >> 8) & 255))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[7 + inpos] >> 16) & 255))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[7 + inpos] >> 24))
+                            + @out[31 + outpos - 1];
+    }
+
+    protected static void integratedunpack9(int initoffset, int[] @in, int inpos, int[] @out, int outpos)
+    {
+        @out[0 + outpos] = (((int)((uint)@in[0 + inpos] >> 0) & 511)) + initoffset;
+        @out[1 + outpos] = (((int)((uint)@in[0 + inpos] >> 9) & 511))
+                           + @out[1 + outpos - 1];
+        @out[2 + outpos] = (((int)((uint)@in[0 + inpos] >> 18) & 511))
+                           + @out[2 + outpos - 1];
+        @out[3 + outpos] = ((int)((uint)@in[0 + inpos] >> 27) | ((@in[1 + inpos] & 15) << (9 - 4)))
+                           + @out[3 + outpos - 1];
+        @out[4 + outpos] = (((int)((uint)@in[1 + inpos] >> 4) & 511))
+                           + @out[4 + outpos - 1];
+        @out[5 + outpos] = (((int)((uint)@in[1 + inpos] >> 13) & 511))
+                           + @out[5 + outpos - 1];
+        @out[6 + outpos] = (((int)((uint)@in[1 + inpos] >> 22) & 511))
+                           + @out[6 + outpos - 1];
+        @out[7 + outpos] = ((int)((uint)@in[1 + inpos] >> 31) | ((@in[2 + inpos] & 255) << (9 - 8)))
+                           + @out[7 + outpos - 1];
+        @out[8 + outpos] = (((int)((uint)@in[2 + inpos] >> 8) & 511))
+                           + @out[8 + outpos - 1];
+        @out[9 + outpos] = (((int)((uint)@in[2 + inpos] >> 17) & 511))
+                           + @out[9 + outpos - 1];
+        @out[10 + outpos] = ((int)((uint)@in[2 + inpos] >> 26) | ((@in[3 + inpos] & 7) << (9 - 3)))
+                            + @out[10 + outpos - 1];
+        @out[11 + outpos] = (((int)((uint)@in[3 + inpos] >> 3) & 511))
+                            + @out[11 + outpos - 1];
+        @out[12 + outpos] = (((int)((uint)@in[3 + inpos] >> 12) & 511))
+                            + @out[12 + outpos - 1];
+        @out[13 + outpos] = (((int)((uint)@in[3 + inpos] >> 21) & 511))
+                            + @out[13 + outpos - 1];
+        @out[14 + outpos] = ((int)((uint)@in[3 + inpos] >> 30) | ((@in[4 + inpos] & 127) << (9 - 7)))
+                            + @out[14 + outpos - 1];
+        @out[15 + outpos] = (((int)((uint)@in[4 + inpos] >> 7) & 511))
+                            + @out[15 + outpos - 1];
+        @out[16 + outpos] = (((int)((uint)@in[4 + inpos] >> 16) & 511))
+                            + @out[16 + outpos - 1];
+        @out[17 + outpos] = ((int)((uint)@in[4 + inpos] >> 25) | ((@in[5 + inpos] & 3) << (9 - 2)))
+                            + @out[17 + outpos - 1];
+        @out[18 + outpos] = (((int)((uint)@in[5 + inpos] >> 2) & 511))
+                            + @out[18 + outpos - 1];
+        @out[19 + outpos] = (((int)((uint)@in[5 + inpos] >> 11) & 511))
+                            + @out[19 + outpos - 1];
+        @out[20 + outpos] = (((int)((uint)@in[5 + inpos] >> 20) & 511))
+                            + @out[20 + outpos - 1];
+        @out[21 + outpos] = ((int)((uint)@in[5 + inpos] >> 29) | ((@in[6 + inpos] & 63) << (9 - 6)))
+                            + @out[21 + outpos - 1];
+        @out[22 + outpos] = (((int)((uint)@in[6 + inpos] >> 6) & 511))
+                            + @out[22 + outpos - 1];
+        @out[23 + outpos] = (((int)((uint)@in[6 + inpos] >> 15) & 511))
+                            + @out[23 + outpos - 1];
+        @out[24 + outpos] = ((int)((uint)@in[6 + inpos] >> 24) | ((@in[7 + inpos] & 1) << (9 - 1)))
+                            + @out[24 + outpos - 1];
+        @out[25 + outpos] = (((int)((uint)@in[7 + inpos] >> 1) & 511))
+                            + @out[25 + outpos - 1];
+        @out[26 + outpos] = (((int)((uint)@in[7 + inpos] >> 10) & 511))
+                            + @out[26 + outpos - 1];
+        @out[27 + outpos] = (((int)((uint)@in[7 + inpos] >> 19) & 511))
+                            + @out[27 + outpos - 1];
+        @out[28 + outpos] = ((int)((uint)@in[7 + inpos] >> 28) | ((@in[8 + inpos] & 31) << (9 - 5)))
+                            + @out[28 + outpos - 1];
+        @out[29 + outpos] = (((int)((uint)@in[8 + inpos] >> 5) & 511))
+                            + @out[29 + outpos - 1];
+        @out[30 + outpos] = (((int)((uint)@in[8 + inpos] >> 14) & 511))
+                            + @out[30 + outpos - 1];
+        @out[31 + outpos] = ((int)((uint)@in[8 + inpos] >> 23))
+                            + @out[31 + outpos - 1];
     }
 }

--- a/src/CSharpFastPFOR/Differential/IntegratedByteIntegerCODEC.cs
+++ b/src/CSharpFastPFOR/Differential/IntegratedByteIntegerCODEC.cs
@@ -13,9 +13,8 @@
  * @author Daniel Lemire
  * 
  */
-namespace Genbox.CSharpFastPFOR.Differential
+namespace Genbox.CSharpFastPFOR.Differential;
+
+public interface IntegratedByteIntegerCODEC : ByteIntegerCODEC
 {
-    public interface IntegratedByteIntegerCODEC : ByteIntegerCODEC
-    {
-    }
 }

--- a/src/CSharpFastPFOR/Differential/IntegratedComposition.cs
+++ b/src/CSharpFastPFOR/Differential/IntegratedComposition.cs
@@ -11,64 +11,63 @@
  * @author Daniel Lemire
  */
 
-namespace Genbox.CSharpFastPFOR.Differential
+namespace Genbox.CSharpFastPFOR.Differential;
+
+public class IntegratedComposition : IntegratedIntegerCODEC
 {
-    public class IntegratedComposition : IntegratedIntegerCODEC
+    private IntegratedIntegerCODEC F1;
+    private IntegratedIntegerCODEC F2;
+
+    /**
+     * Compose a scheme from a first one (f1) and a second one (f2). The
+     * first one is called first and then the second one tries to compress
+     * whatever remains from the first run.
+     * 
+     * By convention, the first scheme should be such that if, during
+     * decoding, a 32-bit zero is first encountered, then there is no
+     * output.
+     * 
+     * @param f1
+     *                first codec
+     * @param f2
+     *                second codec
+     */
+    public IntegratedComposition(IntegratedIntegerCODEC f1, IntegratedIntegerCODEC f2)
     {
-        private IntegratedIntegerCODEC F1;
-        private IntegratedIntegerCODEC F2;
+        F1 = f1;
+        F2 = f2;
+    }
 
-        /**
-         * Compose a scheme from a first one (f1) and a second one (f2). The
-         * first one is called first and then the second one tries to compress
-         * whatever remains from the first run.
-         * 
-         * By convention, the first scheme should be such that if, during
-         * decoding, a 32-bit zero is first encountered, then there is no
-         * output.
-         * 
-         * @param f1
-         *                first codec
-         * @param f2
-         *                second codec
-         */
-        public IntegratedComposition(IntegratedIntegerCODEC f1, IntegratedIntegerCODEC f2)
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
         {
-            F1 = f1;
-            F2 = f2;
+            return;
         }
+        int inposInit = inpos.get();
+        int outposInit = outpos.get();
+        F1.compress(@in, inpos, inlength, @out, outpos);
+        if (outpos.get() == outposInit)
+        {
+            @out[outposInit] = 0;
+            outpos.increment();
+        }
+        inlength -= inpos.get() - inposInit;
+        F2.compress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-            {
-                return;
-            }
-            int inposInit = inpos.get();
-            int outposInit = outpos.get();
-            F1.compress(@in, inpos, inlength, @out, outpos);
-            if (outpos.get() == outposInit)
-            {
-                @out[outposInit] = 0;
-                outpos.increment();
-            }
-            inlength -= inpos.get() - inposInit;
-            F2.compress(@in, inpos, inlength, @out, outpos);
-        }
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int init = inpos.get();
+        F1.uncompress(@in, inpos, inlength, @out, outpos);
+        inlength -= inpos.get() - init;
+        F2.uncompress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            int init = inpos.get();
-            F1.uncompress(@in, inpos, inlength, @out, outpos);
-            inlength -= inpos.get() - init;
-            F2.uncompress(@in, inpos, inlength, @out, outpos);
-        }
-
-        public override string ToString()
-        {
-            return F1 + " + " + F2;
-        }
+    public override string ToString()
+    {
+        return F1 + " + " + F2;
     }
 }

--- a/src/CSharpFastPFOR/Differential/IntegratedComposition.cs
+++ b/src/CSharpFastPFOR/Differential/IntegratedComposition.cs
@@ -13,7 +13,7 @@
 
 namespace Genbox.CSharpFastPFOR.Differential;
 
-public class IntegratedComposition : IntegratedIntegerCODEC
+public sealed class IntegratedComposition : IntegratedIntegerCODEC
 {
     private readonly IntegratedIntegerCODEC F1;
     private readonly IntegratedIntegerCODEC F2;

--- a/src/CSharpFastPFOR/Differential/IntegratedComposition.cs
+++ b/src/CSharpFastPFOR/Differential/IntegratedComposition.cs
@@ -15,8 +15,8 @@ namespace Genbox.CSharpFastPFOR.Differential;
 
 public class IntegratedComposition : IntegratedIntegerCODEC
 {
-    private IntegratedIntegerCODEC F1;
-    private IntegratedIntegerCODEC F2;
+    private readonly IntegratedIntegerCODEC F1;
+    private readonly IntegratedIntegerCODEC F2;
 
     /**
      * Compose a scheme from a first one (f1) and a second one (f2). The

--- a/src/CSharpFastPFOR/Differential/IntegratedIntCompressor.cs
+++ b/src/CSharpFastPFOR/Differential/IntegratedIntCompressor.cs
@@ -12,63 +12,62 @@
 
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR.Differential
+namespace Genbox.CSharpFastPFOR.Differential;
+
+public class IntegratedIntCompressor
 {
-    public class IntegratedIntCompressor
+    private SkippableIntegratedIntegerCODEC codec;
+
+    /**
+     * Constructor wrapping a codec.
+     * 
+     * @param c the underlying codec
+     */
+    public IntegratedIntCompressor(SkippableIntegratedIntegerCODEC c)
     {
-        private SkippableIntegratedIntegerCODEC codec;
+        codec = c;
+    }
 
-        /**
-         * Constructor wrapping a codec.
-         * 
-         * @param c the underlying codec
-         */
-        public IntegratedIntCompressor(SkippableIntegratedIntegerCODEC c)
-        {
-            codec = c;
-        }
+    /**
+     * Constructor with default codec.
+     */
+    public IntegratedIntCompressor()
+    {
+        codec = new SkippableIntegratedComposition(new IntegratedBinaryPacking(), new IntegratedVariableByte());
+    }
 
-        /**
-         * Constructor with default codec.
-         */
-        public IntegratedIntCompressor()
-        {
-            codec = new SkippableIntegratedComposition(new IntegratedBinaryPacking(), new IntegratedVariableByte());
-        }
+    /**
+     * Compress an array and returns the compressed result as a new array.
+     * 
+     * @param input array to be compressed
+     * @return compressed array
+     */
+    public int[] compress(int[] input)
+    {
+        int[] compressed = new int[input.Length + 1024];
+        compressed[0] = input.Length;
+        IntWrapper outpos = new IntWrapper(1);
+        IntWrapper initvalue = new IntWrapper(0);
+        codec.headlessCompress(input, new IntWrapper(0),
+            input.Length, compressed, outpos, initvalue);
+        compressed = Arrays.copyOf(compressed, outpos.intValue());
+        return compressed;
+    }
 
-        /**
-         * Compress an array and returns the compressed result as a new array.
-         * 
-         * @param input array to be compressed
-         * @return compressed array
-         */
-        public int[] compress(int[] input)
-        {
-            int[] compressed = new int[input.Length + 1024];
-            compressed[0] = input.Length;
-            IntWrapper outpos = new IntWrapper(1);
-            IntWrapper initvalue = new IntWrapper(0);
-            codec.headlessCompress(input, new IntWrapper(0),
-                input.Length, compressed, outpos, initvalue);
-            compressed = Arrays.copyOf(compressed, outpos.intValue());
-            return compressed;
-        }
-
-        /**
-         * Uncompress an array and returns the uncompressed result as a new array.
-         * 
-         * @param compressed compressed array
-         * @return uncompressed array
-         */
-        public int[] uncompress(int[] compressed)
-        {
-            int[] decompressed = new int[compressed[0]];
-            IntWrapper inpos = new IntWrapper(1);
-            codec.headlessUncompress(compressed, inpos,
-                compressed.Length - inpos.intValue(),
-                decompressed, new IntWrapper(0),
-                decompressed.Length, new IntWrapper(0));
-            return decompressed;
-        }
+    /**
+     * Uncompress an array and returns the uncompressed result as a new array.
+     * 
+     * @param compressed compressed array
+     * @return uncompressed array
+     */
+    public int[] uncompress(int[] compressed)
+    {
+        int[] decompressed = new int[compressed[0]];
+        IntWrapper inpos = new IntWrapper(1);
+        codec.headlessUncompress(compressed, inpos,
+            compressed.Length - inpos.intValue(),
+            decompressed, new IntWrapper(0),
+            decompressed.Length, new IntWrapper(0));
+        return decompressed;
     }
 }

--- a/src/CSharpFastPFOR/Differential/IntegratedIntCompressor.cs
+++ b/src/CSharpFastPFOR/Differential/IntegratedIntCompressor.cs
@@ -46,8 +46,8 @@ public class IntegratedIntCompressor
     {
         int[] compressed = new int[input.Length + 1024];
         compressed[0] = input.Length;
-        IntWrapper outpos = new IntWrapper(1);
-        IntWrapper initvalue = new IntWrapper(0);
+        var outpos = new IntWrapper(1);
+        var initvalue = new IntWrapper(0);
         codec.headlessCompress(input, new IntWrapper(0),
             input.Length, compressed, outpos, initvalue);
         compressed = Arrays.copyOf(compressed, outpos.intValue());
@@ -63,7 +63,7 @@ public class IntegratedIntCompressor
     public int[] uncompress(int[] compressed)
     {
         int[] decompressed = new int[compressed[0]];
-        IntWrapper inpos = new IntWrapper(1);
+        var inpos = new IntWrapper(1);
         codec.headlessUncompress(compressed, inpos,
             compressed.Length - inpos.intValue(),
             decompressed, new IntWrapper(0),

--- a/src/CSharpFastPFOR/Differential/IntegratedIntCompressor.cs
+++ b/src/CSharpFastPFOR/Differential/IntegratedIntCompressor.cs
@@ -16,7 +16,7 @@ namespace Genbox.CSharpFastPFOR.Differential;
 
 public class IntegratedIntCompressor
 {
-    private SkippableIntegratedIntegerCODEC codec;
+    private readonly SkippableIntegratedIntegerCODEC codec;
 
     /**
      * Constructor wrapping a codec.

--- a/src/CSharpFastPFOR/Differential/IntegratedIntegerCODEC.cs
+++ b/src/CSharpFastPFOR/Differential/IntegratedIntegerCODEC.cs
@@ -11,9 +11,8 @@
  * 
  * @author Daniel Lemire
  */
-namespace Genbox.CSharpFastPFOR.Differential
+namespace Genbox.CSharpFastPFOR.Differential;
+
+public interface IntegratedIntegerCODEC : IntegerCODEC
 {
-    public interface IntegratedIntegerCODEC : IntegerCODEC
-    {
-    }
 }

--- a/src/CSharpFastPFOR/Differential/IntegratedVariableByte.cs
+++ b/src/CSharpFastPFOR/Differential/IntegratedVariableByte.cs
@@ -17,280 +17,279 @@
 
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR.Differential
+namespace Genbox.CSharpFastPFOR.Differential;
+
+public sealed class IntegratedVariableByte : IntegratedIntegerCODEC, IntegratedByteIntegerCODEC, SkippableIntegratedIntegerCODEC
 {
-    public class IntegratedVariableByte : IntegratedIntegerCODEC, IntegratedByteIntegerCODEC, SkippableIntegratedIntegerCODEC
+    private static sbyte extract7bits(int i, long val)
     {
-        private static sbyte extract7bits(int i, long val)
+        return (sbyte)((val >> (7 * i)) & ((1 << 7) - 1));
+    }
+
+    private static sbyte extract7bitsmaskless(int i, long val)
+    {
+        return (sbyte)((val >> (7 * i)));
+    }
+
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int initoffset = 0;
+
+        ByteBuffer buf = ByteBuffer.allocateDirect(inlength * 8);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+
+        for (int k = inpos.get(); k < inpos.get() + inlength; ++k)
         {
-            return (sbyte)((val >> (7 * i)) & ((1 << 7) - 1));
-        }
-
-        private static sbyte extract7bitsmaskless(int i, long val)
-        {
-            return (sbyte)((val >> (7 * i)));
-        }
-
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            int initoffset = 0;
-
-            ByteBuffer buf = ByteBuffer.allocateDirect(inlength * 8);
-            buf.order(ByteOrder.LITTLE_ENDIAN);
-
-            for (int k = inpos.get(); k < inpos.get() + inlength; ++k)
+            long val = (@in[k] - initoffset) & 0xFFFFFFFFL; // To be consistent with unsigned integers in C/C++
+            initoffset = @in[k];
+            if (val < (1 << 7))
             {
-                long val = (@in[k] - initoffset) & 0xFFFFFFFFL; // To be consistent with unsigned integers in C/C++
-                initoffset = @in[k];
-                if (val < (1 << 7))
-                {
-                    buf.put((sbyte)(val | (1 << 7)));
-                }
-                else if (val < (1 << 14))
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)(extract7bitsmaskless(1, (val)) | (1 << 7)));
-                }
-                else if (val < (1 << 21))
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)extract7bits(1, val));
-                    buf.put((sbyte)(extract7bitsmaskless(2, (val)) | (1 << 7)));
-                }
-                else if (val < (1 << 28))
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)extract7bits(1, val));
-                    buf.put((sbyte)extract7bits(2, val));
-                    buf.put((sbyte)(extract7bitsmaskless(3, (val)) | (1 << 7)));
-                }
-                else
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)extract7bits(1, val));
-                    buf.put((sbyte)extract7bits(2, val));
-                    buf.put((sbyte)extract7bits(3, val));
-                    buf.put((sbyte)(extract7bitsmaskless(4, (val)) | (1 << 7)));
-                }
+                buf.put((sbyte)(val | (1 << 7)));
             }
-            while (buf.position() % 4 != 0)
-                buf.put((sbyte)0);
-            int length = buf.position();
-            buf.flip();
-            IntBuffer ibuf = buf.asIntBuffer();
-            ibuf.get(@out, outpos.get(), length / 4);
-
-            outpos.add(length / 4);
-            inpos.add(inlength);
-        }
-
-        public void compress(int[] @in, IntWrapper inpos, int inlength, sbyte[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            int initoffset = 0;
-            int outpostmp = outpos.get();
-            for (int k = inpos.get(); k < inpos.get() + inlength; ++k)
+            else if (val < (1 << 14))
             {
-                long val = (@in[k] - initoffset) & 0xFFFFFFFFL;  // To be consistent with unsigned integers in C/C++
-                initoffset = @in[k];
-                if (val < (1 << 7))
-                {
-                    @out[outpostmp++] = (sbyte)(val | (1 << 7));
-                }
-                else if (val < (1 << 14))
-                {
-                    @out[outpostmp++] = (sbyte)extract7bits(0, val);
-                    @out[outpostmp++] = (sbyte)(extract7bitsmaskless(1, (val)) | (1 << 7));
-                }
-                else if (val < (1 << 21))
-                {
-                    @out[outpostmp++] = (sbyte)extract7bits(0, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(1, val);
-                    @out[outpostmp++] = (sbyte)(extract7bitsmaskless(2, (val)) | (1 << 7));
-                }
-                else if (val < (1 << 28))
-                {
-                    @out[outpostmp++] = (sbyte)extract7bits(0, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(1, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(2, val);
-                    @out[outpostmp++] = (sbyte)(extract7bitsmaskless(3, (val)) | (1 << 7));
-                }
-                else
-                {
-                    @out[outpostmp++] = (sbyte)extract7bits(0, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(1, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(2, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(3, val);
-                    @out[outpostmp++] = (sbyte)(extract7bitsmaskless(4, (val)) | (1 << 7));
-                }
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)(extract7bitsmaskless(1, (val)) | (1 << 7)));
             }
-            outpos.set(outpostmp);
-            inpos.add(inlength);
-        }
-
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            int s = 0;
-            int val = 0;
-            int p = inpos.get();
-            int finalp = inpos.get() + inlength;
-            int tmpoutpos = outpos.get();
-            int initoffset = 0;
-            for (int v = 0, shift = 0; p < finalp;)
+            else if (val < (1 << 21))
             {
-                val = @in[p];
-                int c = (sbyte)(int)((uint)val >> s);
-                s += 8;
-                p += s >> 5;
-                s = s & 31;
-                v += ((c & 127) << shift);
-                if ((c & 128) == 128)
-                {
-                    @out[tmpoutpos] = v + initoffset;
-                    initoffset = @out[tmpoutpos];
-                    tmpoutpos++;
-                    v = 0;
-                    shift = 0;
-                }
-                else
-                    shift += 7;
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)extract7bits(1, val));
+                buf.put((sbyte)(extract7bitsmaskless(2, (val)) | (1 << 7)));
             }
-            outpos.set(tmpoutpos);
-            inpos.add(inlength);
-        }
-
-        public void uncompress(sbyte[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            int p = inpos.get();
-            int initoffset = 0;
-            int finalp = inpos.get() + inlength;
-            int tmpoutpos = outpos.get();
-            for (int v = 0; p < finalp; @out[tmpoutpos++] = (initoffset = initoffset + v))
+            else if (val < (1 << 28))
             {
-                v = @in[p] & 0x7F;
-                if (@in[p] < 0)
-                {
-                    p += 1;
-                    continue;
-                }
-                v = ((@in[p + 1] & 0x7F) << 7) | v;
-                if (@in[p + 1] < 0)
-                {
-                    p += 2;
-                    continue;
-                }
-                v = ((@in[p + 2] & 0x7F) << 14) | v;
-                if (@in[p + 2] < 0)
-                {
-                    p += 3;
-                    continue;
-                }
-                v = ((@in[p + 3] & 0x7F) << 21) | v;
-                if (@in[p + 3] < 0)
-                {
-                    p += 4;
-                    continue;
-                }
-                v = ((@in[p + 4] & 0x7F) << 28) | v;
-                p += 5;
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)extract7bits(1, val));
+                buf.put((sbyte)extract7bits(2, val));
+                buf.put((sbyte)(extract7bitsmaskless(3, (val)) | (1 << 7)));
             }
-            outpos.set(tmpoutpos);
-            inpos.add(p);
-        }
-
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, IntWrapper initvalue)
-        {
-            if (inlength == 0)
-                return;
-            int initoffset = initvalue.get();
-            initvalue.set(@in[inpos.get() + inlength - 1]);
-            ByteBuffer buf = ByteBuffer.allocateDirect(inlength * 8);
-            buf.order(ByteOrder.LITTLE_ENDIAN);
-
-            for (int k = inpos.get(); k < inpos.get() + inlength; ++k)
+            else
             {
-                long val = (@in[k] - initoffset) & 0xFFFFFFFFL;  // To be consistent with unsigned integers in C/C++
-                initoffset = @in[k];
-                if (val < (1 << 7))
-                {
-                    buf.put((sbyte)(val | (1 << 7)));
-                }
-                else if (val < (1 << 14))
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)(extract7bitsmaskless(1, (val)) | (1 << 7)));
-                }
-                else if (val < (1 << 21))
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)extract7bits(1, val));
-                    buf.put((sbyte)(extract7bitsmaskless(2, (val)) | (1 << 7)));
-                }
-                else if (val < (1 << 28))
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)extract7bits(1, val));
-                    buf.put((sbyte)extract7bits(2, val));
-                    buf.put((sbyte)(extract7bitsmaskless(3, (val)) | (1 << 7)));
-                }
-                else
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)extract7bits(1, val));
-                    buf.put((sbyte)extract7bits(2, val));
-                    buf.put((sbyte)extract7bits(3, val));
-                    buf.put((sbyte)(extract7bitsmaskless(4, (val)) | (1 << 7)));
-                }
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)extract7bits(1, val));
+                buf.put((sbyte)extract7bits(2, val));
+                buf.put((sbyte)extract7bits(3, val));
+                buf.put((sbyte)(extract7bitsmaskless(4, (val)) | (1 << 7)));
             }
-            while (buf.position() % 4 != 0)
-                buf.put((sbyte)0);
-
-            int length = buf.position();
-            buf.flip();
-            IntBuffer ibuf = buf.asIntBuffer();
-            ibuf.get(@out, outpos.get(), length / 4);
-
-            outpos.add(length / 4);
-            inpos.add(inlength);
         }
+        while (buf.position() % 4 != 0)
+            buf.put((sbyte)0);
+        int length = buf.position();
+        buf.flip();
+        IntBuffer ibuf = buf.asIntBuffer();
+        ibuf.get(@out, outpos.get(), length / 4);
 
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num, IntWrapper initvalue)
+        outpos.add(length / 4);
+        inpos.add(inlength);
+    }
+
+    public void compress(int[] @in, IntWrapper inpos, int inlength, sbyte[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int initoffset = 0;
+        int outpostmp = outpos.get();
+        for (int k = inpos.get(); k < inpos.get() + inlength; ++k)
         {
-            int s = 0;
-            int val = 0;
-            int p = inpos.get();
-            int initoffset = initvalue.get();
-            int tmpoutpos = outpos.get();
-            int finaloutpos = num + tmpoutpos;
-            for (int v = 0, shift = 0; tmpoutpos < finaloutpos;)
+            long val = (@in[k] - initoffset) & 0xFFFFFFFFL;  // To be consistent with unsigned integers in C/C++
+            initoffset = @in[k];
+            if (val < (1 << 7))
             {
-                val = @in[p];
-                int c = (int)((uint)val >> s);
-                s += 8;
-                p += s >> 5;
-                s = s & 31;
-                v += ((c & 127) << shift);
-                if ((c & 128) == 128)
-                {
-                    @out[tmpoutpos++] = (initoffset = initoffset + v);
-                    v = 0;
-                    shift = 0;
-                }
-                else
-                    shift += 7;
+                @out[outpostmp++] = (sbyte)(val | (1 << 7));
             }
-            initvalue.set(@out[tmpoutpos - 1]);
-            outpos.set(tmpoutpos);
-
-            inpos.set(p + (s != 0 ? 1 : 0));
+            else if (val < (1 << 14))
+            {
+                @out[outpostmp++] = (sbyte)extract7bits(0, val);
+                @out[outpostmp++] = (sbyte)(extract7bitsmaskless(1, (val)) | (1 << 7));
+            }
+            else if (val < (1 << 21))
+            {
+                @out[outpostmp++] = (sbyte)extract7bits(0, val);
+                @out[outpostmp++] = (sbyte)extract7bits(1, val);
+                @out[outpostmp++] = (sbyte)(extract7bitsmaskless(2, (val)) | (1 << 7));
+            }
+            else if (val < (1 << 28))
+            {
+                @out[outpostmp++] = (sbyte)extract7bits(0, val);
+                @out[outpostmp++] = (sbyte)extract7bits(1, val);
+                @out[outpostmp++] = (sbyte)extract7bits(2, val);
+                @out[outpostmp++] = (sbyte)(extract7bitsmaskless(3, (val)) | (1 << 7));
+            }
+            else
+            {
+                @out[outpostmp++] = (sbyte)extract7bits(0, val);
+                @out[outpostmp++] = (sbyte)extract7bits(1, val);
+                @out[outpostmp++] = (sbyte)extract7bits(2, val);
+                @out[outpostmp++] = (sbyte)extract7bits(3, val);
+                @out[outpostmp++] = (sbyte)(extract7bitsmaskless(4, (val)) | (1 << 7));
+            }
         }
+        outpos.set(outpostmp);
+        inpos.add(inlength);
+    }
 
-        public override string ToString()
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        int s = 0;
+        int val = 0;
+        int p = inpos.get();
+        int finalp = inpos.get() + inlength;
+        int tmpoutpos = outpos.get();
+        int initoffset = 0;
+        for (int v = 0, shift = 0; p < finalp;)
         {
-            return nameof(IntegratedVariableByte);
+            val = @in[p];
+            int c = (sbyte)(int)((uint)val >> s);
+            s += 8;
+            p += s >> 5;
+            s = s & 31;
+            v += ((c & 127) << shift);
+            if ((c & 128) == 128)
+            {
+                @out[tmpoutpos] = v + initoffset;
+                initoffset = @out[tmpoutpos];
+                tmpoutpos++;
+                v = 0;
+                shift = 0;
+            }
+            else
+                shift += 7;
         }
+        outpos.set(tmpoutpos);
+        inpos.add(inlength);
+    }
+
+    public void uncompress(sbyte[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        int p = inpos.get();
+        int initoffset = 0;
+        int finalp = inpos.get() + inlength;
+        int tmpoutpos = outpos.get();
+        for (int v = 0; p < finalp; @out[tmpoutpos++] = (initoffset = initoffset + v))
+        {
+            v = @in[p] & 0x7F;
+            if (@in[p] < 0)
+            {
+                p += 1;
+                continue;
+            }
+            v = ((@in[p + 1] & 0x7F) << 7) | v;
+            if (@in[p + 1] < 0)
+            {
+                p += 2;
+                continue;
+            }
+            v = ((@in[p + 2] & 0x7F) << 14) | v;
+            if (@in[p + 2] < 0)
+            {
+                p += 3;
+                continue;
+            }
+            v = ((@in[p + 3] & 0x7F) << 21) | v;
+            if (@in[p + 3] < 0)
+            {
+                p += 4;
+                continue;
+            }
+            v = ((@in[p + 4] & 0x7F) << 28) | v;
+            p += 5;
+        }
+        outpos.set(tmpoutpos);
+        inpos.add(p);
+    }
+
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, IntWrapper initvalue)
+    {
+        if (inlength == 0)
+            return;
+        int initoffset = initvalue.get();
+        initvalue.set(@in[inpos.get() + inlength - 1]);
+        ByteBuffer buf = ByteBuffer.allocateDirect(inlength * 8);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+
+        for (int k = inpos.get(); k < inpos.get() + inlength; ++k)
+        {
+            long val = (@in[k] - initoffset) & 0xFFFFFFFFL;  // To be consistent with unsigned integers in C/C++
+            initoffset = @in[k];
+            if (val < (1 << 7))
+            {
+                buf.put((sbyte)(val | (1 << 7)));
+            }
+            else if (val < (1 << 14))
+            {
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)(extract7bitsmaskless(1, (val)) | (1 << 7)));
+            }
+            else if (val < (1 << 21))
+            {
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)extract7bits(1, val));
+                buf.put((sbyte)(extract7bitsmaskless(2, (val)) | (1 << 7)));
+            }
+            else if (val < (1 << 28))
+            {
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)extract7bits(1, val));
+                buf.put((sbyte)extract7bits(2, val));
+                buf.put((sbyte)(extract7bitsmaskless(3, (val)) | (1 << 7)));
+            }
+            else
+            {
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)extract7bits(1, val));
+                buf.put((sbyte)extract7bits(2, val));
+                buf.put((sbyte)extract7bits(3, val));
+                buf.put((sbyte)(extract7bitsmaskless(4, (val)) | (1 << 7)));
+            }
+        }
+        while (buf.position() % 4 != 0)
+            buf.put((sbyte)0);
+
+        int length = buf.position();
+        buf.flip();
+        IntBuffer ibuf = buf.asIntBuffer();
+        ibuf.get(@out, outpos.get(), length / 4);
+
+        outpos.add(length / 4);
+        inpos.add(inlength);
+    }
+
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num, IntWrapper initvalue)
+    {
+        int s = 0;
+        int val = 0;
+        int p = inpos.get();
+        int initoffset = initvalue.get();
+        int tmpoutpos = outpos.get();
+        int finaloutpos = num + tmpoutpos;
+        for (int v = 0, shift = 0; tmpoutpos < finaloutpos;)
+        {
+            val = @in[p];
+            int c = (int)((uint)val >> s);
+            s += 8;
+            p += s >> 5;
+            s = s & 31;
+            v += ((c & 127) << shift);
+            if ((c & 128) == 128)
+            {
+                @out[tmpoutpos++] = (initoffset = initoffset + v);
+                v = 0;
+                shift = 0;
+            }
+            else
+                shift += 7;
+        }
+        initvalue.set(@out[tmpoutpos - 1]);
+        outpos.set(tmpoutpos);
+
+        inpos.set(p + (s != 0 ? 1 : 0));
+    }
+
+    public override string ToString()
+    {
+        return nameof(IntegratedVariableByte);
     }
 }

--- a/src/CSharpFastPFOR/Differential/SkippableIntegratedComposition.cs
+++ b/src/CSharpFastPFOR/Differential/SkippableIntegratedComposition.cs
@@ -14,8 +14,8 @@ namespace Genbox.CSharpFastPFOR.Differential;
 
 public class SkippableIntegratedComposition : SkippableIntegratedIntegerCODEC
 {
-    private SkippableIntegratedIntegerCODEC F1;
-    private SkippableIntegratedIntegerCODEC F2;
+    private readonly SkippableIntegratedIntegerCODEC F1;
+    private readonly SkippableIntegratedIntegerCODEC F2;
 
     /**
      * Compose a scheme from a first one (f1) and a second one (f2). The first

--- a/src/CSharpFastPFOR/Differential/SkippableIntegratedComposition.cs
+++ b/src/CSharpFastPFOR/Differential/SkippableIntegratedComposition.cs
@@ -10,61 +10,60 @@
  * 
  * @author Daniel Lemire
  */
-namespace Genbox.CSharpFastPFOR.Differential
+namespace Genbox.CSharpFastPFOR.Differential;
+
+public class SkippableIntegratedComposition : SkippableIntegratedIntegerCODEC
 {
-    public class SkippableIntegratedComposition : SkippableIntegratedIntegerCODEC
+    private SkippableIntegratedIntegerCODEC F1;
+    private SkippableIntegratedIntegerCODEC F2;
+
+    /**
+     * Compose a scheme from a first one (f1) and a second one (f2). The first
+     * one is called first and then the second one tries to compress whatever
+     * remains from the first run.
+     * 
+     * By convention, the first scheme should be such that if, during decoding,
+     * a 32-bit zero is first encountered, then there is no output.
+     * 
+     * @param f1
+     *            first codec
+     * @param f2
+     *            second codec
+     */
+    public SkippableIntegratedComposition(SkippableIntegratedIntegerCODEC f1, SkippableIntegratedIntegerCODEC f2)
     {
-        private SkippableIntegratedIntegerCODEC F1;
-        private SkippableIntegratedIntegerCODEC F2;
+        F1 = f1;
+        F2 = f2;
+    }
 
-        /**
-         * Compose a scheme from a first one (f1) and a second one (f2). The first
-         * one is called first and then the second one tries to compress whatever
-         * remains from the first run.
-         * 
-         * By convention, the first scheme should be such that if, during decoding,
-         * a 32-bit zero is first encountered, then there is no output.
-         * 
-         * @param f1
-         *            first codec
-         * @param f2
-         *            second codec
-         */
-        public SkippableIntegratedComposition(SkippableIntegratedIntegerCODEC f1, SkippableIntegratedIntegerCODEC f2)
-        {
-            F1 = f1;
-            F2 = f2;
-        }
+    public override string ToString()
+    {
+        return F1 + " + " + F2;
+    }
 
-        public override string ToString()
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, IntWrapper initvalue)
+    {
+        if (inlength == 0)
+            return;
+        int init = inpos.get();
+        F1.headlessCompress(@in, inpos, inlength, @out, outpos, initvalue);
+        if (outpos.get() == 0)
         {
-            return F1 + " + " + F2;
+            @out[0] = 0;
+            outpos.increment();
         }
+        inlength -= inpos.get() - init;
+        F2.headlessCompress(@in, inpos, inlength, @out, outpos, initvalue);
+    }
 
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, IntWrapper initvalue)
-        {
-            if (inlength == 0)
-                return;
-            int init = inpos.get();
-            F1.headlessCompress(@in, inpos, inlength, @out, outpos, initvalue);
-            if (outpos.get() == 0)
-            {
-                @out[0] = 0;
-                outpos.increment();
-            }
-            inlength -= inpos.get() - init;
-            F2.headlessCompress(@in, inpos, inlength, @out, outpos, initvalue);
-        }
-
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num, IntWrapper initvalue)
-        {
-            if (inlength == 0)
-                return;
-            int init = inpos.get();
-            F1.headlessUncompress(@in, inpos, inlength, @out, outpos, num, initvalue);
-            inlength -= inpos.get() - init;
-            num -= outpos.get();
-            F2.headlessUncompress(@in, inpos, inlength, @out, outpos, num, initvalue);
-        }
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num, IntWrapper initvalue)
+    {
+        if (inlength == 0)
+            return;
+        int init = inpos.get();
+        F1.headlessUncompress(@in, inpos, inlength, @out, outpos, num, initvalue);
+        inlength -= inpos.get() - init;
+        num -= outpos.get();
+        F2.headlessUncompress(@in, inpos, inlength, @out, outpos, num, initvalue);
     }
 }

--- a/src/CSharpFastPFOR/Differential/SkippableIntegratedIntegerCODEC.cs
+++ b/src/CSharpFastPFOR/Differential/SkippableIntegratedIntegerCODEC.cs
@@ -19,52 +19,51 @@
  * @author Daniel Lemire
  * 
  */
-namespace Genbox.CSharpFastPFOR.Differential
-{
-    public interface SkippableIntegratedIntegerCODEC
-    {
-        /**
-         * Compress data from an array to another array.
-         * 
-         * Both inpos and outpos are modified to represent how much data was read
-         * and written to if 12 ints (inlength = 12) are compressed to 3 ints, then
-         * inpos will be incremented by 12 while outpos will be incremented by 3 we
-         * use IntWrapper to pass the values by reference.
-         * 
-         * @param in
-         *            input array
-         * @param inpos
-         *            location in the input array
-         * @param inlength
-         *            how many integers to compress
-         * @param out
-         *            output array
-         * @param outpos
-         *            where to write in the output array
-         * @param initvalue initial value for the purpose of differential coding, the value is automatically updated 
-         */
-        void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, IntWrapper initvalue);
+namespace Genbox.CSharpFastPFOR.Differential;
 
-        /**
-         * Uncompress data from an array to another array.
-         * 
-         * Both inpos and outpos parameters are modified to indicate new positions
-         * after read/write.
-         * 
-         * @param in
-         *            array containing data in compressed form
-         * @param inpos
-         *            where to start reading in the array
-         * @param inlength
-         *            length of the compressed data (ignored by some schemes)
-         * @param out
-         *            array where to write the compressed output
-         * @param outpos
-         *            where to write the compressed output in out
-         * @param num
-         *            number of integers we want to decode, the actual number of integers decoded can be less
-         * @param initvalue initial value for the purpose of differential coding, the value is automatically updated 
-         */
-        void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num, IntWrapper initvalue);
-    }
+public interface SkippableIntegratedIntegerCODEC
+{
+    /**
+     * Compress data from an array to another array.
+     * 
+     * Both inpos and outpos are modified to represent how much data was read
+     * and written to if 12 ints (inlength = 12) are compressed to 3 ints, then
+     * inpos will be incremented by 12 while outpos will be incremented by 3 we
+     * use IntWrapper to pass the values by reference.
+     * 
+     * @param in
+     *            input array
+     * @param inpos
+     *            location in the input array
+     * @param inlength
+     *            how many integers to compress
+     * @param out
+     *            output array
+     * @param outpos
+     *            where to write in the output array
+     * @param initvalue initial value for the purpose of differential coding, the value is automatically updated 
+     */
+    void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, IntWrapper initvalue);
+
+    /**
+     * Uncompress data from an array to another array.
+     * 
+     * Both inpos and outpos parameters are modified to indicate new positions
+     * after read/write.
+     * 
+     * @param in
+     *            array containing data in compressed form
+     * @param inpos
+     *            where to start reading in the array
+     * @param inlength
+     *            length of the compressed data (ignored by some schemes)
+     * @param out
+     *            array where to write the compressed output
+     * @param outpos
+     *            where to write the compressed output in out
+     * @param num
+     *            number of integers we want to decode, the actual number of integers decoded can be less
+     * @param initvalue initial value for the purpose of differential coding, the value is automatically updated 
+     */
+    void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num, IntWrapper initvalue);
 }

--- a/src/CSharpFastPFOR/Differential/XorBinaryPacking.cs
+++ b/src/CSharpFastPFOR/Differential/XorBinaryPacking.cs
@@ -14,128 +14,127 @@
 
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR.Differential
+namespace Genbox.CSharpFastPFOR.Differential;
+
+public class XorBinaryPacking : IntegratedIntegerCODEC
 {
-    public class XorBinaryPacking : IntegratedIntegerCODEC
+    private const int BLOCK_LENGTH = 128;
+
+    public void compress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
     {
-        private const int BLOCK_LENGTH = 128;
+        inLen = inLen - inLen % BLOCK_LENGTH;
+        if (inLen == 0)
+            return;
 
-        public void compress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
+        outBuf[outPos.get()] = inLen;
+        outPos.increment();
+
+        int context = 0;
+        int[] work = new int[32];
+
+        int op = outPos.get();
+        int ip = inPos.get();
+        int inPosLast = ip + inLen;
+        for (; ip < inPosLast; ip += BLOCK_LENGTH)
         {
-            inLen = inLen - inLen % BLOCK_LENGTH;
-            if (inLen == 0)
-                return;
-
-            outBuf[outPos.get()] = inLen;
-            outPos.increment();
-
-            int context = 0;
-            int[] work = new int[32];
-
-            int op = outPos.get();
-            int ip = inPos.get();
-            int inPosLast = ip + inLen;
-            for (; ip < inPosLast; ip += BLOCK_LENGTH)
-            {
-                int bits1 = xorMaxBits(inBuf, ip + 0, 32, context);
-                int bits2 = xorMaxBits(inBuf, ip + 32, 32,
-                    inBuf[ip + 31]);
-                int bits3 = xorMaxBits(inBuf, ip + 64, 32,
-                    inBuf[ip + 63]);
-                int bits4 = xorMaxBits(inBuf, ip + 96, 32,
-                    inBuf[ip + 95]);
-                outBuf[op++] = (bits1 << 24) | (bits2 << 16)
-                               | (bits3 << 8) | (bits4 << 0);
-                op += xorPack(inBuf, ip + 0, outBuf, op, bits1,
-                    context, work);
-                op += xorPack(inBuf, ip + 32, outBuf, op, bits2,
-                    inBuf[ip + 31], work);
-                op += xorPack(inBuf, ip + 64, outBuf, op, bits3,
-                    inBuf[ip + 63], work);
-                op += xorPack(inBuf, ip + 96, outBuf, op, bits4,
-                    inBuf[ip + 95], work);
-                context = inBuf[ip + 127];
-            }
-
-            inPos.add(inLen);
-            outPos.set(op);
+            int bits1 = xorMaxBits(inBuf, ip + 0, 32, context);
+            int bits2 = xorMaxBits(inBuf, ip + 32, 32,
+                inBuf[ip + 31]);
+            int bits3 = xorMaxBits(inBuf, ip + 64, 32,
+                inBuf[ip + 63]);
+            int bits4 = xorMaxBits(inBuf, ip + 96, 32,
+                inBuf[ip + 95]);
+            outBuf[op++] = (bits1 << 24) | (bits2 << 16)
+                           | (bits3 << 8) | (bits4 << 0);
+            op += xorPack(inBuf, ip + 0, outBuf, op, bits1,
+                context, work);
+            op += xorPack(inBuf, ip + 32, outBuf, op, bits2,
+                inBuf[ip + 31], work);
+            op += xorPack(inBuf, ip + 64, outBuf, op, bits3,
+                inBuf[ip + 63], work);
+            op += xorPack(inBuf, ip + 96, outBuf, op, bits4,
+                inBuf[ip + 95], work);
+            context = inBuf[ip + 127];
         }
 
-        public void uncompress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
+        inPos.add(inLen);
+        outPos.set(op);
+    }
+
+    public void uncompress(int[] inBuf, IntWrapper inPos, int inLen, int[] outBuf, IntWrapper outPos)
+    {
+        if (inLen == 0)
+            return;
+
+        int outLen = inBuf[inPos.get()];
+        inPos.increment();
+
+        int context = 0;
+        int[] work = new int[32];
+
+        int ip = inPos.get();
+        int op = outPos.get();
+        int outPosLast = op + outLen;
+        for (; op < outPosLast; op += BLOCK_LENGTH)
         {
-            if (inLen == 0)
-                return;
-
-            int outLen = inBuf[inPos.get()];
-            inPos.increment();
-
-            int context = 0;
-            int[] work = new int[32];
-
-            int ip = inPos.get();
-            int op = outPos.get();
-            int outPosLast = op + outLen;
-            for (; op < outPosLast; op += BLOCK_LENGTH)
-            {
-                int bits1 = (int)((uint)inBuf[ip] >> 24);
-                int bits2 = (int)((uint)inBuf[ip] >> 16) & 0xFF;
-                int bits3 = (int)((uint)inBuf[ip] >> 8) & 0xFF;
-                int bits4 = (int)((uint)inBuf[ip] >> 0) & 0xFF;
-                ++ip;
-                ip += xorUnpack(inBuf, ip, outBuf, op + 0, bits1,
-                    context, work);
-                ip += xorUnpack(inBuf, ip, outBuf, op + 32, bits2,
-                    outBuf[op + 31], work);
-                ip += xorUnpack(inBuf, ip, outBuf, op + 64, bits3,
-                    outBuf[op + 63], work);
-                ip += xorUnpack(inBuf, ip, outBuf, op + 96, bits4,
-                    outBuf[op + 95], work);
-                context = outBuf[op + 127];
-            }
-
-            outPos.add(outLen);
-            inPos.set(ip);
+            int bits1 = (int)((uint)inBuf[ip] >> 24);
+            int bits2 = (int)((uint)inBuf[ip] >> 16) & 0xFF;
+            int bits3 = (int)((uint)inBuf[ip] >> 8) & 0xFF;
+            int bits4 = (int)((uint)inBuf[ip] >> 0) & 0xFF;
+            ++ip;
+            ip += xorUnpack(inBuf, ip, outBuf, op + 0, bits1,
+                context, work);
+            ip += xorUnpack(inBuf, ip, outBuf, op + 32, bits2,
+                outBuf[op + 31], work);
+            ip += xorUnpack(inBuf, ip, outBuf, op + 64, bits3,
+                outBuf[op + 63], work);
+            ip += xorUnpack(inBuf, ip, outBuf, op + 96, bits4,
+                outBuf[op + 95], work);
+            context = outBuf[op + 127];
         }
 
-        private static int xorMaxBits(int[] buf, int offset, int length, int context)
-        {
-            int mask = buf[offset] ^ context;
-            int M = offset + length;
-            for (int i = offset + 1, prev = offset; i < M; ++i, ++prev)
-            {
-                mask |= buf[i] ^ buf[prev];
-            }
+        outPos.add(outLen);
+        inPos.set(ip);
+    }
 
-            return 32 - Integer.numberOfLeadingZeros(mask);
+    private static int xorMaxBits(int[] buf, int offset, int length, int context)
+    {
+        int mask = buf[offset] ^ context;
+        int M = offset + length;
+        for (int i = offset + 1, prev = offset; i < M; ++i, ++prev)
+        {
+            mask |= buf[i] ^ buf[prev];
         }
 
-        private static int xorPack(int[] inBuf, int inOff, int[] outBuf, int outOff, int validBits, int context, int[] work)
-        {
-            work[0] = inBuf[inOff] ^ context;
-            for (int i = 1, p = inOff + 1; i < 32; ++i, ++p)
-            {
-                work[i] = inBuf[p] ^ inBuf[p - 1];
-            }
-            BitPacking.fastpackwithoutmask(work, 0, outBuf, outOff,
-                validBits);
+        return 32 - Integer.numberOfLeadingZeros(mask);
+    }
 
-            return validBits;
-        }
-
-        private static int xorUnpack(int[] inBuf, int inOff, int[] outBuf, int outOff, int validBits, int context, int[] work)
+    private static int xorPack(int[] inBuf, int inOff, int[] outBuf, int outOff, int validBits, int context, int[] work)
+    {
+        work[0] = inBuf[inOff] ^ context;
+        for (int i = 1, p = inOff + 1; i < 32; ++i, ++p)
         {
-            BitPacking.fastunpack(inBuf, inOff, work, 0, validBits);
-            outBuf[outOff] = context = work[0] ^ context;
-            for (int i = 1, p = outOff + 1; i < 32; ++i, ++p)
-            {
-                outBuf[p] = context = work[i] ^ context;
-            }
-            return validBits;
+            work[i] = inBuf[p] ^ inBuf[p - 1];
         }
+        BitPacking.fastpackwithoutmask(work, 0, outBuf, outOff,
+            validBits);
 
-        public override string ToString()
+        return validBits;
+    }
+
+    private static int xorUnpack(int[] inBuf, int inOff, int[] outBuf, int outOff, int validBits, int context, int[] work)
+    {
+        BitPacking.fastunpack(inBuf, inOff, work, 0, validBits);
+        outBuf[outOff] = context = work[0] ^ context;
+        for (int i = 1, p = outOff + 1; i < 32; ++i, ++p)
         {
-            return nameof(XorBinaryPacking);
+            outBuf[p] = context = work[i] ^ context;
         }
+        return validBits;
+    }
+
+    public override string ToString()
+    {
+        return nameof(XorBinaryPacking);
     }
 }

--- a/src/CSharpFastPFOR/Differential/XorBinaryPacking.cs
+++ b/src/CSharpFastPFOR/Differential/XorBinaryPacking.cs
@@ -16,7 +16,7 @@ using Genbox.CSharpFastPFOR.Port;
 
 namespace Genbox.CSharpFastPFOR.Differential;
 
-public class XorBinaryPacking : IntegratedIntegerCODEC
+public sealed class XorBinaryPacking : IntegratedIntegerCODEC
 {
     private const int BLOCK_LENGTH = 128;
 

--- a/src/CSharpFastPFOR/FastPFOR.cs
+++ b/src/CSharpFastPFOR/FastPFOR.cs
@@ -46,14 +46,14 @@ namespace Genbox.CSharpFastPFOR
         public const int BLOCK_SIZE = 256;
 
 
-        private int pageSize;
-        private int[][] dataTobePacked = new int[33][];
-        private ByteBuffer byteContainer;
+        private readonly int pageSize;
+        private readonly int[][] dataTobePacked = new int[33][];
+        private readonly ByteBuffer byteContainer;
 
         // Working area for compress and uncompress.
-        private int[] dataPointers = new int[33];
-        private int[] freqs = new int[33];
-        private int[] bestbbestcexceptmaxb = new int[3];
+        private readonly int[] dataPointers = new int[33];
+        private readonly int[] freqs = new int[33];
+        private readonly int[] bestbbestcexceptmaxb = new int[3];
 
         /**
          * Construct the FastPFOR CODEC.

--- a/src/CSharpFastPFOR/FastPFOR.cs
+++ b/src/CSharpFastPFOR/FastPFOR.cs
@@ -37,332 +37,331 @@
 using System;
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public sealed class FastPFOR : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class FastPFOR : IntegerCODEC, SkippableIntegerCODEC
+    private const int OVERHEAD_OF_EACH_EXCEPT = 8;
+    private const int DEFAULT_PAGE_SIZE = 65536;
+    public const int BLOCK_SIZE = 256;
+
+
+    private readonly int pageSize;
+    private readonly int[][] dataTobePacked = new int[33][];
+    private readonly ByteBuffer byteContainer;
+
+    // Working area for compress and uncompress.
+    private readonly int[] dataPointers = new int[33];
+    private readonly int[] freqs = new int[33];
+    private readonly int[] bestbbestcexceptmaxb = new int[3];
+
+    /**
+     * Construct the FastPFOR CODEC.
+     * 
+     * @param pagesize
+     *                the desired page size (recommended value is FastPFOR.DEFAULT_PAGE_SIZE)
+     */
+    private FastPFOR(int pagesize)
     {
-        private const int OVERHEAD_OF_EACH_EXCEPT = 8;
-        private const int DEFAULT_PAGE_SIZE = 65536;
-        public const int BLOCK_SIZE = 256;
+        pageSize = pagesize;
+        // Initiate arrrays.
+        byteContainer = ByteBuffer.allocateDirect(3 * pageSize / BLOCK_SIZE + pageSize);
+        byteContainer.order(ByteOrder.LITTLE_ENDIAN);
+        for (int k = 1; k < dataTobePacked.Length; ++k)
+            dataTobePacked[k] = new int[pageSize / 32 * 4]; // heuristic
+    }
 
+    /**
+     * Construct the fastPFOR CODEC with default parameters.
+     */
+    public FastPFOR() : this(DEFAULT_PAGE_SIZE)
+    {
+    }
 
-        private readonly int pageSize;
-        private readonly int[][] dataTobePacked = new int[33][];
-        private readonly ByteBuffer byteContainer;
-
-        // Working area for compress and uncompress.
-        private readonly int[] dataPointers = new int[33];
-        private readonly int[] freqs = new int[33];
-        private readonly int[] bestbbestcexceptmaxb = new int[3];
-
-        /**
-         * Construct the FastPFOR CODEC.
-         * 
-         * @param pagesize
-         *                the desired page size (recommended value is FastPFOR.DEFAULT_PAGE_SIZE)
-         */
-        private FastPFOR(int pagesize)
+    /**
+     * Compress data in blocks of BLOCK_SIZE integers (if fewer than BLOCK_SIZE integers
+     * are provided, nothing is done).
+     * 
+     * @see IntegerCODEC#compress(int[], IntWrapper, int, int[], IntWrapper)
+     */
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        // Allocate memory for working area.
+        int finalinpos = inpos.get() + inlength;
+        while (inpos.get() != finalinpos)
         {
-            pageSize = pagesize;
-            // Initiate arrrays.
-            byteContainer = ByteBuffer.allocateDirect(3 * pageSize / BLOCK_SIZE + pageSize);
-            byteContainer.order(ByteOrder.LITTLE_ENDIAN);
-            for (int k = 1; k < dataTobePacked.Length; ++k)
-                dataTobePacked[k] = new int[pageSize / 32 * 4]; // heuristic
+            int thissize = Math.Min(pageSize,
+                finalinpos - inpos.get());
+            encodePage(@in, inpos, thissize, @out, outpos);
         }
+    }
 
-        /**
-         * Construct the fastPFOR CODEC with default parameters.
-         */
-        public FastPFOR() : this(DEFAULT_PAGE_SIZE)
+    private void getBestBFromData(int[] @in, int pos)
+    {
+        Arrays.fill(freqs, 0);
+        for (int k = pos, k_end = pos + BLOCK_SIZE; k < k_end; ++k)
         {
+            freqs[Util.bits(@in[k])]++;
         }
-
-        /**
-         * Compress data in blocks of BLOCK_SIZE integers (if fewer than BLOCK_SIZE integers
-         * are provided, nothing is done).
-         * 
-         * @see IntegerCODEC#compress(int[], IntWrapper, int, int[], IntWrapper)
-         */
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+        bestbbestcexceptmaxb[0] = 32;
+        while (freqs[bestbbestcexceptmaxb[0]] == 0)
+            bestbbestcexceptmaxb[0]--;
+        bestbbestcexceptmaxb[2] = bestbbestcexceptmaxb[0];
+        int bestcost = bestbbestcexceptmaxb[0] * BLOCK_SIZE;
+        int cexcept = 0;
+        bestbbestcexceptmaxb[1] = cexcept;
+        for (int b = bestbbestcexceptmaxb[0] - 1; b >= 0; --b)
         {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            // Allocate memory for working area.
-            int finalinpos = inpos.get() + inlength;
-            while (inpos.get() != finalinpos)
+            cexcept += freqs[b + 1];
+            if (cexcept == BLOCK_SIZE)
+                break;
+            // the extra 8 is the cost of storing maxbits
+            int thiscost = cexcept * OVERHEAD_OF_EACH_EXCEPT
+                           + cexcept * (bestbbestcexceptmaxb[2] - b) + b
+                           * BLOCK_SIZE + 8;
+            if (bestbbestcexceptmaxb[2] - b == 1) thiscost -= cexcept;
+            if (thiscost < bestcost)
             {
-                int thissize = Math.Min(pageSize,
-                    finalinpos - inpos.get());
-                encodePage(@in, inpos, thissize, @out, outpos);
+                bestcost = thiscost;
+                bestbbestcexceptmaxb[0] = b;
+                bestbbestcexceptmaxb[1] = cexcept;
             }
         }
+    }
 
-        private void getBestBFromData(int[] @in, int pos)
+    private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
+    {
+        int headerpos = outpos.get();
+        outpos.increment();
+        int tmpoutpos = outpos.get();
+
+        // Clear working area.
+        Arrays.fill(dataPointers, 0);
+        byteContainer.clear();
+
+        int tmpinpos = inpos.get();
+        for (int finalinpos = tmpinpos + thissize - BLOCK_SIZE; tmpinpos <= finalinpos; tmpinpos += BLOCK_SIZE)
         {
-            Arrays.fill(freqs, 0);
-            for (int k = pos, k_end = pos + BLOCK_SIZE; k < k_end; ++k)
+            getBestBFromData(@in, tmpinpos);
+
+            int tmpbestb = bestbbestcexceptmaxb[0];
+            byteContainer.put((sbyte)bestbbestcexceptmaxb[0]);
+            byteContainer.put((sbyte)bestbbestcexceptmaxb[1]);
+            if (bestbbestcexceptmaxb[1] > 0)
             {
-                freqs[Util.bits(@in[k])]++;
-            }
-            bestbbestcexceptmaxb[0] = 32;
-            while (freqs[bestbbestcexceptmaxb[0]] == 0)
-                bestbbestcexceptmaxb[0]--;
-            bestbbestcexceptmaxb[2] = bestbbestcexceptmaxb[0];
-            int bestcost = bestbbestcexceptmaxb[0] * BLOCK_SIZE;
-            int cexcept = 0;
-            bestbbestcexceptmaxb[1] = cexcept;
-            for (int b = bestbbestcexceptmaxb[0] - 1; b >= 0; --b)
-            {
-                cexcept += freqs[b + 1];
-                if (cexcept == BLOCK_SIZE)
-                    break;
-                // the extra 8 is the cost of storing maxbits
-                int thiscost = cexcept * OVERHEAD_OF_EACH_EXCEPT
-                               + cexcept * (bestbbestcexceptmaxb[2] - b) + b
-                               * BLOCK_SIZE + 8;
-                if (bestbbestcexceptmaxb[2] - b == 1) thiscost -= cexcept;
-                if (thiscost < bestcost)
+                byteContainer.put((sbyte)bestbbestcexceptmaxb[2]);
+
+                int index = bestbbestcexceptmaxb[2]
+                            - bestbbestcexceptmaxb[0];
+                if (dataPointers[index]
+                    + bestbbestcexceptmaxb[1] >= dataTobePacked[index].Length)
                 {
-                    bestcost = thiscost;
-                    bestbbestcexceptmaxb[0] = b;
-                    bestbbestcexceptmaxb[1] = cexcept;
+                    int newsize = 2 * (dataPointers[index] + bestbbestcexceptmaxb[1]);
+                    // make sure it is a multiple of 32
+                    newsize = Util.greatestMultiple(newsize + 31, 32);
+                    dataTobePacked[index] = Arrays.copyOf(dataTobePacked[index], newsize);
                 }
-            }
-        }
-
-        private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
-        {
-            int headerpos = outpos.get();
-            outpos.increment();
-            int tmpoutpos = outpos.get();
-
-            // Clear working area.
-            Arrays.fill(dataPointers, 0);
-            byteContainer.clear();
-
-            int tmpinpos = inpos.get();
-            for (int finalinpos = tmpinpos + thissize - BLOCK_SIZE; tmpinpos <= finalinpos; tmpinpos += BLOCK_SIZE)
-            {
-                getBestBFromData(@in, tmpinpos);
-
-                int tmpbestb = bestbbestcexceptmaxb[0];
-                byteContainer.put((sbyte)bestbbestcexceptmaxb[0]);
-                byteContainer.put((sbyte)bestbbestcexceptmaxb[1]);
-                if (bestbbestcexceptmaxb[1] > 0)
+                for (int k = 0; k < BLOCK_SIZE; ++k)
                 {
-                    byteContainer.put((sbyte)bestbbestcexceptmaxb[2]);
-
-                    int index = bestbbestcexceptmaxb[2]
-                                - bestbbestcexceptmaxb[0];
-                    if (dataPointers[index]
-                        + bestbbestcexceptmaxb[1] >= dataTobePacked[index].Length)
+                    if ((int)((uint)@in[k + tmpinpos] >> bestbbestcexceptmaxb[0]) != 0)
                     {
-                        int newsize = 2 * (dataPointers[index] + bestbbestcexceptmaxb[1]);
-                        // make sure it is a multiple of 32
-                        newsize = Util.greatestMultiple(newsize + 31, 32);
-                        dataTobePacked[index] = Arrays.copyOf(dataTobePacked[index], newsize);
-                    }
-                    for (int k = 0; k < BLOCK_SIZE; ++k)
-                    {
-                        if ((int)((uint)@in[k + tmpinpos] >> bestbbestcexceptmaxb[0]) != 0)
-                        {
-                            // we have an exception
-                            byteContainer.put((sbyte)k);
-                            dataTobePacked[index][dataPointers[index]++] = (int)((uint)@in[k + tmpinpos] >> tmpbestb);
-                        }
+                        // we have an exception
+                        byteContainer.put((sbyte)k);
+                        dataTobePacked[index][dataPointers[index]++] = (int)((uint)@in[k + tmpinpos] >> tmpbestb);
                     }
                 }
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
+            }
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
+            {
+                BitPacking.fastpack(@in, tmpinpos + k, @out,
+                    tmpoutpos, tmpbestb);
+                tmpoutpos += tmpbestb;
+            }
+        }
+        inpos.set(tmpinpos);
+        @out[headerpos] = tmpoutpos - headerpos;
+
+        int bytesize = byteContainer.position();
+        while ((byteContainer.position() & 3) != 0)
+            byteContainer.put((sbyte)0);
+        @out[tmpoutpos++] = bytesize;
+
+        int howmanyints = byteContainer.position() / 4;
+        byteContainer.flip();
+        byteContainer.asIntBuffer().get(@out, tmpoutpos, howmanyints);
+        tmpoutpos += howmanyints;
+        int bitmap = 0;
+        for (int k = 2; k <= 32; ++k)
+        {
+            if (dataPointers[k] != 0)
+                bitmap |= (1 << (k - 1));
+        }
+        @out[tmpoutpos++] = bitmap;
+
+        for (int k = 2; k <= 32; ++k)
+        {
+            if (dataPointers[k] != 0)
+            {
+                @out[tmpoutpos++] = dataPointers[k];// size
+                int j = 0;
+                for (; j < dataPointers[k]; j += 32)
                 {
-                    BitPacking.fastpack(@in, tmpinpos + k, @out,
-                        tmpoutpos, tmpbestb);
-                    tmpoutpos += tmpbestb;
+                    BitPacking.fastpack(dataTobePacked[k],
+                        j, @out, tmpoutpos, k);
+                    tmpoutpos += k;
                 }
+                int overflow = j - dataPointers[k];
+                tmpoutpos -= overflow * k / 32;
             }
-            inpos.set(tmpinpos);
-            @out[headerpos] = tmpoutpos - headerpos;
+        }
+        outpos.set(tmpoutpos);
+    }
 
-            int bytesize = byteContainer.position();
-            while ((byteContainer.position() & 3) != 0)
-                byteContainer.put((sbyte)0);
-            @out[tmpoutpos++] = bytesize;
+    /**
+     * Uncompress data in blocks of integers. In this particular case,
+     * the inlength parameter is ignored: it is deduced from the compressed
+     * data.
+     * 
+     * @see IntegerCODEC#compress(int[], IntWrapper, int, int[], IntWrapper)
+     */
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
+    {
+        mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
+        int finalout = outpos.get() + mynvalue;
+        while (outpos.get() != finalout)
+        {
+            int thissize = Math.Min(pageSize,
+                finalout - outpos.get());
+            decodePage(@in, inpos, @out, outpos, thissize);
+        }
+    }
 
-            int howmanyints = byteContainer.position() / 4;
-            byteContainer.flip();
-            byteContainer.asIntBuffer().get(@out, tmpoutpos, howmanyints);
-            tmpoutpos += howmanyints;
-            int bitmap = 0;
-            for (int k = 2; k <= 32; ++k)
+    private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
+    {
+        int initpos = inpos.get();
+
+        int wheremeta = @in[inpos.get()];
+        inpos.increment();
+        int inexcept = initpos + wheremeta;
+
+        int bytesize = @in[inexcept++];
+        byteContainer.clear();
+        //byteContainer.asIntBuffer().put(@in, inexcept, (bytesize + 3) / 4); //Port note: I've collapsed the code here
+        byteContainer.put(@in, inexcept, (bytesize + 3) / 4);
+        byteContainer._ms.Position = 0;
+        inexcept += (bytesize + 3) / 4;
+
+        int bitmap = @in[inexcept++];
+        for (int k = 2; k <= 32; ++k)
+        {
+            if ((bitmap & (1 << (k - 1))) != 0)
             {
-                if (dataPointers[k] != 0)
-                    bitmap |= (1 << (k - 1));
-            }
-            @out[tmpoutpos++] = bitmap;
-
-            for (int k = 2; k <= 32; ++k)
-            {
-                if (dataPointers[k] != 0)
+                int size = @in[inexcept++];
+                int roundedup = Util
+                    .greatestMultiple(size + 31, 32);
+                if (dataTobePacked[k].Length < roundedup)
+                    dataTobePacked[k] = new int[roundedup];
+                if (inexcept + roundedup / 32 * k <= @in.Length)
                 {
-                    @out[tmpoutpos++] = dataPointers[k];// size
                     int j = 0;
-                    for (; j < dataPointers[k]; j += 32)
+                    for (; j < size; j += 32)
                     {
-                        BitPacking.fastpack(dataTobePacked[k],
-                            j, @out, tmpoutpos, k);
-                        tmpoutpos += k;
+                        BitPacking.fastunpack(@in, inexcept,
+                            dataTobePacked[k], j, k);
+                        inexcept += k;
                     }
-                    int overflow = j - dataPointers[k];
-                    tmpoutpos -= overflow * k / 32;
+                    int overflow = j - size;
+                    inexcept -= overflow * k / 32;
                 }
-            }
-            outpos.set(tmpoutpos);
-        }
-
-        /**
-         * Uncompress data in blocks of integers. In this particular case,
-         * the inlength parameter is ignored: it is deduced from the compressed
-         * data.
-         * 
-         * @see IntegerCODEC#compress(int[], IntWrapper, int, int[], IntWrapper)
-         */
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
-        {
-            mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
-            int finalout = outpos.get() + mynvalue;
-            while (outpos.get() != finalout)
-            {
-                int thissize = Math.Min(pageSize,
-                    finalout - outpos.get());
-                decodePage(@in, inpos, @out, outpos, thissize);
-            }
-        }
-
-        private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
-        {
-            int initpos = inpos.get();
-
-            int wheremeta = @in[inpos.get()];
-            inpos.increment();
-            int inexcept = initpos + wheremeta;
-
-            int bytesize = @in[inexcept++];
-            byteContainer.clear();
-            //byteContainer.asIntBuffer().put(@in, inexcept, (bytesize + 3) / 4); //Port note: I've collapsed the code here
-            byteContainer.put(@in, inexcept, (bytesize + 3) / 4);
-            byteContainer._ms.Position = 0;
-            inexcept += (bytesize + 3) / 4;
-
-            int bitmap = @in[inexcept++];
-            for (int k = 2; k <= 32; ++k)
-            {
-                if ((bitmap & (1 << (k - 1))) != 0)
+                else
                 {
-                    int size = @in[inexcept++];
-                    int roundedup = Util
-                        .greatestMultiple(size + 31, 32);
-                    if (dataTobePacked[k].Length < roundedup)
-                        dataTobePacked[k] = new int[roundedup];
-                    if (inexcept + roundedup / 32 * k <= @in.Length)
+                    int j = 0;
+                    int[] buf = new int[roundedup / 32 * k];
+                    int initinexcept = inexcept;
+                    Array.Copy(@in, inexcept, buf, 0, @in.Length - inexcept);
+                    for (; j < size; j += 32)
                     {
-                        int j = 0;
-                        for (; j < size; j += 32)
-                        {
-                            BitPacking.fastunpack(@in, inexcept,
-                                dataTobePacked[k], j, k);
-                            inexcept += k;
-                        }
-                        int overflow = j - size;
-                        inexcept -= overflow * k / 32;
+                        BitPacking.fastunpack(buf, inexcept - initinexcept,
+                            dataTobePacked[k], j, k);
+                        inexcept += k;
                     }
-                    else
-                    {
-                        int j = 0;
-                        int[] buf = new int[roundedup / 32 * k];
-                        int initinexcept = inexcept;
-                        Array.Copy(@in, inexcept, buf, 0, @in.Length - inexcept);
-                        for (; j < size; j += 32)
-                        {
-                            BitPacking.fastunpack(buf, inexcept - initinexcept,
-                                dataTobePacked[k], j, k);
-                            inexcept += k;
-                        }
-                        int overflow = j - size;
-                        inexcept -= overflow * k / 32;
-                    }
+                    int overflow = j - size;
+                    inexcept -= overflow * k / 32;
                 }
             }
-            Arrays.fill(dataPointers, 0);
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
+        }
+        Arrays.fill(dataPointers, 0);
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
 
-            for (int run = 0, run_end = thissize / BLOCK_SIZE; run < run_end; ++run, tmpoutpos += BLOCK_SIZE)
+        for (int run = 0, run_end = thissize / BLOCK_SIZE; run < run_end; ++run, tmpoutpos += BLOCK_SIZE)
+        {
+
+            int b = byteContainer.get();
+
+            int cexcept = byteContainer.get() & 0xFF;
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
+            {
+                BitPacking.fastunpack(@in, tmpinpos, @out,
+                    tmpoutpos + k, b);
+                tmpinpos += b;
+            }
+            if (cexcept > 0)
             {
 
-                int b = byteContainer.get();
+                int maxbits = byteContainer.get();
 
-                int cexcept = byteContainer.get() & 0xFF;
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
+                int index = maxbits - b;
+                if (index == 1)
                 {
-                    BitPacking.fastunpack(@in, tmpinpos, @out,
-                        tmpoutpos + k, b);
-                    tmpinpos += b;
-                }
-                if (cexcept > 0)
-                {
-
-                    int maxbits = byteContainer.get();
-
-                    int index = maxbits - b;
-                    if (index == 1)
+                    for (int k = 0; k < cexcept; ++k)
                     {
-                        for (int k = 0; k < cexcept; ++k)
-                        {
 
-                            int pos = byteContainer.get() & 0xFF;
-                            @out[pos + tmpoutpos] |= 1 << b;
-                        }
+                        int pos = byteContainer.get() & 0xFF;
+                        @out[pos + tmpoutpos] |= 1 << b;
                     }
-                    else
+                }
+                else
+                {
+                    for (int k = 0; k < cexcept; ++k)
                     {
-                        for (int k = 0; k < cexcept; ++k)
-                        {
 
-                            int pos = byteContainer.get() & 0xFF;
+                        int pos = byteContainer.get() & 0xFF;
 
-                            int exceptvalue = dataTobePacked[index][dataPointers[index]++];
-                            @out[pos + tmpoutpos] |= exceptvalue << b;
-                        }
+                        int exceptvalue = dataTobePacked[index][dataPointers[index]++];
+                        @out[pos + tmpoutpos] |= exceptvalue << b;
                     }
                 }
             }
-            outpos.set(tmpoutpos);
-            inpos.set(inexcept);
         }
+        outpos.set(tmpoutpos);
+        inpos.set(inexcept);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
 
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
 
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
-        }
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
+    }
 
-        public override string ToString()
-        {
-            return nameof(FastPFOR);
-        }
+    public override string ToString()
+    {
+        return nameof(FastPFOR);
     }
 }

--- a/src/CSharpFastPFOR/FastPFOR128.cs
+++ b/src/CSharpFastPFOR/FastPFOR128.cs
@@ -20,331 +20,330 @@
 using System;
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class FastPFOR128 : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class FastPFOR128 : IntegerCODEC, SkippableIntegerCODEC
+    private const int OVERHEAD_OF_EACH_EXCEPT = 8;
+    private const int DEFAULT_PAGE_SIZE = 65536;
+    public const int BLOCK_SIZE = 128;
+
+    private int pageSize;
+    private int[][] dataTobePacked = new int[33][];
+    private ByteBuffer byteContainer;
+
+    // Working area for compress and uncompress.
+    private int[] dataPointers = new int[33];
+    private int[] freqs = new int[33];
+    private int[] bestbbestcexceptmaxb = new int[3];
+
+    /**
+     * Construct the FastPFOR CODEC.
+     * 
+     * @param pagesize
+     *                the desired page size (recommended value is FastPFOR.DEFAULT_PAGE_SIZE)
+     */
+    public FastPFOR128(int pagesize)
     {
-        private const int OVERHEAD_OF_EACH_EXCEPT = 8;
-        private const int DEFAULT_PAGE_SIZE = 65536;
-        public const int BLOCK_SIZE = 128;
+        pageSize = pagesize;
+        // Initiate arrrays.
+        byteContainer = ByteBuffer.allocateDirect(3 * pageSize / BLOCK_SIZE + pageSize);
+        byteContainer.order(ByteOrder.LITTLE_ENDIAN);
+        for (int k = 1; k < dataTobePacked.Length; ++k)
+            dataTobePacked[k] = new int[pageSize / 32 * 4]; // heuristic
+    }
+    /**
+     * Construct the fastPFOR CODEC with default parameters.
+     */
+    public FastPFOR128() : this(DEFAULT_PAGE_SIZE)
+    {
+    }
 
-        private int pageSize;
-        private int[][] dataTobePacked = new int[33][];
-        private ByteBuffer byteContainer;
+    /**
+     * Compress data in blocks of BLOCK_SIZE integers (if fewer than BLOCK_SIZE integers
+     * are provided, nothing is done).
+     * 
+     * @see IntegerCODEC#compress(int[], IntWrapper, int, int[], IntWrapper)
+     */
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
 
-        // Working area for compress and uncompress.
-        private int[] dataPointers = new int[33];
-        private int[] freqs = new int[33];
-        private int[] bestbbestcexceptmaxb = new int[3];
-
-        /**
-         * Construct the FastPFOR CODEC.
-         * 
-         * @param pagesize
-         *                the desired page size (recommended value is FastPFOR.DEFAULT_PAGE_SIZE)
-         */
-        public FastPFOR128(int pagesize)
+        int finalinpos = inpos.get() + inlength;
+        while (inpos.get() != finalinpos)
         {
-            pageSize = pagesize;
-            // Initiate arrrays.
-            byteContainer = ByteBuffer.allocateDirect(3 * pageSize / BLOCK_SIZE + pageSize);
-            byteContainer.order(ByteOrder.LITTLE_ENDIAN);
-            for (int k = 1; k < dataTobePacked.Length; ++k)
-                dataTobePacked[k] = new int[pageSize / 32 * 4]; // heuristic
+            int thissize = Math.Min(pageSize, finalinpos - inpos.get());
+            encodePage(@in, inpos, thissize, @out, outpos);
         }
-        /**
-         * Construct the fastPFOR CODEC with default parameters.
-         */
-        public FastPFOR128() : this(DEFAULT_PAGE_SIZE)
+    }
+
+    private void getBestBFromData(int[] @in, int pos)
+    {
+        Arrays.fill(freqs, 0);
+        for (int k = pos, k_end = pos + BLOCK_SIZE; k < k_end; ++k)
         {
+            freqs[Util.bits(@in[k])]++;
         }
-
-        /**
-         * Compress data in blocks of BLOCK_SIZE integers (if fewer than BLOCK_SIZE integers
-         * are provided, nothing is done).
-         * 
-         * @see IntegerCODEC#compress(int[], IntWrapper, int, int[], IntWrapper)
-         */
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+        bestbbestcexceptmaxb[0] = 32;
+        while (freqs[bestbbestcexceptmaxb[0]] == 0)
+            bestbbestcexceptmaxb[0]--;
+        bestbbestcexceptmaxb[2] = bestbbestcexceptmaxb[0];
+        int bestcost = bestbbestcexceptmaxb[0] * BLOCK_SIZE;
+        int cexcept = 0;
+        bestbbestcexceptmaxb[1] = cexcept;
+        for (int b = bestbbestcexceptmaxb[0] - 1; b >= 0; --b)
         {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-
-            int finalinpos = inpos.get() + inlength;
-            while (inpos.get() != finalinpos)
+            cexcept += freqs[b + 1];
+            if (cexcept == BLOCK_SIZE)
+                break;
+            // the extra 8 is the cost of storing maxbits
+            int thiscost = cexcept * OVERHEAD_OF_EACH_EXCEPT
+                           + cexcept * (bestbbestcexceptmaxb[2] - b) + b
+                           * BLOCK_SIZE + 8;
+            if (bestbbestcexceptmaxb[2] - b == 1) thiscost -= cexcept;
+            if (thiscost < bestcost)
             {
-                int thissize = Math.Min(pageSize, finalinpos - inpos.get());
-                encodePage(@in, inpos, thissize, @out, outpos);
+                bestcost = thiscost;
+                bestbbestcexceptmaxb[0] = b;
+                bestbbestcexceptmaxb[1] = cexcept;
             }
         }
+    }
 
-        private void getBestBFromData(int[] @in, int pos)
+    private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
+    {
+        int headerpos = outpos.get();
+        outpos.increment();
+        int tmpoutpos = outpos.get();
+
+        // Clear working area.
+        Arrays.fill(dataPointers, 0);
+        byteContainer.clear();
+
+        int tmpinpos = inpos.get();
+        for (int finalinpos = tmpinpos + thissize - BLOCK_SIZE; tmpinpos <= finalinpos; tmpinpos += BLOCK_SIZE)
         {
-            Arrays.fill(freqs, 0);
-            for (int k = pos, k_end = pos + BLOCK_SIZE; k < k_end; ++k)
+            getBestBFromData(@in, tmpinpos);
+
+            int tmpbestb = bestbbestcexceptmaxb[0];
+            byteContainer.put((sbyte)bestbbestcexceptmaxb[0]);
+            byteContainer.put((sbyte)bestbbestcexceptmaxb[1]);
+            if (bestbbestcexceptmaxb[1] > 0)
             {
-                freqs[Util.bits(@in[k])]++;
-            }
-            bestbbestcexceptmaxb[0] = 32;
-            while (freqs[bestbbestcexceptmaxb[0]] == 0)
-                bestbbestcexceptmaxb[0]--;
-            bestbbestcexceptmaxb[2] = bestbbestcexceptmaxb[0];
-            int bestcost = bestbbestcexceptmaxb[0] * BLOCK_SIZE;
-            int cexcept = 0;
-            bestbbestcexceptmaxb[1] = cexcept;
-            for (int b = bestbbestcexceptmaxb[0] - 1; b >= 0; --b)
-            {
-                cexcept += freqs[b + 1];
-                if (cexcept == BLOCK_SIZE)
-                    break;
-                // the extra 8 is the cost of storing maxbits
-                int thiscost = cexcept * OVERHEAD_OF_EACH_EXCEPT
-                               + cexcept * (bestbbestcexceptmaxb[2] - b) + b
-                               * BLOCK_SIZE + 8;
-                if (bestbbestcexceptmaxb[2] - b == 1) thiscost -= cexcept;
-                if (thiscost < bestcost)
+                byteContainer.put((sbyte)bestbbestcexceptmaxb[2]);
+
+                int index = bestbbestcexceptmaxb[2]
+                            - bestbbestcexceptmaxb[0];
+                if (dataPointers[index] + bestbbestcexceptmaxb[1] >= dataTobePacked[index].Length)
                 {
-                    bestcost = thiscost;
-                    bestbbestcexceptmaxb[0] = b;
-                    bestbbestcexceptmaxb[1] = cexcept;
+                    int newsize = 2 * (dataPointers[index] + bestbbestcexceptmaxb[1]);
+                    // make sure it is a multiple of 32
+                    newsize = Util
+                        .greatestMultiple(newsize + 31, 32);
+                    dataTobePacked[index] = Arrays.copyOf(
+                        dataTobePacked[index], newsize);
                 }
-            }
-        }
-
-        private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
-        {
-            int headerpos = outpos.get();
-            outpos.increment();
-            int tmpoutpos = outpos.get();
-
-            // Clear working area.
-            Arrays.fill(dataPointers, 0);
-            byteContainer.clear();
-
-            int tmpinpos = inpos.get();
-            for (int finalinpos = tmpinpos + thissize - BLOCK_SIZE; tmpinpos <= finalinpos; tmpinpos += BLOCK_SIZE)
-            {
-                getBestBFromData(@in, tmpinpos);
-
-                int tmpbestb = bestbbestcexceptmaxb[0];
-                byteContainer.put((sbyte)bestbbestcexceptmaxb[0]);
-                byteContainer.put((sbyte)bestbbestcexceptmaxb[1]);
-                if (bestbbestcexceptmaxb[1] > 0)
+                for (int k = 0; k < BLOCK_SIZE; ++k)
                 {
-                    byteContainer.put((sbyte)bestbbestcexceptmaxb[2]);
-
-                    int index = bestbbestcexceptmaxb[2]
-                                - bestbbestcexceptmaxb[0];
-                    if (dataPointers[index] + bestbbestcexceptmaxb[1] >= dataTobePacked[index].Length)
+                    if ((int)((uint)@in[k + tmpinpos] >> bestbbestcexceptmaxb[0]) != 0)
                     {
-                        int newsize = 2 * (dataPointers[index] + bestbbestcexceptmaxb[1]);
-                        // make sure it is a multiple of 32
-                        newsize = Util
-                            .greatestMultiple(newsize + 31, 32);
-                        dataTobePacked[index] = Arrays.copyOf(
-                            dataTobePacked[index], newsize);
+                        // we have an exception
+                        byteContainer.put((sbyte)k);
+                        dataTobePacked[index][dataPointers[index]++] = (int)((uint)@in[k + tmpinpos] >> tmpbestb);
                     }
-                    for (int k = 0; k < BLOCK_SIZE; ++k)
-                    {
-                        if ((int)((uint)@in[k + tmpinpos] >> bestbbestcexceptmaxb[0]) != 0)
-                        {
-                            // we have an exception
-                            byteContainer.put((sbyte)k);
-                            dataTobePacked[index][dataPointers[index]++] = (int)((uint)@in[k + tmpinpos] >> tmpbestb);
-                        }
-                    }
-
                 }
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
+
+            }
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
+            {
+                BitPacking.fastpack(@in, tmpinpos + k, @out,
+                    tmpoutpos, tmpbestb);
+                tmpoutpos += tmpbestb;
+            }
+        }
+        inpos.set(tmpinpos);
+        @out[headerpos] = tmpoutpos - headerpos;
+
+        int bytesize = byteContainer.position();
+        while ((byteContainer.position() & 3) != 0)
+            byteContainer.put((sbyte)0);
+        @out[tmpoutpos++] = bytesize;
+
+        int howmanyints = byteContainer.position() / 4;
+        byteContainer.flip();
+        byteContainer.asIntBuffer().get(@out, tmpoutpos, howmanyints);
+        tmpoutpos += howmanyints;
+        int bitmap = 0;
+        for (int k = 2; k <= 32; ++k)
+        {
+            if (dataPointers[k] != 0)
+                bitmap |= (1 << (k - 1));
+        }
+        @out[tmpoutpos++] = bitmap;
+
+        for (int k = 2; k <= 32; ++k)
+        {
+            if (dataPointers[k] != 0)
+            {
+                @out[tmpoutpos++] = dataPointers[k];// size
+                int j = 0;
+                for (; j < dataPointers[k]; j += 32)
                 {
-                    BitPacking.fastpack(@in, tmpinpos + k, @out,
-                        tmpoutpos, tmpbestb);
-                    tmpoutpos += tmpbestb;
+                    BitPacking.fastpack(dataTobePacked[k],
+                        j, @out, tmpoutpos, k);
+                    tmpoutpos += k;
                 }
+                int overflow = j - dataPointers[k];
+                tmpoutpos -= overflow * k / 32;
             }
-            inpos.set(tmpinpos);
-            @out[headerpos] = tmpoutpos - headerpos;
+        }
+        outpos.set(tmpoutpos);
+    }
 
-            int bytesize = byteContainer.position();
-            while ((byteContainer.position() & 3) != 0)
-                byteContainer.put((sbyte)0);
-            @out[tmpoutpos++] = bytesize;
+    /**
+     * Uncompress data in blocks of integers. In this particular case,
+     * the inlength parameter is ignored: it is deduced from the compressed
+     * data.
+     * 
+     * @see IntegerCODEC#compress(int[], IntWrapper, int, int[], IntWrapper)
+     */
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
+    {
+        if (inlength == 0)
+            return;
+        mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
+        int finalout = outpos.get() + mynvalue;
+        while (outpos.get() != finalout)
+        {
+            int thissize = Math.Min(pageSize,
+                finalout - outpos.get());
+            decodePage(@in, inpos, @out, outpos, thissize);
+        }
+    }
 
-            int howmanyints = byteContainer.position() / 4;
-            byteContainer.flip();
-            byteContainer.asIntBuffer().get(@out, tmpoutpos, howmanyints);
-            tmpoutpos += howmanyints;
-            int bitmap = 0;
-            for (int k = 2; k <= 32; ++k)
+    private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
+    {
+        int initpos = inpos.get();
+
+        int wheremeta = @in[inpos.get()];
+        inpos.increment();
+        int inexcept = initpos + wheremeta;
+
+        int bytesize = @in[inexcept++];
+        byteContainer.clear();
+        //byteContainer.asIntBuffer().put(@in, inexcept, (bytesize + 3) / 4); //Port note: I've collapsed the code here
+        byteContainer.put(@in, inexcept, (bytesize + 3) / 4);
+        byteContainer._ms.Position = 0;
+        inexcept += (bytesize + 3) / 4;
+
+        int bitmap = @in[inexcept++];
+        for (int k = 2; k <= 32; ++k)
+        {
+            if ((bitmap & (1 << (k - 1))) != 0)
             {
-                if (dataPointers[k] != 0)
-                    bitmap |= (1 << (k - 1));
-            }
-            @out[tmpoutpos++] = bitmap;
-
-            for (int k = 2; k <= 32; ++k)
-            {
-                if (dataPointers[k] != 0)
+                int size = @in[inexcept++];
+                int roundedup = Util
+                    .greatestMultiple(size + 31, 32);
+                if (dataTobePacked[k].Length < roundedup)
+                    dataTobePacked[k] = new int[roundedup];
+                if (inexcept + roundedup / 32 * k <= @in.Length)
                 {
-                    @out[tmpoutpos++] = dataPointers[k];// size
                     int j = 0;
-                    for (; j < dataPointers[k]; j += 32)
+                    for (; j < size; j += 32)
                     {
-                        BitPacking.fastpack(dataTobePacked[k],
-                            j, @out, tmpoutpos, k);
-                        tmpoutpos += k;
+                        BitPacking.fastunpack(@in, inexcept,
+                            dataTobePacked[k], j, k);
+                        inexcept += k;
                     }
-                    int overflow = j - dataPointers[k];
-                    tmpoutpos -= overflow * k / 32;
+                    int overflow = j - size;
+                    inexcept -= overflow * k / 32;
                 }
-            }
-            outpos.set(tmpoutpos);
-        }
-
-        /**
-         * Uncompress data in blocks of integers. In this particular case,
-         * the inlength parameter is ignored: it is deduced from the compressed
-         * data.
-         * 
-         * @see IntegerCODEC#compress(int[], IntWrapper, int, int[], IntWrapper)
-         */
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
-        {
-            if (inlength == 0)
-                return;
-            mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
-            int finalout = outpos.get() + mynvalue;
-            while (outpos.get() != finalout)
-            {
-                int thissize = Math.Min(pageSize,
-                    finalout - outpos.get());
-                decodePage(@in, inpos, @out, outpos, thissize);
-            }
-        }
-
-        private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
-        {
-            int initpos = inpos.get();
-
-            int wheremeta = @in[inpos.get()];
-            inpos.increment();
-            int inexcept = initpos + wheremeta;
-
-            int bytesize = @in[inexcept++];
-            byteContainer.clear();
-            //byteContainer.asIntBuffer().put(@in, inexcept, (bytesize + 3) / 4); //Port note: I've collapsed the code here
-            byteContainer.put(@in, inexcept, (bytesize + 3) / 4);
-            byteContainer._ms.Position = 0;
-            inexcept += (bytesize + 3) / 4;
-
-            int bitmap = @in[inexcept++];
-            for (int k = 2; k <= 32; ++k)
-            {
-                if ((bitmap & (1 << (k - 1))) != 0)
+                else
                 {
-                    int size = @in[inexcept++];
-                    int roundedup = Util
-                        .greatestMultiple(size + 31, 32);
-                    if (dataTobePacked[k].Length < roundedup)
-                        dataTobePacked[k] = new int[roundedup];
-                    if (inexcept + roundedup / 32 * k <= @in.Length)
+                    int j = 0;
+                    int[] buf = new int[roundedup / 32 * k];
+                    int initinexcept = inexcept;
+                    Array.Copy(@in, inexcept, buf, 0, @in.Length - inexcept);
+                    for (; j < size; j += 32)
                     {
-                        int j = 0;
-                        for (; j < size; j += 32)
-                        {
-                            BitPacking.fastunpack(@in, inexcept,
-                                dataTobePacked[k], j, k);
-                            inexcept += k;
-                        }
-                        int overflow = j - size;
-                        inexcept -= overflow * k / 32;
+                        BitPacking.fastunpack(buf, inexcept - initinexcept,
+                            dataTobePacked[k], j, k);
+                        inexcept += k;
                     }
-                    else
-                    {
-                        int j = 0;
-                        int[] buf = new int[roundedup / 32 * k];
-                        int initinexcept = inexcept;
-                        Array.Copy(@in, inexcept, buf, 0, @in.Length - inexcept);
-                        for (; j < size; j += 32)
-                        {
-                            BitPacking.fastunpack(buf, inexcept - initinexcept,
-                                dataTobePacked[k], j, k);
-                            inexcept += k;
-                        }
-                        int overflow = j - size;
-                        inexcept -= overflow * k / 32;
-                    }
+                    int overflow = j - size;
+                    inexcept -= overflow * k / 32;
                 }
             }
-            Arrays.fill(dataPointers, 0);
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
+        }
+        Arrays.fill(dataPointers, 0);
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
 
-            for (int run = 0, run_end = thissize / BLOCK_SIZE; run < run_end; ++run, tmpoutpos += BLOCK_SIZE)
+        for (int run = 0, run_end = thissize / BLOCK_SIZE; run < run_end; ++run, tmpoutpos += BLOCK_SIZE)
+        {
+            int b = byteContainer.get();
+
+            int cexcept = byteContainer.get() & 0xFF;
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
             {
-                int b = byteContainer.get();
+                BitPacking.fastunpack(@in, tmpinpos, @out,
+                    tmpoutpos + k, b);
+                tmpinpos += b;
+            }
+            if (cexcept > 0)
+            {
+                int maxbits = byteContainer.get();
 
-                int cexcept = byteContainer.get() & 0xFF;
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
+                int index = maxbits - b;
+                if (index == 1)
                 {
-                    BitPacking.fastunpack(@in, tmpinpos, @out,
-                        tmpoutpos + k, b);
-                    tmpinpos += b;
-                }
-                if (cexcept > 0)
-                {
-                    int maxbits = byteContainer.get();
-
-                    int index = maxbits - b;
-                    if (index == 1)
+                    for (int k = 0; k < cexcept; ++k)
                     {
-                        for (int k = 0; k < cexcept; ++k)
-                        {
 
-                            int pos = byteContainer.get() & 0xFF;
-                            @out[pos + tmpoutpos] |= 1 << b;
-                        }
+                        int pos = byteContainer.get() & 0xFF;
+                        @out[pos + tmpoutpos] |= 1 << b;
                     }
-                    else
+                }
+                else
+                {
+                    for (int k = 0; k < cexcept; ++k)
                     {
-                        for (int k = 0; k < cexcept; ++k)
-                        {
 
-                            int pos = byteContainer.get() & 0xFF;
+                        int pos = byteContainer.get() & 0xFF;
 
-                            int exceptvalue = dataTobePacked[index][dataPointers[index]++];
-                            @out[pos + tmpoutpos] |= exceptvalue << b;
-                        }
+                        int exceptvalue = dataTobePacked[index][dataPointers[index]++];
+                        @out[pos + tmpoutpos] |= exceptvalue << b;
                     }
                 }
             }
-            outpos.set(tmpoutpos);
-            inpos.set(inexcept);
         }
+        outpos.set(tmpoutpos);
+        inpos.set(inexcept);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
 
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
 
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
-        }
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
+    }
 
-        public override string ToString()
-        {
-            return nameof(FastPFOR128);
-        }
+    public override string ToString()
+    {
+        return nameof(FastPFOR128);
     }
 }

--- a/src/CSharpFastPFOR/FastPFOR128.cs
+++ b/src/CSharpFastPFOR/FastPFOR128.cs
@@ -28,14 +28,14 @@ public class FastPFOR128 : IntegerCODEC, SkippableIntegerCODEC
     private const int DEFAULT_PAGE_SIZE = 65536;
     public const int BLOCK_SIZE = 128;
 
-    private int pageSize;
-    private int[][] dataTobePacked = new int[33][];
-    private ByteBuffer byteContainer;
+    private readonly int pageSize;
+    private readonly int[][] dataTobePacked = new int[33][];
+    private readonly ByteBuffer byteContainer;
 
     // Working area for compress and uncompress.
-    private int[] dataPointers = new int[33];
-    private int[] freqs = new int[33];
-    private int[] bestbbestcexceptmaxb = new int[3];
+    private readonly int[] dataPointers = new int[33];
+    private readonly int[] freqs = new int[33];
+    private readonly int[] bestbbestcexceptmaxb = new int[3];
 
     /**
      * Construct the FastPFOR CODEC.

--- a/src/CSharpFastPFOR/IntCompressor.cs
+++ b/src/CSharpFastPFOR/IntCompressor.cs
@@ -44,7 +44,7 @@ public class IntCompressor
     {
         int[] compressed = new int[input.Length + 1024];
         compressed[0] = input.Length;
-        IntWrapper outpos = new IntWrapper(1);
+        var outpos = new IntWrapper(1);
         codec.headlessCompress(input, new IntWrapper(0), input.Length, compressed, outpos);
         compressed = Arrays.copyOf(compressed, outpos.intValue());
         return compressed;

--- a/src/CSharpFastPFOR/IntCompressor.cs
+++ b/src/CSharpFastPFOR/IntCompressor.cs
@@ -14,7 +14,7 @@ namespace Genbox.CSharpFastPFOR;
 
 public class IntCompressor
 {
-    private SkippableIntegerCODEC codec;
+    private readonly SkippableIntegerCODEC codec;
 
     /**
      * Constructor wrapping a codec.

--- a/src/CSharpFastPFOR/IntCompressor.cs
+++ b/src/CSharpFastPFOR/IntCompressor.cs
@@ -10,58 +10,57 @@
 
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class IntCompressor
 {
-    public class IntCompressor
+    private SkippableIntegerCODEC codec;
+
+    /**
+     * Constructor wrapping a codec.
+     * 
+     * @param c the underlying codec
+     */
+    public IntCompressor(SkippableIntegerCODEC c)
     {
-        private SkippableIntegerCODEC codec;
+        codec = c;
+    }
 
-        /**
-         * Constructor wrapping a codec.
-         * 
-         * @param c the underlying codec
-         */
-        public IntCompressor(SkippableIntegerCODEC c)
-        {
-            codec = c;
-        }
+    /**
+     * Constructor with default codec.
+     */
+    public IntCompressor()
+    {
+        codec = new SkippableComposition(new BinaryPacking(), new VariableByte());
+    }
 
-        /**
-         * Constructor with default codec.
-         */
-        public IntCompressor()
-        {
-            codec = new SkippableComposition(new BinaryPacking(), new VariableByte());
-        }
+    /**
+     * Compress an array and returns the compressed result as a new array.
+     * 
+     * @param input array to be compressed
+     * @return compressed array
+     */
+    public int[] compress(int[] input)
+    {
+        int[] compressed = new int[input.Length + 1024];
+        compressed[0] = input.Length;
+        IntWrapper outpos = new IntWrapper(1);
+        codec.headlessCompress(input, new IntWrapper(0), input.Length, compressed, outpos);
+        compressed = Arrays.copyOf(compressed, outpos.intValue());
+        return compressed;
+    }
 
-        /**
-         * Compress an array and returns the compressed result as a new array.
-         * 
-         * @param input array to be compressed
-         * @return compressed array
-         */
-        public int[] compress(int[] input)
-        {
-            int[] compressed = new int[input.Length + 1024];
-            compressed[0] = input.Length;
-            IntWrapper outpos = new IntWrapper(1);
-            codec.headlessCompress(input, new IntWrapper(0), input.Length, compressed, outpos);
-            compressed = Arrays.copyOf(compressed, outpos.intValue());
-            return compressed;
-        }
-
-        /**
-         * Uncompress an array and returns the uncompressed result as a new array.
-         * 
-         * @param compressed compressed array
-         * @return uncompressed array
-         */
-        public int[] uncompress(int[] compressed)
-        {
-            int[] decompressed = new int[compressed[0]];
-            IntWrapper inpos = new IntWrapper(1);
-            codec.headlessUncompress(compressed, inpos, compressed.Length - inpos.intValue(), decompressed, new IntWrapper(0), decompressed.Length);
-            return decompressed;
-        }
+    /**
+     * Uncompress an array and returns the uncompressed result as a new array.
+     * 
+     * @param compressed compressed array
+     * @return uncompressed array
+     */
+    public int[] uncompress(int[] compressed)
+    {
+        int[] decompressed = new int[compressed[0]];
+        IntWrapper inpos = new IntWrapper(1);
+        codec.headlessUncompress(compressed, inpos, compressed.Length - inpos.intValue(), decompressed, new IntWrapper(0), decompressed.Length);
+        return decompressed;
     }
 }

--- a/src/CSharpFastPFOR/IntCompressor.cs
+++ b/src/CSharpFastPFOR/IntCompressor.cs
@@ -59,7 +59,7 @@ public class IntCompressor
     public int[] uncompress(int[] compressed)
     {
         int[] decompressed = new int[compressed[0]];
-        IntWrapper inpos = new IntWrapper(1);
+        var inpos = new IntWrapper(1);
         codec.headlessUncompress(compressed, inpos, compressed.Length - inpos.intValue(), decompressed, new IntWrapper(0), decompressed.Length);
         return decompressed;
     }

--- a/src/CSharpFastPFOR/IntWrapper.cs
+++ b/src/CSharpFastPFOR/IntWrapper.cs
@@ -9,90 +9,89 @@
  * 
  * @author dwu
  */
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class IntWrapper
 {
-    public class IntWrapper
+    private int value;
+
+    /**
+     * Constructor: value set to 0.
+     */
+    public IntWrapper() : this(0)
     {
-        private int value;
+    }
 
-        /**
-         * Constructor: value set to 0.
-         */
-        public IntWrapper() : this(0)
-        {
-        }
+    /**
+     * Construction: value set to provided argument.
+     * 
+     * @param v
+     *                value to wrap
+     */
+    public IntWrapper(int v)
+    {
+        this.value = v;
+    }
 
-        /**
-         * Construction: value set to provided argument.
-         * 
-         * @param v
-         *                value to wrap
-         */
-        public IntWrapper(int v)
-        {
-            this.value = v;
-        }
-
-        /**
-         * add the provided value to the integer
-         * @param v value to add
-         */
-        public void add(int v)
-        {
-            this.value += v;
-        }
+    /**
+     * add the provided value to the integer
+     * @param v value to add
+     */
+    public void add(int v)
+    {
+        this.value += v;
+    }
 
 
-        public double doubleValue()
-        {
-            return this.value;
-        }
+    public double doubleValue()
+    {
+        return this.value;
+    }
 
-        public float floatValue()
-        {
-            return this.value;
-        }
+    public float floatValue()
+    {
+        return this.value;
+    }
 
-        /**
-         * @return the integer value
-         */
-        public int get()
-        {
-            return this.value;
-        }
+    /**
+     * @return the integer value
+     */
+    public int get()
+    {
+        return this.value;
+    }
 
-        /**
-         * add 1 to the integer value
-         */
-        public void increment()
-        {
-            this.value++;
-        }
+    /**
+     * add 1 to the integer value
+     */
+    public void increment()
+    {
+        this.value++;
+    }
 
-        public int intValue()
-        {
-            return this.value;
-        }
+    public int intValue()
+    {
+        return this.value;
+    }
 
-        public long longValue()
-        {
-            return this.value;
-        }
+    public long longValue()
+    {
+        return this.value;
+    }
 
-        /**
-         * Set the value to that of the specified integer.
-         * 
-         * @param value
-         *                specified integer value
-         */
-        public void set(int value)
-        {
-            this.value = value;
-        }
+    /**
+     * Set the value to that of the specified integer.
+     * 
+     * @param value
+     *                specified integer value
+     */
+    public void set(int value)
+    {
+        this.value = value;
+    }
 
-        public override string ToString()
-        {
-            return value.ToString();
-        }
+    public override string ToString()
+    {
+        return value.ToString();
     }
 }

--- a/src/CSharpFastPFOR/IntegerCODEC.cs
+++ b/src/CSharpFastPFOR/IntegerCODEC.cs
@@ -11,49 +11,48 @@
  * @author Daniel Lemire
  * 
  */
-namespace Genbox.CSharpFastPFOR
-{
-    public interface IntegerCODEC
-    {
-        /**
-         * Compress data from an array to another array.
-         * 
-         * Both inpos and outpos are modified to represent how much data was
-         * read and written to if 12 ints (inlength = 12) are compressed to 3
-         * ints, then inpos will be incremented by 12 while outpos will be
-         * incremented by 3 we use IntWrapper to pass the values by reference.
-         * 
-         * @param in
-         *                input array
-         * @param inpos
-         *                location in the input array
-         * @param inlength
-         *                how many integers to compress
-         * @param out
-         *                output array
-         * @param outpos
-         *                where to write in the output array
-         */
-        void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos);
+namespace Genbox.CSharpFastPFOR;
 
-        /**
-         * Uncompress data from an array to another array.
-         * 
-         * Both inpos and outpos parameters are modified to indicate new
-         * positions after read/write.
-         * 
-         * @param in
-         *                array containing data in compressed form
-         * @param inpos
-         *                where to start reading in the array
-         * @param inlength
-         *                length of the compressed data (ignored by some
-         *                schemes)
-         * @param out
-         *                array where to write the compressed output
-         * @param outpos
-         *                where to write the compressed output in out
-         */
-        void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos);
-    }
+public interface IntegerCODEC
+{
+    /**
+     * Compress data from an array to another array.
+     * 
+     * Both inpos and outpos are modified to represent how much data was
+     * read and written to if 12 ints (inlength = 12) are compressed to 3
+     * ints, then inpos will be incremented by 12 while outpos will be
+     * incremented by 3 we use IntWrapper to pass the values by reference.
+     * 
+     * @param in
+     *                input array
+     * @param inpos
+     *                location in the input array
+     * @param inlength
+     *                how many integers to compress
+     * @param out
+     *                output array
+     * @param outpos
+     *                where to write in the output array
+     */
+    void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos);
+
+    /**
+     * Uncompress data from an array to another array.
+     * 
+     * Both inpos and outpos parameters are modified to indicate new
+     * positions after read/write.
+     * 
+     * @param in
+     *                array containing data in compressed form
+     * @param inpos
+     *                where to start reading in the array
+     * @param inlength
+     *                length of the compressed data (ignored by some
+     *                schemes)
+     * @param out
+     *                array where to write the compressed output
+     * @param outpos
+     *                where to write the compressed output in out
+     */
+    void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos);
 }

--- a/src/CSharpFastPFOR/JustCopy.cs
+++ b/src/CSharpFastPFOR/JustCopy.cs
@@ -12,37 +12,36 @@
 
 using System;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class JustCopy : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class JustCopy : IntegerCODEC, SkippableIntegerCODEC
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
     {
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            Array.Copy(@in, inpos.get(), @out, outpos.get(), inlength);
-            inpos.add(inlength);
-            outpos.add(inlength);
-        }
+        Array.Copy(@in, inpos.get(), @out, outpos.get(), inlength);
+        inpos.add(inlength);
+        outpos.add(inlength);
+    }
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            headlessUncompress(@in, inpos, inlength, @out, outpos, inlength);
-        }
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        headlessUncompress(@in, inpos, inlength, @out, outpos, inlength);
+    }
 
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num)
-        {
-            Array.Copy(@in, inpos.get(), @out, outpos.get(), num);
-            inpos.add(num);
-            outpos.add(num);
-        }
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num)
+    {
+        Array.Copy(@in, inpos.get(), @out, outpos.get(), num);
+        inpos.add(num);
+        outpos.add(num);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public override string ToString()
-        {
-            return nameof(JustCopy);
-        }
+    public override string ToString()
+    {
+        return nameof(JustCopy);
     }
 }

--- a/src/CSharpFastPFOR/NewPFD.cs
+++ b/src/CSharpFastPFOR/NewPFD.cs
@@ -31,166 +31,165 @@
 * 
 * @author Daniel Lemire
 */
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class NewPFD : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class NewPFD : IntegerCODEC, SkippableIntegerCODEC
+    private const int BLOCK_SIZE = 128;
+
+    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+
+    /**
+     * Constructor for the NewPFD CODEC.
+     */
+    public NewPFD()
     {
-        private const int BLOCK_SIZE = 128;
+    }
 
-        private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        encodePage(@in, inpos, inlength, @out, outpos);
+    }
 
-        /**
-         * Constructor for the NewPFD CODEC.
-         */
-        public NewPFD()
+    protected static int[] bits = { 0, 1, 2, 3, 4, 5,
+                                    6, 7, 8, 9, 10, 11,
+                                    12, 13, 16, 20, 32 };
+
+    protected static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                                       10, 11, 12, 13, 14, 14, 14, 15,
+                                       15, 15, 15, 16, 16, 16, 16, 16,
+                                       16, 16, 16, 16, 16, 16, 16 };
+
+    protected static void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
+    {
+        int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
+        int mini = 0;
+        if (mini + 28 < bits[invbits[mb]])
+            mini = bits[invbits[mb]] - 28; // 28 is the max for
+        // exceptions
+        int besti = bits.Length - 1;
+        int exceptcounter = 0;
+        for (int i = mini; i < bits.Length - 1; ++i)
         {
-        }
-
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            encodePage(@in, inpos, inlength, @out, outpos);
-        }
-
-        protected static int[] bits = { 0, 1, 2, 3, 4, 5,
-                                        6, 7, 8, 9, 10, 11,
-                                        12, 13, 16, 20, 32 };
-
-        protected static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-                                           10, 11, 12, 13, 14, 14, 14, 15,
-                                           15, 15, 15, 16, 16, 16, 16, 16,
-                                           16, 16, 16, 16, 16, 16, 16 };
-
-        protected static void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
-        {
-            int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
-            int mini = 0;
-            if (mini + 28 < bits[invbits[mb]])
-                mini = bits[invbits[mb]] - 28; // 28 is the max for
-            // exceptions
-            int besti = bits.Length - 1;
-            int exceptcounter = 0;
-            for (int i = mini; i < bits.Length - 1; ++i)
+            int tmpcounter = 0;
+            for (int k = pos; k < BLOCK_SIZE + pos; ++k)
+                if ((int)((uint)@in[k] >> bits[i]) != 0)
+                    ++tmpcounter;
+            if (tmpcounter * 10 <= BLOCK_SIZE)
             {
-                int tmpcounter = 0;
-                for (int k = pos; k < BLOCK_SIZE + pos; ++k)
-                    if ((int)((uint)@in[k] >> bits[i]) != 0)
-                        ++tmpcounter;
-                if (tmpcounter * 10 <= BLOCK_SIZE)
-                {
-                    besti = i;
-                    exceptcounter = tmpcounter;
-                    break;
-                }
+                besti = i;
+                exceptcounter = tmpcounter;
+                break;
             }
-            bestb.set(besti);
-            bestexcept.set(exceptcounter);
         }
+        bestb.set(besti);
+        bestexcept.set(exceptcounter);
+    }
 
-        private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
+    private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
+        IntWrapper bestb = new IntWrapper();
+        IntWrapper bestexcept = new IntWrapper();
+        for (int finalinpos = tmpinpos + thissize; tmpinpos
+                                                               + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
         {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-            IntWrapper bestb = new IntWrapper();
-            IntWrapper bestexcept = new IntWrapper();
-            for (int finalinpos = tmpinpos + thissize; tmpinpos
-                                                                   + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
+            getBestBFromData(@in, tmpinpos, bestb, bestexcept);
+            int tmpbestb = bestb.get();
+            int nbrexcept = bestexcept.get();
+            int exceptsize = 0;
+            int remember = tmpoutpos;
+            tmpoutpos++;
+            if (nbrexcept > 0)
             {
-                getBestBFromData(@in, tmpinpos, bestb, bestexcept);
-                int tmpbestb = bestb.get();
-                int nbrexcept = bestexcept.get();
-                int exceptsize = 0;
-                int remember = tmpoutpos;
-                tmpoutpos++;
-                if (nbrexcept > 0)
+                for (int i = 0, c = 0; i < BLOCK_SIZE; ++i)
                 {
-                    for (int i = 0, c = 0; i < BLOCK_SIZE; ++i)
+                    if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
                     {
-                        if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
-                        {
-                            exceptbuffer[c + nbrexcept] = i;
-                            exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
-                            ++c;
-                        }
+                        exceptbuffer[c + nbrexcept] = i;
+                        exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
+                        ++c;
                     }
-                    exceptsize = S16.compress(exceptbuffer, 0,
-                        2 * nbrexcept, @out, tmpoutpos);
-                    tmpoutpos += exceptsize;
                 }
-                @out[remember] = tmpbestb | (nbrexcept << 8)
-                                 | (exceptsize << 16);
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastpack(@in, tmpinpos + k, @out,
-                        tmpoutpos, bits[tmpbestb]);
-                    tmpoutpos += bits[tmpbestb];
-                }
+                exceptsize = S16.compress(exceptbuffer, 0,
+                    2 * nbrexcept, @out, tmpoutpos);
+                tmpoutpos += exceptsize;
             }
-            inpos.set(tmpinpos);
-            outpos.set(tmpoutpos);
-        }
-
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
-        {
-            if (inlength == 0)
-                return;
-            mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
-            decodePage(@in, inpos, @out, outpos, mynvalue);
-        }
-
-        private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
-        {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-
-            for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
+            @out[remember] = tmpbestb | (nbrexcept << 8)
+                             | (exceptsize << 16);
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
             {
-                int b = @in[tmpinpos] & 0xFF;
-                int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
-                int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
-                ++tmpinpos;
-                S16.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
-                    0, 2 * cexcept);
-                tmpinpos += exceptsize;
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastunpack(@in, tmpinpos, @out,
-                        tmpoutpos + k, bits[b]);
-                    tmpinpos += bits[b];
-                }
-                for (int k = 0; k < cexcept; ++k)
-                {
-                    @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
-                }
+                BitPacking.fastpack(@in, tmpinpos + k, @out,
+                    tmpoutpos, bits[tmpbestb]);
+                tmpoutpos += bits[tmpbestb];
             }
-            outpos.set(tmpoutpos);
-            inpos.set(tmpinpos);
         }
+        inpos.set(tmpinpos);
+        outpos.set(tmpoutpos);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
+    {
+        if (inlength == 0)
+            return;
+        mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
+        decodePage(@in, inpos, @out, outpos, mynvalue);
+    }
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
-        }
+    private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
 
-        public override string ToString()
+        for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
         {
-            return nameof(NewPFD);
+            int b = @in[tmpinpos] & 0xFF;
+            int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
+            int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
+            ++tmpinpos;
+            S16.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
+                0, 2 * cexcept);
+            tmpinpos += exceptsize;
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
+            {
+                BitPacking.fastunpack(@in, tmpinpos, @out,
+                    tmpoutpos + k, bits[b]);
+                tmpinpos += bits[b];
+            }
+            for (int k = 0; k < cexcept; ++k)
+            {
+                @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
+            }
         }
+        outpos.set(tmpoutpos);
+        inpos.set(tmpinpos);
+    }
+
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
+
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
+    }
+
+    public override string ToString()
+    {
+        return nameof(NewPFD);
     }
 }

--- a/src/CSharpFastPFOR/NewPFD.cs
+++ b/src/CSharpFastPFOR/NewPFD.cs
@@ -37,7 +37,7 @@ public class NewPFD : IntegerCODEC, SkippableIntegerCODEC
 {
     private const int BLOCK_SIZE = 128;
 
-    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    private readonly int[] exceptbuffer = new int[2 * BLOCK_SIZE];
 
     /**
      * Constructor for the NewPFD CODEC.

--- a/src/CSharpFastPFOR/NewPFD.cs
+++ b/src/CSharpFastPFOR/NewPFD.cs
@@ -93,8 +93,8 @@ public class NewPFD : IntegerCODEC, SkippableIntegerCODEC
     {
         int tmpoutpos = outpos.get();
         int tmpinpos = inpos.get();
-        IntWrapper bestb = new IntWrapper();
-        IntWrapper bestexcept = new IntWrapper();
+        var bestb = new IntWrapper();
+        var bestexcept = new IntWrapper();
         for (int finalinpos = tmpinpos + thissize; tmpinpos
                                                                + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
         {

--- a/src/CSharpFastPFOR/NewPFDS16.cs
+++ b/src/CSharpFastPFOR/NewPFDS16.cs
@@ -30,165 +30,164 @@
  * 
  * @author Daniel Lemire
  */
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class NewPFDS16 : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class NewPFDS16 : IntegerCODEC, SkippableIntegerCODEC
+    private const int BLOCK_SIZE = 128;
+
+    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+
+    /**
+     * Constructor for the NewPFDS16 CODEC.
+     */
+    public NewPFDS16()
     {
-        private const int BLOCK_SIZE = 128;
+    }
 
-        private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        encodePage(@in, inpos, inlength, @out, outpos);
+    }
 
-        /**
-         * Constructor for the NewPFDS16 CODEC.
-         */
-        public NewPFDS16()
+    private static int[] bits = { 0, 1, 2, 3, 4, 5,
+                                  6, 7, 8, 9, 10, 11,
+                                 12, 13, 16, 20, 32 };
+
+    private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16 };
+
+    private static void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
+    {
+        int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
+        int mini = 0;
+        if (mini + 28 < bits[invbits[mb]])
+            mini = bits[invbits[mb]] - 28; // 28 is the max for
+        // exceptions
+        int besti = bits.Length - 1;
+        int exceptcounter = 0;
+        for (int i = mini; i < bits.Length - 1; ++i)
         {
-        }
-
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            encodePage(@in, inpos, inlength, @out, outpos);
-        }
-
-        private static int[] bits = { 0, 1, 2, 3, 4, 5,
-                                      6, 7, 8, 9, 10, 11,
-                                     12, 13, 16, 20, 32 };
-
-        private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-            10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
-            16, 16, 16, 16, 16, 16, 16 };
-
-        private static void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
-        {
-            int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
-            int mini = 0;
-            if (mini + 28 < bits[invbits[mb]])
-                mini = bits[invbits[mb]] - 28; // 28 is the max for
-            // exceptions
-            int besti = bits.Length - 1;
-            int exceptcounter = 0;
-            for (int i = mini; i < bits.Length - 1; ++i)
+            int tmpcounter = 0;
+            for (int k = pos; k < BLOCK_SIZE + pos; ++k)
+                if ((int)((uint)@in[k] >> bits[i]) != 0)
+                    ++tmpcounter;
+            if (tmpcounter * 10 <= BLOCK_SIZE)
             {
-                int tmpcounter = 0;
-                for (int k = pos; k < BLOCK_SIZE + pos; ++k)
-                    if ((int)((uint)@in[k] >> bits[i]) != 0)
-                        ++tmpcounter;
-                if (tmpcounter * 10 <= BLOCK_SIZE)
-                {
-                    besti = i;
-                    exceptcounter = tmpcounter;
-                    break;
-                }
+                besti = i;
+                exceptcounter = tmpcounter;
+                break;
             }
-            bestb.set(besti);
-            bestexcept.set(exceptcounter);
         }
+        bestb.set(besti);
+        bestexcept.set(exceptcounter);
+    }
 
-        private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
+    private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
+        IntWrapper bestb = new IntWrapper();
+        IntWrapper bestexcept = new IntWrapper();
+        for (int finalinpos = tmpinpos + thissize; tmpinpos
+                                                               + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
         {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-            IntWrapper bestb = new IntWrapper();
-            IntWrapper bestexcept = new IntWrapper();
-            for (int finalinpos = tmpinpos + thissize; tmpinpos
-                                                                   + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
+            getBestBFromData(@in, tmpinpos, bestb, bestexcept);
+            int tmpbestb = bestb.get();
+            int nbrexcept = bestexcept.get();
+            int exceptsize = 0;
+            int remember = tmpoutpos;
+            tmpoutpos++;
+            if (nbrexcept > 0)
             {
-                getBestBFromData(@in, tmpinpos, bestb, bestexcept);
-                int tmpbestb = bestb.get();
-                int nbrexcept = bestexcept.get();
-                int exceptsize = 0;
-                int remember = tmpoutpos;
-                tmpoutpos++;
-                if (nbrexcept > 0)
+                for (int i = 0, c = 0; i < BLOCK_SIZE; ++i)
                 {
-                    for (int i = 0, c = 0; i < BLOCK_SIZE; ++i)
+                    if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
                     {
-                        if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
-                        {
-                            exceptbuffer[c + nbrexcept] = i;
-                            exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
-                            ++c;
-                        }
+                        exceptbuffer[c + nbrexcept] = i;
+                        exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
+                        ++c;
                     }
-                    exceptsize = S16.compress(exceptbuffer, 0,
-                        2 * nbrexcept, @out, tmpoutpos);
-                    tmpoutpos += exceptsize;
                 }
-                @out[remember] = tmpbestb | (nbrexcept << 8)
-                                 | (exceptsize << 16);
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastpack(@in, tmpinpos + k, @out,
-                        tmpoutpos, bits[tmpbestb]);
-                    tmpoutpos += bits[tmpbestb];
-                }
+                exceptsize = S16.compress(exceptbuffer, 0,
+                    2 * nbrexcept, @out, tmpoutpos);
+                tmpoutpos += exceptsize;
             }
-            inpos.set(tmpinpos);
-            outpos.set(tmpoutpos);
-        }
-
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
-        {
-            if (inlength == 0)
-                return;
-            mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
-            decodePage(@in, inpos, @out, outpos, mynvalue);
-        }
-
-        private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
-        {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-
-            for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
+            @out[remember] = tmpbestb | (nbrexcept << 8)
+                             | (exceptsize << 16);
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
             {
-                int b = @in[tmpinpos] & 0xFF;
-                int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
-                int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
-                ++tmpinpos;
-                S16.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
-                    0, 2 * cexcept);
-                tmpinpos += exceptsize;
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastunpack(@in, tmpinpos, @out,
-                        tmpoutpos + k, bits[b]);
-                    tmpinpos += bits[b];
-                }
-                for (int k = 0; k < cexcept; ++k)
-                {
-                    @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
-                }
+                BitPacking.fastpack(@in, tmpinpos + k, @out,
+                    tmpoutpos, bits[tmpbestb]);
+                tmpoutpos += bits[tmpbestb];
             }
-            outpos.set(tmpoutpos);
-            inpos.set(tmpinpos);
         }
+        inpos.set(tmpinpos);
+        outpos.set(tmpoutpos);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
+    {
+        if (inlength == 0)
+            return;
+        mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
+        decodePage(@in, inpos, @out, outpos, mynvalue);
+    }
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
-        }
+    private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
 
-        public override string ToString()
+        for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
         {
-            return nameof(NewPFDS16);
+            int b = @in[tmpinpos] & 0xFF;
+            int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
+            int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
+            ++tmpinpos;
+            S16.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
+                0, 2 * cexcept);
+            tmpinpos += exceptsize;
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
+            {
+                BitPacking.fastunpack(@in, tmpinpos, @out,
+                    tmpoutpos + k, bits[b]);
+                tmpinpos += bits[b];
+            }
+            for (int k = 0; k < cexcept; ++k)
+            {
+                @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
+            }
         }
+        outpos.set(tmpoutpos);
+        inpos.set(tmpinpos);
+    }
+
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
+
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
+    }
+
+    public override string ToString()
+    {
+        return nameof(NewPFDS16);
     }
 }

--- a/src/CSharpFastPFOR/NewPFDS16.cs
+++ b/src/CSharpFastPFOR/NewPFDS16.cs
@@ -91,8 +91,8 @@ public class NewPFDS16 : IntegerCODEC, SkippableIntegerCODEC
     {
         int tmpoutpos = outpos.get();
         int tmpinpos = inpos.get();
-        IntWrapper bestb = new IntWrapper();
-        IntWrapper bestexcept = new IntWrapper();
+        var bestb = new IntWrapper();
+        var bestexcept = new IntWrapper();
         for (int finalinpos = tmpinpos + thissize; tmpinpos
                                                                + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
         {

--- a/src/CSharpFastPFOR/NewPFDS16.cs
+++ b/src/CSharpFastPFOR/NewPFDS16.cs
@@ -36,7 +36,7 @@ public class NewPFDS16 : IntegerCODEC, SkippableIntegerCODEC
 {
     private const int BLOCK_SIZE = 128;
 
-    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    private readonly int[] exceptbuffer = new int[2 * BLOCK_SIZE];
 
     /**
      * Constructor for the NewPFDS16 CODEC.
@@ -53,11 +53,11 @@ public class NewPFDS16 : IntegerCODEC, SkippableIntegerCODEC
         encodePage(@in, inpos, inlength, @out, outpos);
     }
 
-    private static int[] bits = { 0, 1, 2, 3, 4, 5,
+    private static readonly int[] bits = { 0, 1, 2, 3, 4, 5,
                                   6, 7, 8, 9, 10, 11,
                                  12, 13, 16, 20, 32 };
 
-    private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    private static readonly int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
         10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
         16, 16, 16, 16, 16, 16, 16 };
 

--- a/src/CSharpFastPFOR/NewPFDS16.cs
+++ b/src/CSharpFastPFOR/NewPFDS16.cs
@@ -32,7 +32,7 @@
  */
 namespace Genbox.CSharpFastPFOR;
 
-public class NewPFDS16 : IntegerCODEC, SkippableIntegerCODEC
+public sealed class NewPFDS16 : IntegerCODEC, SkippableIntegerCODEC
 {
     private const int BLOCK_SIZE = 128;
 

--- a/src/CSharpFastPFOR/NewPFDS9.cs
+++ b/src/CSharpFastPFOR/NewPFDS9.cs
@@ -35,7 +35,7 @@ public class NewPFDS9 : IntegerCODEC, SkippableIntegerCODEC
 {
     private const int BLOCK_SIZE = 128;
 
-    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    private readonly int[] exceptbuffer = new int[2 * BLOCK_SIZE];
 
     /**
      * Constructor for the NewPFDS9 CODEC.
@@ -52,9 +52,9 @@ public class NewPFDS9 : IntegerCODEC, SkippableIntegerCODEC
         encodePage(@in, inpos, inlength, @out, outpos);
     }
 
-    private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    private static readonly int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
         11, 12, 13, 16, 20, 32 };
-    private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    private static readonly int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
         10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
         16, 16, 16, 16, 16, 16, 16 };
 

--- a/src/CSharpFastPFOR/NewPFDS9.cs
+++ b/src/CSharpFastPFOR/NewPFDS9.cs
@@ -29,163 +29,162 @@
  * 
  * @author Daniel Lemire
  */
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class NewPFDS9 : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class NewPFDS9 : IntegerCODEC, SkippableIntegerCODEC
+    private const int BLOCK_SIZE = 128;
+
+    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+
+    /**
+     * Constructor for the NewPFDS9 CODEC.
+     */
+    public NewPFDS9()
     {
-        private const int BLOCK_SIZE = 128;
+    }
 
-        private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        encodePage(@in, inpos, inlength, @out, outpos);
+    }
 
-        /**
-         * Constructor for the NewPFDS9 CODEC.
-         */
-        public NewPFDS9()
+    private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        11, 12, 13, 16, 20, 32 };
+    private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16 };
+
+    private static void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
+    {
+        int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
+        int mini = 0;
+        if (mini + 28 < bits[invbits[mb]])
+            mini = bits[invbits[mb]] - 28; // 28 is the max for
+        // exceptions
+        int besti = bits.Length - 1;
+        int exceptcounter = 0;
+        for (int i = mini; i < bits.Length - 1; ++i)
         {
-        }
-
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            encodePage(@in, inpos, inlength, @out, outpos);
-        }
-
-        private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-            11, 12, 13, 16, 20, 32 };
-        private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-            10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
-            16, 16, 16, 16, 16, 16, 16 };
-
-        private static void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
-        {
-            int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
-            int mini = 0;
-            if (mini + 28 < bits[invbits[mb]])
-                mini = bits[invbits[mb]] - 28; // 28 is the max for
-            // exceptions
-            int besti = bits.Length - 1;
-            int exceptcounter = 0;
-            for (int i = mini; i < bits.Length - 1; ++i)
+            int tmpcounter = 0;
+            for (int k = pos; k < BLOCK_SIZE + pos; ++k)
+                if ((int)((uint)@in[k] >> bits[i]) != 0)
+                    ++tmpcounter;
+            if (tmpcounter * 10 <= BLOCK_SIZE)
             {
-                int tmpcounter = 0;
-                for (int k = pos; k < BLOCK_SIZE + pos; ++k)
-                    if ((int)((uint)@in[k] >> bits[i]) != 0)
-                        ++tmpcounter;
-                if (tmpcounter * 10 <= BLOCK_SIZE)
-                {
-                    besti = i;
-                    exceptcounter = tmpcounter;
-                    break;
-                }
+                besti = i;
+                exceptcounter = tmpcounter;
+                break;
             }
-            bestb.set(besti);
-            bestexcept.set(exceptcounter);
         }
+        bestb.set(besti);
+        bestexcept.set(exceptcounter);
+    }
 
-        private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
+    private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
+        IntWrapper bestb = new IntWrapper();
+        IntWrapper bestexcept = new IntWrapper();
+        for (int finalinpos = tmpinpos + thissize; tmpinpos
+                                                               + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
         {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-            IntWrapper bestb = new IntWrapper();
-            IntWrapper bestexcept = new IntWrapper();
-            for (int finalinpos = tmpinpos + thissize; tmpinpos
-                                                                   + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
+            getBestBFromData(@in, tmpinpos, bestb, bestexcept);
+            int tmpbestb = bestb.get();
+            int nbrexcept = bestexcept.get();
+            int exceptsize = 0;
+            int remember = tmpoutpos;
+            tmpoutpos++;
+            if (nbrexcept > 0)
             {
-                getBestBFromData(@in, tmpinpos, bestb, bestexcept);
-                int tmpbestb = bestb.get();
-                int nbrexcept = bestexcept.get();
-                int exceptsize = 0;
-                int remember = tmpoutpos;
-                tmpoutpos++;
-                if (nbrexcept > 0)
+                for (int i = 0, c = 0; i < BLOCK_SIZE; ++i)
                 {
-                    for (int i = 0, c = 0; i < BLOCK_SIZE; ++i)
+                    if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
                     {
-                        if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
-                        {
-                            exceptbuffer[c + nbrexcept] = i;
-                            exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
-                            ++c;
-                        }
+                        exceptbuffer[c + nbrexcept] = i;
+                        exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
+                        ++c;
                     }
-                    exceptsize = S9.compress(exceptbuffer, 0,
-                        2 * nbrexcept, @out, tmpoutpos);
-                    tmpoutpos += exceptsize;
                 }
-                @out[remember] = tmpbestb | (nbrexcept << 8)
-                                 | (exceptsize << 16);
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastpack(@in, tmpinpos + k, @out,
-                        tmpoutpos, bits[tmpbestb]);
-                    tmpoutpos += bits[tmpbestb];
-                }
+                exceptsize = S9.compress(exceptbuffer, 0,
+                    2 * nbrexcept, @out, tmpoutpos);
+                tmpoutpos += exceptsize;
             }
-            inpos.set(tmpinpos);
-            outpos.set(tmpoutpos);
-        }
-
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
-        {
-            if (inlength == 0)
-                return;
-            mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
-            decodePage(@in, inpos, @out, outpos, mynvalue);
-        }
-
-        private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
-        {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-
-            for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
+            @out[remember] = tmpbestb | (nbrexcept << 8)
+                             | (exceptsize << 16);
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
             {
-                int b = @in[tmpinpos] & 0xFF;
-                int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
-                int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
-                ++tmpinpos;
-                S9.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
-                    0, 2 * cexcept);
-                tmpinpos += exceptsize;
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastunpack(@in, tmpinpos, @out,
-                        tmpoutpos + k, bits[b]);
-                    tmpinpos += bits[b];
-                }
-                for (int k = 0; k < cexcept; ++k)
-                {
-                    @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
-                }
+                BitPacking.fastpack(@in, tmpinpos + k, @out,
+                    tmpoutpos, bits[tmpbestb]);
+                tmpoutpos += bits[tmpbestb];
             }
-            outpos.set(tmpoutpos);
-            inpos.set(tmpinpos);
         }
+        inpos.set(tmpinpos);
+        outpos.set(tmpoutpos);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
+    {
+        if (inlength == 0)
+            return;
+        mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
+        decodePage(@in, inpos, @out, outpos, mynvalue);
+    }
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
-        }
+    private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
 
-        public override string ToString()
+        for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
         {
-            return nameof(NewPFDS9);
+            int b = @in[tmpinpos] & 0xFF;
+            int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
+            int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
+            ++tmpinpos;
+            S9.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
+                0, 2 * cexcept);
+            tmpinpos += exceptsize;
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
+            {
+                BitPacking.fastunpack(@in, tmpinpos, @out,
+                    tmpoutpos + k, bits[b]);
+                tmpinpos += bits[b];
+            }
+            for (int k = 0; k < cexcept; ++k)
+            {
+                @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
+            }
         }
+        outpos.set(tmpoutpos);
+        inpos.set(tmpinpos);
+    }
+
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
+
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
+    }
+
+    public override string ToString()
+    {
+        return nameof(NewPFDS9);
     }
 }

--- a/src/CSharpFastPFOR/NewPFDS9.cs
+++ b/src/CSharpFastPFOR/NewPFDS9.cs
@@ -54,6 +54,7 @@ public class NewPFDS9 : IntegerCODEC, SkippableIntegerCODEC
 
     private static readonly int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
         11, 12, 13, 16, 20, 32 };
+
     private static readonly int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
         10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
         16, 16, 16, 16, 16, 16, 16 };
@@ -88,8 +89,8 @@ public class NewPFDS9 : IntegerCODEC, SkippableIntegerCODEC
     {
         int tmpoutpos = outpos.get();
         int tmpinpos = inpos.get();
-        IntWrapper bestb = new IntWrapper();
-        IntWrapper bestexcept = new IntWrapper();
+        var bestb = new IntWrapper();
+        var bestexcept = new IntWrapper();
         for (int finalinpos = tmpinpos + thissize; tmpinpos
                                                                + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
         {

--- a/src/CSharpFastPFOR/OptPFD.cs
+++ b/src/CSharpFastPFOR/OptPFD.cs
@@ -104,8 +104,8 @@ public class OptPFD : IntegerCODEC, SkippableIntegerCODEC
     {
         int tmpoutpos = outpos.get();
         int tmpinpos = inpos.get();
-        IntWrapper bestb = new IntWrapper();
-        IntWrapper bestexcept = new IntWrapper();
+        var bestb = new IntWrapper();
+        var bestexcept = new IntWrapper();
         for (int finalinpos = tmpinpos + thissize; tmpinpos + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
         {
             getBestBFromData(@in, tmpinpos, bestb, bestexcept);

--- a/src/CSharpFastPFOR/OptPFD.cs
+++ b/src/CSharpFastPFOR/OptPFD.cs
@@ -36,7 +36,7 @@ public class OptPFD : IntegerCODEC, SkippableIntegerCODEC
 {
     private const int BLOCK_SIZE = 128;
 
-    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    private readonly int[] exceptbuffer = new int[2 * BLOCK_SIZE];
 
     /**
      * Constructor for the OptPFD CODEC.
@@ -53,9 +53,9 @@ public class OptPFD : IntegerCODEC, SkippableIntegerCODEC
         encodePage(@in, inpos, inlength, @out, outpos);
     }
 
-    private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    private static readonly int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
         11, 12, 13, 16, 20, 32 };
-    private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    private static readonly int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
         10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
         16, 16, 16, 16, 16, 16, 16 };
 

--- a/src/CSharpFastPFOR/OptPFD.cs
+++ b/src/CSharpFastPFOR/OptPFD.cs
@@ -30,178 +30,177 @@
  * 
  * @author Daniel Lemire
  */
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class OptPFD : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class OptPFD : IntegerCODEC, SkippableIntegerCODEC
+    private const int BLOCK_SIZE = 128;
+
+    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+
+    /**
+     * Constructor for the OptPFD CODEC.
+     */
+    public OptPFD()
     {
-        private const int BLOCK_SIZE = 128;
+    }
 
-        private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        encodePage(@in, inpos, inlength, @out, outpos);
+    }
 
-        /**
-         * Constructor for the OptPFD CODEC.
-         */
-        public OptPFD()
+    private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        11, 12, 13, 16, 20, 32 };
+    private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16 };
+
+    private void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
+    {
+        int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
+        int mini = 0;
+        if (mini + 28 < bits[invbits[mb]])
+            mini = bits[invbits[mb]] - 28; // 28 is the max for
+        // exceptions
+        int besti = bits.Length - 1;
+        int bestcost = bits[besti] * 4;
+        int exceptcounter = 0;
+        for (int i = mini; i < bits.Length - 1; ++i)
         {
-        }
+            int tmpcounter = 0;
+            for (int k = pos; k < BLOCK_SIZE + pos; ++k)
+                if ((int)((uint)@in[k] >> bits[i]) != 0)
+                {
+                    ++tmpcounter;
+                }
+            if (tmpcounter == BLOCK_SIZE)
+                continue; // no need
+            for (int k = pos, c = 0; k < pos + BLOCK_SIZE; ++k)
+                if ((int)((uint)@in[k] >> bits[i]) != 0)
+                {
+                    exceptbuffer[tmpcounter + c] = k - pos;
+                    exceptbuffer[c] = (int)((uint)@in[k] >> bits[i]);
+                    ++c;
+                }
 
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            encodePage(@in, inpos, inlength, @out, outpos);
-        }
-
-        private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-            11, 12, 13, 16, 20, 32 };
-        private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-            10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
-            16, 16, 16, 16, 16, 16, 16 };
-
-        private void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
-        {
-            int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
-            int mini = 0;
-            if (mini + 28 < bits[invbits[mb]])
-                mini = bits[invbits[mb]] - 28; // 28 is the max for
-            // exceptions
-            int besti = bits.Length - 1;
-            int bestcost = bits[besti] * 4;
-            int exceptcounter = 0;
-            for (int i = mini; i < bits.Length - 1; ++i)
+            int thiscost = bits[i] * 4 + S16.estimatecompress(exceptbuffer, 0, 2 * tmpcounter);
+            if (thiscost <= bestcost)
             {
-                int tmpcounter = 0;
-                for (int k = pos; k < BLOCK_SIZE + pos; ++k)
-                    if ((int)((uint)@in[k] >> bits[i]) != 0)
+                bestcost = thiscost;
+                besti = i;
+                exceptcounter = tmpcounter;
+            }
+        }
+
+        bestb.set(besti);
+        bestexcept.set(exceptcounter);
+    }
+
+    private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
+        IntWrapper bestb = new IntWrapper();
+        IntWrapper bestexcept = new IntWrapper();
+        for (int finalinpos = tmpinpos + thissize; tmpinpos + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
+        {
+            getBestBFromData(@in, tmpinpos, bestb, bestexcept);
+            int tmpbestb = bestb.get();
+            int nbrexcept = bestexcept.get();
+            int exceptsize = 0;
+            int remember = tmpoutpos;
+            tmpoutpos++;
+            if (nbrexcept > 0)
+            {
+                int c = 0;
+                for (int i = 0; i < BLOCK_SIZE; ++i)
+                {
+                    if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
                     {
-                        ++tmpcounter;
-                    }
-                if (tmpcounter == BLOCK_SIZE)
-                    continue; // no need
-                for (int k = pos, c = 0; k < pos + BLOCK_SIZE; ++k)
-                    if ((int)((uint)@in[k] >> bits[i]) != 0)
-                    {
-                        exceptbuffer[tmpcounter + c] = k - pos;
-                        exceptbuffer[c] = (int)((uint)@in[k] >> bits[i]);
+                        exceptbuffer[c + nbrexcept] = i;
+                        exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
                         ++c;
                     }
-
-                int thiscost = bits[i] * 4 + S16.estimatecompress(exceptbuffer, 0, 2 * tmpcounter);
-                if (thiscost <= bestcost)
-                {
-                    bestcost = thiscost;
-                    besti = i;
-                    exceptcounter = tmpcounter;
                 }
+                exceptsize = S16.compress(exceptbuffer, 0,
+                    2 * nbrexcept, @out, tmpoutpos);
+                tmpoutpos += exceptsize;
             }
-
-            bestb.set(besti);
-            bestexcept.set(exceptcounter);
-        }
-
-        private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
-        {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-            IntWrapper bestb = new IntWrapper();
-            IntWrapper bestexcept = new IntWrapper();
-            for (int finalinpos = tmpinpos + thissize; tmpinpos + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
+            @out[remember] = tmpbestb | (nbrexcept << 8)
+                             | (exceptsize << 16);
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
             {
-                getBestBFromData(@in, tmpinpos, bestb, bestexcept);
-                int tmpbestb = bestb.get();
-                int nbrexcept = bestexcept.get();
-                int exceptsize = 0;
-                int remember = tmpoutpos;
-                tmpoutpos++;
-                if (nbrexcept > 0)
-                {
-                    int c = 0;
-                    for (int i = 0; i < BLOCK_SIZE; ++i)
-                    {
-                        if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
-                        {
-                            exceptbuffer[c + nbrexcept] = i;
-                            exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
-                            ++c;
-                        }
-                    }
-                    exceptsize = S16.compress(exceptbuffer, 0,
-                        2 * nbrexcept, @out, tmpoutpos);
-                    tmpoutpos += exceptsize;
-                }
-                @out[remember] = tmpbestb | (nbrexcept << 8)
-                                 | (exceptsize << 16);
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastpack(@in, tmpinpos + k, @out,
-                        tmpoutpos, bits[tmpbestb]);
-                    tmpoutpos += bits[tmpbestb];
-                }
+                BitPacking.fastpack(@in, tmpinpos + k, @out,
+                    tmpoutpos, bits[tmpbestb]);
+                tmpoutpos += bits[tmpbestb];
             }
-            inpos.set(tmpinpos);
-            outpos.set(tmpoutpos);
         }
+        inpos.set(tmpinpos);
+        outpos.set(tmpoutpos);
+    }
 
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
+    {
+        if (inlength == 0)
+            return;
+        mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
+        decodePage(@in, inpos, @out, outpos, mynvalue);
+    }
+
+    private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
+
+        for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
         {
-            if (inlength == 0)
-                return;
-            mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
-            decodePage(@in, inpos, @out, outpos, mynvalue);
-        }
-
-        private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
-        {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-
-            for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
+            int b = @in[tmpinpos] & 0xFF;
+            int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
+            int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
+            ++tmpinpos;
+            S16.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
+                0, 2 * cexcept);
+            tmpinpos += exceptsize;
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
             {
-                int b = @in[tmpinpos] & 0xFF;
-                int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
-                int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
-                ++tmpinpos;
-                S16.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
-                    0, 2 * cexcept);
-                tmpinpos += exceptsize;
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastunpack(@in, tmpinpos, @out,
-                        tmpoutpos + k, bits[b]);
-                    tmpinpos += bits[b];
-                }
-                for (int k = 0; k < cexcept; ++k)
-                {
-                    @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
-                }
+                BitPacking.fastunpack(@in, tmpinpos, @out,
+                    tmpoutpos + k, bits[b]);
+                tmpinpos += bits[b];
             }
-            outpos.set(tmpoutpos);
-            inpos.set(tmpinpos);
+            for (int k = 0; k < cexcept; ++k)
+            {
+                @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
+            }
         }
+        outpos.set(tmpoutpos);
+        inpos.set(tmpinpos);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = inlength / BLOCK_SIZE * BLOCK_SIZE;
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = inlength / BLOCK_SIZE * BLOCK_SIZE;
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
-        }
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
+    }
 
-        public override string ToString()
-        {
-            return nameof(OptPFD);
-        }
+    public override string ToString()
+    {
+        return nameof(OptPFD);
     }
 }

--- a/src/CSharpFastPFOR/OptPFDS16.cs
+++ b/src/CSharpFastPFOR/OptPFDS16.cs
@@ -34,7 +34,7 @@ namespace Genbox.CSharpFastPFOR;
 public class OptPFDS16 : IntegerCODEC, SkippableIntegerCODEC
 {
     private const int BLOCK_SIZE = 128;
-    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    private readonly int[] exceptbuffer = new int[2 * BLOCK_SIZE];
 
     /**
      * Constructor for the OptPFDS16 CODEC.
@@ -52,9 +52,9 @@ public class OptPFDS16 : IntegerCODEC, SkippableIntegerCODEC
         encodePage(@in, inpos, inlength, @out, outpos);
     }
 
-    private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    private static readonly int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
         11, 12, 13, 16, 20, 32 };
-    private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    private static readonly int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
         10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
         16, 16, 16, 16, 16, 16, 16 };
 

--- a/src/CSharpFastPFOR/OptPFDS16.cs
+++ b/src/CSharpFastPFOR/OptPFDS16.cs
@@ -29,177 +29,176 @@
  * 
  * @author Daniel Lemire
  */
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class OptPFDS16 : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class OptPFDS16 : IntegerCODEC, SkippableIntegerCODEC
+    private const int BLOCK_SIZE = 128;
+    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+
+    /**
+     * Constructor for the OptPFDS16 CODEC.
+     */
+    public OptPFDS16()
     {
-        private const int BLOCK_SIZE = 128;
-        private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    }
 
-        /**
-         * Constructor for the OptPFDS16 CODEC.
-         */
-        public OptPFDS16()
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+
+        encodePage(@in, inpos, inlength, @out, outpos);
+    }
+
+    private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        11, 12, 13, 16, 20, 32 };
+    private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16 };
+
+    private void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
+    {
+        int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
+        int mini = 0;
+        if (mini + 28 < bits[invbits[mb]])
+            mini = bits[invbits[mb]] - 28; // 28 is the max for
+        // exceptions
+        int besti = bits.Length - 1;
+        int bestcost = bits[besti] * 4;
+        int exceptcounter = 0;
+        for (int i = mini; i < bits.Length - 1; ++i)
         {
-        }
+            int tmpcounter = 0;
+            for (int k = pos; k < BLOCK_SIZE + pos; ++k)
+                if ((int)((uint)@in[k] >> bits[i]) != 0)
+                {
+                    ++tmpcounter;
+                }
+            if (tmpcounter == BLOCK_SIZE)
+                continue; // no need
+            for (int k = pos, c = 0; k < pos + BLOCK_SIZE; ++k)
+                if ((int)((uint)@in[k] >> bits[i]) != 0)
+                {
+                    exceptbuffer[tmpcounter + c] = k - pos;
+                    exceptbuffer[c] = (int)((uint)@in[k] >> bits[i]);
+                    ++c;
+                }
 
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-
-            encodePage(@in, inpos, inlength, @out, outpos);
-        }
-
-        private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-            11, 12, 13, 16, 20, 32 };
-        private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-            10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
-            16, 16, 16, 16, 16, 16, 16 };
-
-        private void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
-        {
-            int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
-            int mini = 0;
-            if (mini + 28 < bits[invbits[mb]])
-                mini = bits[invbits[mb]] - 28; // 28 is the max for
-            // exceptions
-            int besti = bits.Length - 1;
-            int bestcost = bits[besti] * 4;
-            int exceptcounter = 0;
-            for (int i = mini; i < bits.Length - 1; ++i)
+            int thiscost = bits[i] * 4 + S16.estimatecompress(exceptbuffer, 0, 2 * tmpcounter);
+            if (thiscost <= bestcost)
             {
-                int tmpcounter = 0;
-                for (int k = pos; k < BLOCK_SIZE + pos; ++k)
-                    if ((int)((uint)@in[k] >> bits[i]) != 0)
+                bestcost = thiscost;
+                besti = i;
+                exceptcounter = tmpcounter;
+            }
+        }
+        bestb.set(besti);
+        bestexcept.set(exceptcounter);
+    }
+
+    private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
+        IntWrapper bestb = new IntWrapper();
+        IntWrapper bestexcept = new IntWrapper();
+        for (int finalinpos = tmpinpos + thissize; tmpinpos + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
+        {
+            getBestBFromData(@in, tmpinpos, bestb, bestexcept);
+            int tmpbestb = bestb.get();
+            int nbrexcept = bestexcept.get();
+            int exceptsize = 0;
+            int remember = tmpoutpos;
+            tmpoutpos++;
+            if (nbrexcept > 0)
+            {
+                int c = 0;
+                for (int i = 0; i < BLOCK_SIZE; ++i)
+                {
+                    if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
                     {
-                        ++tmpcounter;
-                    }
-                if (tmpcounter == BLOCK_SIZE)
-                    continue; // no need
-                for (int k = pos, c = 0; k < pos + BLOCK_SIZE; ++k)
-                    if ((int)((uint)@in[k] >> bits[i]) != 0)
-                    {
-                        exceptbuffer[tmpcounter + c] = k - pos;
-                        exceptbuffer[c] = (int)((uint)@in[k] >> bits[i]);
+                        exceptbuffer[c + nbrexcept] = i;
+                        exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
                         ++c;
                     }
-
-                int thiscost = bits[i] * 4 + S16.estimatecompress(exceptbuffer, 0, 2 * tmpcounter);
-                if (thiscost <= bestcost)
-                {
-                    bestcost = thiscost;
-                    besti = i;
-                    exceptcounter = tmpcounter;
                 }
+                exceptsize = S16.compress(exceptbuffer, 0,
+                    2 * nbrexcept, @out, tmpoutpos);
+                tmpoutpos += exceptsize;
             }
-            bestb.set(besti);
-            bestexcept.set(exceptcounter);
-        }
-
-        private void encodePage(int[] @in, IntWrapper inpos, int thissize, int[] @out, IntWrapper outpos)
-        {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-            IntWrapper bestb = new IntWrapper();
-            IntWrapper bestexcept = new IntWrapper();
-            for (int finalinpos = tmpinpos + thissize; tmpinpos + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
+            @out[remember] = tmpbestb | (nbrexcept << 8)
+                             | (exceptsize << 16);
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
             {
-                getBestBFromData(@in, tmpinpos, bestb, bestexcept);
-                int tmpbestb = bestb.get();
-                int nbrexcept = bestexcept.get();
-                int exceptsize = 0;
-                int remember = tmpoutpos;
-                tmpoutpos++;
-                if (nbrexcept > 0)
-                {
-                    int c = 0;
-                    for (int i = 0; i < BLOCK_SIZE; ++i)
-                    {
-                        if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
-                        {
-                            exceptbuffer[c + nbrexcept] = i;
-                            exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
-                            ++c;
-                        }
-                    }
-                    exceptsize = S16.compress(exceptbuffer, 0,
-                        2 * nbrexcept, @out, tmpoutpos);
-                    tmpoutpos += exceptsize;
-                }
-                @out[remember] = tmpbestb | (nbrexcept << 8)
-                                 | (exceptsize << 16);
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastpack(@in, tmpinpos + k, @out,
-                        tmpoutpos, bits[tmpbestb]);
-                    tmpoutpos += bits[tmpbestb];
-                }
+                BitPacking.fastpack(@in, tmpinpos + k, @out,
+                    tmpoutpos, bits[tmpbestb]);
+                tmpoutpos += bits[tmpbestb];
             }
-            inpos.set(tmpinpos);
-            outpos.set(tmpoutpos);
         }
+        inpos.set(tmpinpos);
+        outpos.set(tmpoutpos);
+    }
 
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
+    {
+        if (inlength == 0)
+            return;
+        mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
+        decodePage(@in, inpos, @out, outpos, mynvalue);
+    }
+
+    private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
+
+        for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
         {
-            if (inlength == 0)
-                return;
-            mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
-            decodePage(@in, inpos, @out, outpos, mynvalue);
-        }
-
-        private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
-        {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-
-            for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
+            int b = @in[tmpinpos] & 0xFF;
+            int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
+            int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
+            ++tmpinpos;
+            S16.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
+                0, 2 * cexcept);
+            tmpinpos += exceptsize;
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
             {
-                int b = @in[tmpinpos] & 0xFF;
-                int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
-                int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
-                ++tmpinpos;
-                S16.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
-                    0, 2 * cexcept);
-                tmpinpos += exceptsize;
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastunpack(@in, tmpinpos, @out,
-                        tmpoutpos + k, bits[b]);
-                    tmpinpos += bits[b];
-                }
-                for (int k = 0; k < cexcept; ++k)
-                {
-                    @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
-                }
+                BitPacking.fastunpack(@in, tmpinpos, @out,
+                    tmpoutpos + k, bits[b]);
+                tmpinpos += bits[b];
             }
-            outpos.set(tmpoutpos);
-            inpos.set(tmpinpos);
+            for (int k = 0; k < cexcept; ++k)
+            {
+                @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
+            }
         }
+        outpos.set(tmpoutpos);
+        inpos.set(tmpinpos);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = inlength / BLOCK_SIZE * BLOCK_SIZE;
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = inlength / BLOCK_SIZE * BLOCK_SIZE;
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
-        }
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
+    }
 
-        public override string ToString()
-        {
-            return nameof(OptPFDS16);
-        }
+    public override string ToString()
+    {
+        return nameof(OptPFDS16);
     }
 }

--- a/src/CSharpFastPFOR/OptPFDS16.cs
+++ b/src/CSharpFastPFOR/OptPFDS16.cs
@@ -31,7 +31,7 @@
  */
 namespace Genbox.CSharpFastPFOR;
 
-public class OptPFDS16 : IntegerCODEC, SkippableIntegerCODEC
+public sealed class OptPFDS16 : IntegerCODEC, SkippableIntegerCODEC
 {
     private const int BLOCK_SIZE = 128;
     private readonly int[] exceptbuffer = new int[2 * BLOCK_SIZE];

--- a/src/CSharpFastPFOR/OptPFDS16.cs
+++ b/src/CSharpFastPFOR/OptPFDS16.cs
@@ -102,8 +102,8 @@ public class OptPFDS16 : IntegerCODEC, SkippableIntegerCODEC
     {
         int tmpoutpos = outpos.get();
         int tmpinpos = inpos.get();
-        IntWrapper bestb = new IntWrapper();
-        IntWrapper bestexcept = new IntWrapper();
+        var bestb = new IntWrapper();
+        var bestexcept = new IntWrapper();
         for (int finalinpos = tmpinpos + thissize; tmpinpos + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
         {
             getBestBFromData(@in, tmpinpos, bestb, bestexcept);

--- a/src/CSharpFastPFOR/OptPFDS9.cs
+++ b/src/CSharpFastPFOR/OptPFDS9.cs
@@ -31,7 +31,7 @@
  */
 namespace Genbox.CSharpFastPFOR;
 
-public class OptPFDS9 : IntegerCODEC, SkippableIntegerCODEC
+public sealed class OptPFDS9 : IntegerCODEC, SkippableIntegerCODEC
 {
     private const int BLOCK_SIZE = 128;
     private readonly int[] exceptbuffer = new int[2 * BLOCK_SIZE];

--- a/src/CSharpFastPFOR/OptPFDS9.cs
+++ b/src/CSharpFastPFOR/OptPFDS9.cs
@@ -34,7 +34,7 @@ namespace Genbox.CSharpFastPFOR;
 public class OptPFDS9 : IntegerCODEC, SkippableIntegerCODEC
 {
     private const int BLOCK_SIZE = 128;
-    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    private readonly int[] exceptbuffer = new int[2 * BLOCK_SIZE];
 
     /**
      * Constructor for the OptPFDS9 CODEC.
@@ -51,9 +51,9 @@ public class OptPFDS9 : IntegerCODEC, SkippableIntegerCODEC
         encodePage(@in, inpos, inlength, @out, outpos);
     }
 
-    private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    private static readonly int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
         11, 12, 13, 16, 20, 32 };
-    private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    private static readonly int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
         10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
         16, 16, 16, 16, 16, 16, 16 };
 

--- a/src/CSharpFastPFOR/OptPFDS9.cs
+++ b/src/CSharpFastPFOR/OptPFDS9.cs
@@ -29,177 +29,176 @@
  * 
  * @author Daniel Lemire
  */
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class OptPFDS9 : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class OptPFDS9 : IntegerCODEC, SkippableIntegerCODEC
+    private const int BLOCK_SIZE = 128;
+    private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+
+    /**
+     * Constructor for the OptPFDS9 CODEC.
+     */
+    public OptPFDS9()
     {
-        private const int BLOCK_SIZE = 128;
-        private int[] exceptbuffer = new int[2 * BLOCK_SIZE];
+    }
 
-        /**
-         * Constructor for the OptPFDS9 CODEC.
-         */
-        public OptPFDS9()
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
+        if (inlength == 0)
+            return;
+        encodePage(@in, inpos, inlength, @out, outpos);
+    }
+
+    private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        11, 12, 13, 16, 20, 32 };
+    private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16 };
+
+    private void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
+    {
+        int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
+        int mini = 0;
+        if (mini + 28 < bits[invbits[mb]])
+            mini = bits[invbits[mb]] - 28; // 28 is the max for
+        // exceptions
+        int besti = bits.Length - 1;
+        int bestcost = bits[besti] * 4;
+        int exceptcounter = 0;
+        for (int i = mini; i < bits.Length - 1; ++i)
         {
-        }
+            int tmpcounter = 0;
+            for (int k = pos; k < BLOCK_SIZE + pos; ++k)
+                if ((int)((uint)@in[k] >> bits[i]) != 0)
+                {
+                    ++tmpcounter;
+                }
+            if (tmpcounter == BLOCK_SIZE)
+                continue; // no need
+            for (int k = pos, c = 0; k < pos + BLOCK_SIZE; ++k)
+                if ((int)((uint)@in[k] >> bits[i]) != 0)
+                {
+                    exceptbuffer[tmpcounter + c] = k - pos;
+                    exceptbuffer[c] = (int)((uint)@in[k] >> bits[i]);
+                    ++c;
+                }
 
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = Util.greatestMultiple(inlength, BLOCK_SIZE);
-            if (inlength == 0)
-                return;
-            encodePage(@in, inpos, inlength, @out, outpos);
-        }
-
-        private static int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-            11, 12, 13, 16, 20, 32 };
-        private static int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-            10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
-            16, 16, 16, 16, 16, 16, 16 };
-
-        private void getBestBFromData(int[] @in, int pos, IntWrapper bestb, IntWrapper bestexcept)
-        {
-            int mb = Util.maxbits(@in, pos, BLOCK_SIZE);
-            int mini = 0;
-            if (mini + 28 < bits[invbits[mb]])
-                mini = bits[invbits[mb]] - 28; // 28 is the max for
-            // exceptions
-            int besti = bits.Length - 1;
-            int bestcost = bits[besti] * 4;
-            int exceptcounter = 0;
-            for (int i = mini; i < bits.Length - 1; ++i)
+            int thiscost = bits[i] * 4 + S9.estimatecompress(exceptbuffer, 0, 2 * tmpcounter);
+            if (thiscost <= bestcost)
             {
-                int tmpcounter = 0;
-                for (int k = pos; k < BLOCK_SIZE + pos; ++k)
-                    if ((int)((uint)@in[k] >> bits[i]) != 0)
+                bestcost = thiscost;
+                besti = i;
+                exceptcounter = tmpcounter;
+            }
+        }
+        bestb.set(besti);
+        bestexcept.set(exceptcounter);
+    }
+
+    private void encodePage(int[] @in, IntWrapper inpos, int thissize,
+        int[] @out, IntWrapper outpos)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
+        IntWrapper bestb = new IntWrapper();
+        IntWrapper bestexcept = new IntWrapper();
+        for (int finalinpos = tmpinpos + thissize; tmpinpos + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
+        {
+            getBestBFromData(@in, tmpinpos, bestb, bestexcept);
+            int tmpbestb = bestb.get();
+            int nbrexcept = bestexcept.get();
+            int exceptsize = 0;
+            int remember = tmpoutpos;
+            tmpoutpos++;
+            if (nbrexcept > 0)
+            {
+                int c = 0;
+                for (int i = 0; i < BLOCK_SIZE; ++i)
+                {
+                    if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
                     {
-                        ++tmpcounter;
-                    }
-                if (tmpcounter == BLOCK_SIZE)
-                    continue; // no need
-                for (int k = pos, c = 0; k < pos + BLOCK_SIZE; ++k)
-                    if ((int)((uint)@in[k] >> bits[i]) != 0)
-                    {
-                        exceptbuffer[tmpcounter + c] = k - pos;
-                        exceptbuffer[c] = (int)((uint)@in[k] >> bits[i]);
+                        exceptbuffer[c + nbrexcept] = i;
+                        exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
                         ++c;
                     }
-
-                int thiscost = bits[i] * 4 + S9.estimatecompress(exceptbuffer, 0, 2 * tmpcounter);
-                if (thiscost <= bestcost)
-                {
-                    bestcost = thiscost;
-                    besti = i;
-                    exceptcounter = tmpcounter;
                 }
+                exceptsize = S9.compress(exceptbuffer, 0,
+                    2 * nbrexcept, @out, tmpoutpos);
+                tmpoutpos += exceptsize;
             }
-            bestb.set(besti);
-            bestexcept.set(exceptcounter);
-        }
-
-        private void encodePage(int[] @in, IntWrapper inpos, int thissize,
-            int[] @out, IntWrapper outpos)
-        {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-            IntWrapper bestb = new IntWrapper();
-            IntWrapper bestexcept = new IntWrapper();
-            for (int finalinpos = tmpinpos + thissize; tmpinpos + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
+            @out[remember] = tmpbestb | (nbrexcept << 8)
+                             | (exceptsize << 16);
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
             {
-                getBestBFromData(@in, tmpinpos, bestb, bestexcept);
-                int tmpbestb = bestb.get();
-                int nbrexcept = bestexcept.get();
-                int exceptsize = 0;
-                int remember = tmpoutpos;
-                tmpoutpos++;
-                if (nbrexcept > 0)
-                {
-                    int c = 0;
-                    for (int i = 0; i < BLOCK_SIZE; ++i)
-                    {
-                        if ((int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]) != 0)
-                        {
-                            exceptbuffer[c + nbrexcept] = i;
-                            exceptbuffer[c] = (int)((uint)@in[tmpinpos + i] >> bits[tmpbestb]);
-                            ++c;
-                        }
-                    }
-                    exceptsize = S9.compress(exceptbuffer, 0,
-                        2 * nbrexcept, @out, tmpoutpos);
-                    tmpoutpos += exceptsize;
-                }
-                @out[remember] = tmpbestb | (nbrexcept << 8)
-                                 | (exceptsize << 16);
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastpack(@in, tmpinpos + k, @out,
-                        tmpoutpos, bits[tmpbestb]);
-                    tmpoutpos += bits[tmpbestb];
-                }
+                BitPacking.fastpack(@in, tmpinpos + k, @out,
+                    tmpoutpos, bits[tmpbestb]);
+                tmpoutpos += bits[tmpbestb];
             }
-            inpos.set(tmpinpos);
-            outpos.set(tmpoutpos);
         }
+        inpos.set(tmpinpos);
+        outpos.set(tmpoutpos);
+    }
 
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int mynvalue)
+    {
+        if (inlength == 0)
+            return;
+        mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
+        decodePage(@in, inpos, @out, outpos, mynvalue);
+    }
+
+    private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
+    {
+        int tmpoutpos = outpos.get();
+        int tmpinpos = inpos.get();
+
+        for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
         {
-            if (inlength == 0)
-                return;
-            mynvalue = Util.greatestMultiple(mynvalue, BLOCK_SIZE);
-            decodePage(@in, inpos, @out, outpos, mynvalue);
-        }
-
-        private void decodePage(int[] @in, IntWrapper inpos, int[] @out, IntWrapper outpos, int thissize)
-        {
-            int tmpoutpos = outpos.get();
-            int tmpinpos = inpos.get();
-
-            for (int run = 0; run < thissize / BLOCK_SIZE; ++run, tmpoutpos += BLOCK_SIZE)
+            int b = @in[tmpinpos] & 0xFF;
+            int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
+            int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
+            ++tmpinpos;
+            S9.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
+                0, 2 * cexcept);
+            tmpinpos += exceptsize;
+            for (int k = 0; k < BLOCK_SIZE; k += 32)
             {
-                int b = @in[tmpinpos] & 0xFF;
-                int cexcept = (int)((uint)@in[tmpinpos] >> 8) & 0xFF;
-                int exceptsize = (int)((uint)@in[tmpinpos] >> 16);
-                ++tmpinpos;
-                S9.uncompress(@in, tmpinpos, exceptsize, exceptbuffer,
-                    0, 2 * cexcept);
-                tmpinpos += exceptsize;
-                for (int k = 0; k < BLOCK_SIZE; k += 32)
-                {
-                    BitPacking.fastunpack(@in, tmpinpos, @out,
-                        tmpoutpos + k, bits[b]);
-                    tmpinpos += bits[b];
-                }
-                for (int k = 0; k < cexcept; ++k)
-                {
-                    @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
-                }
+                BitPacking.fastunpack(@in, tmpinpos, @out,
+                    tmpoutpos + k, bits[b]);
+                tmpinpos += bits[b];
             }
-            outpos.set(tmpoutpos);
-            inpos.set(tmpinpos);
+            for (int k = 0; k < cexcept; ++k)
+            {
+                @out[tmpoutpos + exceptbuffer[k + cexcept]] |= (exceptbuffer[k] << bits[b]);
+            }
         }
+        outpos.set(tmpoutpos);
+        inpos.set(tmpinpos);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            inlength = inlength / BLOCK_SIZE * BLOCK_SIZE;
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        inlength = inlength / BLOCK_SIZE * BLOCK_SIZE;
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
-        }
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
+    }
 
-        public override string ToString()
-        {
-            return nameof(OptPFDS9);
-        }
+    public override string ToString()
+    {
+        return nameof(OptPFDS9);
     }
 }

--- a/src/CSharpFastPFOR/OptPFDS9.cs
+++ b/src/CSharpFastPFOR/OptPFDS9.cs
@@ -53,6 +53,7 @@ public class OptPFDS9 : IntegerCODEC, SkippableIntegerCODEC
 
     private static readonly int[] bits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
         11, 12, 13, 16, 20, 32 };
+
     private static readonly int[] invbits = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
         10, 11, 12, 13, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16,
         16, 16, 16, 16, 16, 16, 16 };
@@ -102,8 +103,8 @@ public class OptPFDS9 : IntegerCODEC, SkippableIntegerCODEC
     {
         int tmpoutpos = outpos.get();
         int tmpinpos = inpos.get();
-        IntWrapper bestb = new IntWrapper();
-        IntWrapper bestexcept = new IntWrapper();
+        var bestb = new IntWrapper();
+        var bestexcept = new IntWrapper();
         for (int finalinpos = tmpinpos + thissize; tmpinpos + BLOCK_SIZE <= finalinpos; tmpinpos += BLOCK_SIZE)
         {
             getBestBFromData(@in, tmpinpos, bestb, bestexcept);

--- a/src/CSharpFastPFOR/Port/Arrays.cs
+++ b/src/CSharpFastPFOR/Port/Arrays.cs
@@ -3,12 +3,12 @@ using System.Linq;
 
 namespace Genbox.CSharpFastPFOR.Port;
 
-public class Arrays
+public static class Arrays
 {
     private static void rangeCheck(int arrayLen, int fromIndex, int toIndex)
     {
         if (fromIndex > toIndex)
-            throw new ArgumentOutOfRangeException("fromIndex(" + fromIndex + ") > toIndex(" + toIndex + ")");
+            throw new ArgumentOutOfRangeException($"fromIndex({fromIndex}) > toIndex({toIndex})");
 
         if (fromIndex < 0)
             throw new ArgumentOutOfRangeException(nameof(fromIndex));

--- a/src/CSharpFastPFOR/Port/Arrays.cs
+++ b/src/CSharpFastPFOR/Port/Arrays.cs
@@ -1,60 +1,59 @@
 ﻿using System;
 using System.Linq;
 
-namespace Genbox.CSharpFastPFOR.Port
+namespace Genbox.CSharpFastPFOR.Port;
+
+public class Arrays
 {
-    public class Arrays
+    private static void rangeCheck(int arrayLen, int fromIndex, int toIndex)
     {
-        private static void rangeCheck(int arrayLen, int fromIndex, int toIndex)
+        if (fromIndex > toIndex)
+            throw new ArgumentOutOfRangeException("fromIndex(" + fromIndex + ") > toIndex(" + toIndex + ")");
+
+        if (fromIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(fromIndex));
+
+        if (toIndex > arrayLen)
+            throw new ArgumentOutOfRangeException(nameof(toIndex));
+    }
+
+    public static void fill<T>(T[] array, int start, int end, T value)
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array));
+
+        rangeCheck(array.Length, start, end);
+
+        for (int i = start; i < end; i++)
         {
-            if (fromIndex > toIndex)
-                throw new ArgumentOutOfRangeException("fromIndex(" + fromIndex + ") > toIndex(" + toIndex + ")");
-
-            if (fromIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(fromIndex));
-
-            if (toIndex > arrayLen)
-                throw new ArgumentOutOfRangeException(nameof(toIndex));
+            array[i] = value;
         }
+    }
 
-        public static void fill<T>(T[] array, int start, int end, T value)
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
+    public static T[] copyOf<T>(T[] original, int newLength)
+    {
+        T[] copy = new T[newLength];
+        Array.Copy(original, 0, copy, 0, Math.Min(original.Length, newLength));
+        return copy;
+    }
 
-            rangeCheck(array.Length, start, end);
+    public static void fill<T>(T[] array, T value)
+    {
+        fill(array, 0, array.Length, value);
+    }
 
-            for (int i = start; i < end; i++)
-            {
-                array[i] = value;
-            }
-        }
+    public static void sort(int[] array)
+    {
+        Array.Sort(array);
+    }
 
-        public static T[] copyOf<T>(T[] original, int newLength)
-        {
-            T[] copy = new T[newLength];
-            Array.Copy(original, 0, copy, 0, Math.Min(original.Length, newLength));
-            return copy;
-        }
+    public static string toString(int[] ints)
+    {
+        return string.Join(", ", ints);
+    }
 
-        public static void fill<T>(T[] array, T value)
-        {
-            fill(array, 0, array.Length, value);
-        }
-
-        public static void sort(int[] array)
-        {
-            Array.Sort(array);
-        }
-
-        public static string toString(int[] ints)
-        {
-            return string.Join(", ", ints);
-        }
-
-        public static bool equals(int[] first, int[] second)
-        {
-            return first.SequenceEqual(second);
-        }
+    public static bool equals(int[] first, int[] second)
+    {
+        return first.SequenceEqual(second);
     }
 }

--- a/src/CSharpFastPFOR/Port/BitSet.cs
+++ b/src/CSharpFastPFOR/Port/BitSet.cs
@@ -4,7 +4,7 @@ namespace Genbox.CSharpFastPFOR.Port;
 
 public class BitSet
 {
-    private BitArray _bitArray;
+    private readonly BitArray _bitArray;
 
     public BitSet(int max)
     {

--- a/src/CSharpFastPFOR/Port/BitSet.cs
+++ b/src/CSharpFastPFOR/Port/BitSet.cs
@@ -1,35 +1,34 @@
 ﻿using System.Collections;
 
-namespace Genbox.CSharpFastPFOR.Port
+namespace Genbox.CSharpFastPFOR.Port;
+
+public class BitSet
 {
-    public class BitSet
+    private BitArray _bitArray;
+
+    public BitSet(int max)
     {
-        private BitArray _bitArray;
+        _bitArray = new BitArray(max);
+    }
 
-        public BitSet(int max)
+    public bool get(int i)
+    {
+        return _bitArray[i];
+    }
+
+    public void set(int i)
+    {
+        _bitArray[i] = true;
+    }
+
+    public int nextSetBit(int fromIndex)
+    {
+        for (int j = fromIndex; j < _bitArray.Length; j++)
         {
-            _bitArray = new BitArray(max);
+            if (_bitArray[j])
+                return j;
         }
 
-        public bool get(int i)
-        {
-            return _bitArray[i];
-        }
-
-        public void set(int i)
-        {
-            _bitArray[i] = true;
-        }
-
-        public int nextSetBit(int fromIndex)
-        {
-            for (int j = fromIndex; j < _bitArray.Length; j++)
-            {
-                if (_bitArray[j])
-                    return j;
-            }
-
-            return -1;
-        }
+        return -1;
     }
 }

--- a/src/CSharpFastPFOR/Port/ByteBuffer.cs
+++ b/src/CSharpFastPFOR/Port/ByteBuffer.cs
@@ -1,78 +1,77 @@
 ﻿using System.IO;
 
-namespace Genbox.CSharpFastPFOR.Port
+namespace Genbox.CSharpFastPFOR.Port;
+
+public class ByteBuffer
 {
-    public class ByteBuffer
+    public readonly MemoryStream _ms;
+    private readonly BinaryWriter _bw;
+    private readonly BinaryReader _br;
+    private ByteOrder _order;
+
+    public ByteBuffer(int length)
     {
-        public readonly MemoryStream _ms;
-        private readonly BinaryWriter _bw;
-        private readonly BinaryReader _br;
-        private ByteOrder _order;
+        _ms = new MemoryStream();
+        _ms.SetLength(length);
 
-        public ByteBuffer(int length)
-        {
-            _ms = new MemoryStream();
-            _ms.SetLength(length);
+        _bw = new BinaryWriter(_ms);
+        _br = new BinaryReader(_ms);
 
-            _bw = new BinaryWriter(_ms);
-            _br = new BinaryReader(_ms);
+        _order = ByteOrder.BIG_ENDIAN; //To simulate Java
+    }
 
-            _order = ByteOrder.BIG_ENDIAN; //To simulate Java
-        }
+    internal static ByteBuffer allocateDirect(int length)
+    {
+        return new ByteBuffer(length);
+    }
 
-        internal static ByteBuffer allocateDirect(int length)
-        {
-            return new ByteBuffer(length);
-        }
+    public void order(ByteOrder order)
+    {
+        _order = order;
+    }
 
-        public void order(ByteOrder order)
-        {
-            _order = order;
-        }
+    public int position()
+    {
+        return (int)_ms.Position;
+    }
 
-        public int position()
-        {
-            return (int)_ms.Position;
-        }
+    public void put(sbyte b)
+    {
+        _bw.Write(b);
+    }
 
-        public void put(sbyte b)
-        {
-            _bw.Write(b);
-        }
+    public void flip()
+    {
+        _ms.Position = 0;
+    }
 
-        public void flip()
-        {
-            _ms.Position = 0;
-        }
+    public IntBuffer asIntBuffer()
+    {
+        return new IntBuffer(_ms, _order);
+    }
 
-        public IntBuffer asIntBuffer()
-        {
-            return new IntBuffer(_ms, _order);
-        }
+    public void clear()
+    {
+        byte[] empty = new byte[_ms.Length];
+        _ms.Position = 0;
+        _ms.Write(empty, 0, empty.Length);
+        _ms.Position = 0;
+    }
 
-        public void clear()
-        {
-            byte[] empty = new byte[_ms.Length];
-            _ms.Position = 0;
-            _ms.Write(empty, 0, empty.Length);
-            _ms.Position = 0;
-        }
+    public sbyte get()
+    {
+        return _br.ReadSByte();
+    }
 
-        public sbyte get()
-        {
-            return _br.ReadSByte();
-        }
+    internal void put(int[] src, int offset, int length)
+    {
+        //TODO: port this
+        //checkBounds(offset, length, src.Length);
+        //if (length > remaining())
+        //    throw new BufferOverflowException();
 
-        internal void put(int[] src, int offset, int length)
-        {
-            //TODO: port this
-            //checkBounds(offset, length, src.Length);
-            //if (length > remaining())
-            //    throw new BufferOverflowException();
-
-            int end = offset + length;
-            for (int i = offset; i < end; i++)
-                _bw.Write(src[i]);
-        }
+        int end = offset + length;
+        for (int i = offset; i < end; i++)
+            _bw.Write(src[i]);
     }
 }

--- a/src/CSharpFastPFOR/Port/ByteOrder.cs
+++ b/src/CSharpFastPFOR/Port/ByteOrder.cs
@@ -1,8 +1,7 @@
-﻿namespace Genbox.CSharpFastPFOR.Port
+﻿namespace Genbox.CSharpFastPFOR.Port;
+
+public enum ByteOrder
 {
-    public enum ByteOrder
-    {
-        LITTLE_ENDIAN,
-        BIG_ENDIAN
-    }
+    LITTLE_ENDIAN,
+    BIG_ENDIAN
 }

--- a/src/CSharpFastPFOR/Port/IntBuffer.cs
+++ b/src/CSharpFastPFOR/Port/IntBuffer.cs
@@ -18,7 +18,7 @@ public class IntBuffer
     {
         int end = offset + length;
 
-        BinaryReader br = new BinaryReader(_ms);
+        var br = new BinaryReader(_ms);
 
         for (int i = offset; i < end; i++)
         {

--- a/src/CSharpFastPFOR/Port/IntBuffer.cs
+++ b/src/CSharpFastPFOR/Port/IntBuffer.cs
@@ -1,48 +1,47 @@
 ﻿using System;
 using System.IO;
 
-namespace Genbox.CSharpFastPFOR.Port
+namespace Genbox.CSharpFastPFOR.Port;
+
+public class IntBuffer
 {
-    public class IntBuffer
+    private readonly MemoryStream _ms;
+    private readonly ByteOrder _order;
+
+    public IntBuffer(MemoryStream ms, ByteOrder order)
     {
-        private readonly MemoryStream _ms;
-        private readonly ByteOrder _order;
+        _ms = ms;
+        _order = order;
+    }
 
-        public IntBuffer(MemoryStream ms, ByteOrder order)
+    public void get(int[] dst, int offset, int length)
+    {
+        int end = offset + length;
+
+        BinaryReader br = new BinaryReader(_ms);
+
+        for (int i = offset; i < end; i++)
         {
-            _ms = ms;
-            _order = order;
+            int value = br.ReadInt32();
+
+            if (BitConverter.IsLittleEndian && _order == ByteOrder.BIG_ENDIAN)
+                value = reverseBytes(value);
+
+            dst[i] = value;
         }
+    }
 
-        public void get(int[] dst, int offset, int length)
-        {
-            int end = offset + length;
+    public static int reverseBytes(int i)
+    {
+        return ((int)((uint)i >> 24)) |
+               ((i >> 8) & 0xFF00) |
+               ((i << 8) & 0xFF0000) |
+               ((i << 24));
+    }
 
-            BinaryReader br = new BinaryReader(_ms);
-
-            for (int i = offset; i < end; i++)
-            {
-                int value = br.ReadInt32();
-
-                if (BitConverter.IsLittleEndian && _order == ByteOrder.BIG_ENDIAN)
-                    value = reverseBytes(value);
-
-                dst[i] = value;
-            }
-        }
-
-        public static int reverseBytes(int i)
-        {
-            return ((int)((uint)i >> 24)) |
-                   ((i >> 8) & 0xFF00) |
-                   ((i << 8) & 0xFF0000) |
-                   ((i << 24));
-        }
-
-        private static void checkBounds(int off, int len, int size)
-        {
-            if ((off | len | (off + len) | (size - (off + len))) < 0)
-                throw new IndexOutOfRangeException();
-        }
+    private static void checkBounds(int off, int len, int size)
+    {
+        if ((off | len | (off + len) | (size - (off + len))) < 0)
+            throw new IndexOutOfRangeException();
     }
 }

--- a/src/CSharpFastPFOR/Port/Integer.cs
+++ b/src/CSharpFastPFOR/Port/Integer.cs
@@ -1,32 +1,31 @@
-﻿namespace Genbox.CSharpFastPFOR.Port
+﻿namespace Genbox.CSharpFastPFOR.Port;
+
+public class Integer
 {
-    public class Integer
+    private int v;
+
+    public Integer(int v)
     {
-        private int v;
+        this.v = v;
+    }
 
-        public Integer(int v)
-        {
-            this.v = v;
-        }
+    public static int numberOfLeadingZeros(int x)
+    {
+        x |= (x >> 1);
+        x |= (x >> 2);
+        x |= (x >> 4);
+        x |= (x >> 8);
+        x |= (x >> 16);
+        return (sizeof(int) * 8 - Ones(x));
+    }
 
-        public static int numberOfLeadingZeros(int x)
-        {
-            x |= (x >> 1);
-            x |= (x >> 2);
-            x |= (x >> 4);
-            x |= (x >> 8);
-            x |= (x >> 16);
-            return (sizeof(int) * 8 - Ones(x));
-        }
-
-        public static int Ones(int x)
-        {
-            x -= ((x >> 1) & 0x55555555);
-            x = (((x >> 2) & 0x33333333) + (x & 0x33333333));
-            x = (((x >> 4) + x) & 0x0f0f0f0f);
-            x += (x >> 8);
-            x += (x >> 16);
-            return (x & 0x0000003f);
-        }
+    public static int Ones(int x)
+    {
+        x -= ((x >> 1) & 0x55555555);
+        x = (((x >> 2) & 0x33333333) + (x & 0x33333333));
+        x = (((x >> 4) + x) & 0x0f0f0f0f);
+        x += (x >> 8);
+        x += (x >> 16);
+        return (x & 0x0000003f);
     }
 }

--- a/src/CSharpFastPFOR/Port/Integer.cs
+++ b/src/CSharpFastPFOR/Port/Integer.cs
@@ -1,6 +1,6 @@
 ﻿namespace Genbox.CSharpFastPFOR.Port;
 
-public class Integer
+public readonly struct Integer
 {
     private readonly int v;
 

--- a/src/CSharpFastPFOR/Port/Integer.cs
+++ b/src/CSharpFastPFOR/Port/Integer.cs
@@ -2,7 +2,7 @@
 
 public class Integer
 {
-    private int v;
+    private readonly int v;
 
     public Integer(int v)
     {

--- a/src/CSharpFastPFOR/S16.cs
+++ b/src/CSharpFastPFOR/S16.cs
@@ -14,215 +14,214 @@
 
 using System;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class S16
 {
-    public class S16
+    /**
+     * Compress an integer array using Simple16
+     *
+     * 
+     * @param in
+     *                array to compress
+     * @param currentPos
+     *                where to start reading
+     * @param inlength
+     *                how many integers to read
+     * @param out   output array
+     * @param tmpoutpos location in the output array
+     * @return the number of 32-bit words written (in compressed form)
+     */
+    public static int compress(int[] @in, int currentPos, int inlength, int[] @out, int tmpoutpos)
     {
-        /**
-         * Compress an integer array using Simple16
-         *
-         * 
-         * @param in
-         *                array to compress
-         * @param currentPos
-         *                where to start reading
-         * @param inlength
-         *                how many integers to read
-         * @param out   output array
-         * @param tmpoutpos location in the output array
-         * @return the number of 32-bit words written (in compressed form)
-         */
-        public static int compress(int[] @in, int currentPos, int inlength, int[] @out, int tmpoutpos)
+        int outpos = tmpoutpos;
+        int finalin = currentPos + inlength;
+        while (currentPos < finalin)
         {
-            int outpos = tmpoutpos;
-            int finalin = currentPos + inlength;
-            while (currentPos < finalin)
-            {
-                int inoffset = compressblock(@out, outpos++, @in,
-                    currentPos, inlength);
-                if (inoffset == -1)
-                    throw new Exception("Too big a number");
-                currentPos += inoffset;
-                inlength -= inoffset;
-            }
-            return outpos - tmpoutpos;
+            int inoffset = compressblock(@out, outpos++, @in,
+                currentPos, inlength);
+            if (inoffset == -1)
+                throw new Exception("Too big a number");
+            currentPos += inoffset;
+            inlength -= inoffset;
         }
+        return outpos - tmpoutpos;
+    }
 
-        /**
-         * Estimate size of the compressed output.
-         * 
-         * @param in
-         *                array to compress
-         * @param currentPos
-         *                where to start reading
-         * @param inlength
-         *                how many integers to read
-         * @return estimated size of the output (in 32-bit integers)
-         */
-        public static int estimatecompress(int[] @in, int currentPos, int inlength)
+    /**
+     * Estimate size of the compressed output.
+     * 
+     * @param in
+     *                array to compress
+     * @param currentPos
+     *                where to start reading
+     * @param inlength
+     *                how many integers to read
+     * @return estimated size of the output (in 32-bit integers)
+     */
+    public static int estimatecompress(int[] @in, int currentPos, int inlength)
+    {
+        int finalin = currentPos + inlength;
+        int counter = 0;
+        while (currentPos < finalin)
         {
-            int finalin = currentPos + inlength;
-            int counter = 0;
-            while (currentPos < finalin)
-            {
-                int inoffset = fakecompressblock(@in, currentPos,
-                    inlength);
-                if (inoffset == -1)
-                    throw new Exception("Too big a number");
-                currentPos += inoffset;
-                inlength -= inoffset;
-                ++counter;
-            }
-            return counter;
+            int inoffset = fakecompressblock(@in, currentPos,
+                inlength);
+            if (inoffset == -1)
+                throw new Exception("Too big a number");
+            currentPos += inoffset;
+            inlength -= inoffset;
+            ++counter;
         }
+        return counter;
+    }
 
-        /**
-         * Compress an integer array using Simple16
-         * 
-         * @param out
-         *                the compressed output
-         * @param outOffset
-         *                the offset of the output in the number of integers
-         * @param in
-         *                the integer input array
-         * @param inOffset
-         *                the offset of the input in the number of integers
-         * @param n
-         *                the number of elements to be compressed
-         * @return the size of the outputs in 32-bit integers
-         * 
-         */
-        public static int compressblock(int[] @out, int outOffset, int[] @in, int inOffset, int n)
+    /**
+     * Compress an integer array using Simple16
+     * 
+     * @param out
+     *                the compressed output
+     * @param outOffset
+     *                the offset of the output in the number of integers
+     * @param in
+     *                the integer input array
+     * @param inOffset
+     *                the offset of the input in the number of integers
+     * @param n
+     *                the number of elements to be compressed
+     * @return the size of the outputs in 32-bit integers
+     * 
+     */
+    public static int compressblock(int[] @out, int outOffset, int[] @in, int inOffset, int n)
+    {
+        int numIdx, j, num, bits;
+        for (numIdx = 0; numIdx < S16_NUMSIZE; numIdx++)
         {
-            int numIdx, j, num, bits;
-            for (numIdx = 0; numIdx < S16_NUMSIZE; numIdx++)
+            @out[outOffset] = numIdx << S16_BITSSIZE;
+            num = (S16_NUM[numIdx] < n) ? S16_NUM[numIdx] : n;
+
+            for (j = 0, bits = 0; (j < num)
+                                  && (@in[inOffset + j] < SHIFTED_S16_BITS[numIdx][j]);)
             {
-                @out[outOffset] = numIdx << S16_BITSSIZE;
-                num = (S16_NUM[numIdx] < n) ? S16_NUM[numIdx] : n;
-
-                for (j = 0, bits = 0; (j < num)
-                                      && (@in[inOffset + j] < SHIFTED_S16_BITS[numIdx][j]);)
-                {
-                    @out[outOffset] |= (@in[inOffset + j] << bits);
-                    bits += S16_BITS[numIdx][j];
-                    j++;
-                }
-
-                if (j == num)
-                {
-                    return num;
-                }
-            }
-
-            return -1;
-        }
-
-        private static int fakecompressblock(int[] @in, int inOffset, int n)
-        {
-            int numIdx, j, num;
-            for (numIdx = 0; numIdx < S16_NUMSIZE; numIdx++)
-            {
-                num = (S16_NUM[numIdx] < n) ? S16_NUM[numIdx] : n;
-
-                for (j = 0; (j < num)
-                            && (@in[inOffset + j] < SHIFTED_S16_BITS[numIdx][j]);)
-                {
-                    j++;
-                }
-
-                if (j == num)
-                {
-                    return num;
-                }
-            }
-
-            return -1;
-        }
-
-        /**
-         * Decompress an integer array using Simple16
-         * 
-         * @param out
-         *                the decompressed output
-         * @param outOffset
-         *                the offset of the output in the number of integers
-         * @param in
-         *                the compressed input array
-         * @param inOffset
-         *                the offset of the input in the number of integers
-         * @param n
-         *                the number of elements to be compressed
-         * @return the number of processed integers
-         */
-        public static int decompressblock(int[] @out, int outOffset, int[] @in, int inOffset, int n)
-        {
-            int numIdx, j = 0, bits = 0;
-            numIdx = (int)((uint)@in[inOffset] >> S16_BITSSIZE);
-            int num = S16_NUM[numIdx] < n ? S16_NUM[numIdx] : n;
-            for (j = 0, bits = 0; j < num; j++)
-            {
-                @out[outOffset + j] = (int)((uint)@in[inOffset] >> bits) & (int)((uint)0xffffffff >> (32 - S16_BITS[numIdx][j]));
+                @out[outOffset] |= (@in[inOffset + j] << bits);
                 bits += S16_BITS[numIdx][j];
+                j++;
             }
-            return num;
-        }
 
-        /**
-         * Uncompressed data from an input array into an output array
-         *
-         * @param in    input array (in compressed form)
-         * @param tmpinpos  starting location in the compressed input array
-         * @param inlength  how much data we wish the read (in 32-bit words)
-         * @param out       output array (in decompressed form)
-         * @param currentPos    current position in the output array
-         * @param outlength     available data in the output array
-         */
-        public static void uncompress(int[] @in, int tmpinpos, int inlength, int[] @out, int currentPos, int outlength)
-        {
-            int pos = tmpinpos + inlength;
-            while (tmpinpos < pos)
+            if (j == num)
             {
-                int howmany = decompressblock(@out, currentPos,
-                   @in, tmpinpos, outlength);
-                outlength -= howmany;
-                currentPos += howmany;
-                tmpinpos += 1;
+                return num;
             }
         }
 
-        private static int[][] shiftme(int[][] x)
+        return -1;
+    }
+
+    private static int fakecompressblock(int[] @in, int inOffset, int n)
+    {
+        int numIdx, j, num;
+        for (numIdx = 0; numIdx < S16_NUMSIZE; numIdx++)
         {
-            int[][] answer = new int[x.Length][];
-            for (int k = 0; k < x.Length; ++k)
+            num = (S16_NUM[numIdx] < n) ? S16_NUM[numIdx] : n;
+
+            for (j = 0; (j < num)
+                        && (@in[inOffset + j] < SHIFTED_S16_BITS[numIdx][j]);)
             {
-                answer[k] = new int[x[k].Length];
-                for (int z = 0; z < answer[k].Length; ++z)
-                    answer[k][z] = 1 << x[k][z];
+                j++;
             }
-            return answer;
+
+            if (j == num)
+            {
+                return num;
+            }
         }
 
-        private const int S16_NUMSIZE = 16;
-        private const int S16_BITSSIZE = 28;
-        // the possible number of bits used to represent one integer
-        private static int[] S16_NUM = { 28, 21, 21, 21, 14, 9, 8, 7, 6, 6, 5, 5, 4, 3, 2, 1 };
-        // the corresponding number of elements for each value of the number of
-        // bits
-        private static int[][] S16_BITS = {
-            new[]{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
-            new[]{ 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
-            new[]{ 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1 },
-            new[]{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2 },
-            new[]{ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
-            new[]{ 4, 3, 3, 3, 3, 3, 3, 3, 3 }, new[] { 3, 4, 4, 4, 4, 3, 3, 3 },
-            new[]{ 4, 4, 4, 4, 4, 4, 4 }, new[]{ 5, 5, 5, 5, 4, 4 },
-            new[]{ 4, 4, 5, 5, 5, 5 }, new[]{ 6, 6, 6, 5, 5 }, new[]{ 5, 5, 6, 6, 6 },
-            new[]{ 7, 7, 7, 7 }, new[]{ 10, 9, 9, }, new[]{ 14, 14 }, new[]{ 28 } };
-        private static int[][] SHIFTED_S16_BITS = shiftme(S16_BITS);
+        return -1;
+    }
 
-        public override string ToString()
+    /**
+     * Decompress an integer array using Simple16
+     * 
+     * @param out
+     *                the decompressed output
+     * @param outOffset
+     *                the offset of the output in the number of integers
+     * @param in
+     *                the compressed input array
+     * @param inOffset
+     *                the offset of the input in the number of integers
+     * @param n
+     *                the number of elements to be compressed
+     * @return the number of processed integers
+     */
+    public static int decompressblock(int[] @out, int outOffset, int[] @in, int inOffset, int n)
+    {
+        int numIdx, j = 0, bits = 0;
+        numIdx = (int)((uint)@in[inOffset] >> S16_BITSSIZE);
+        int num = S16_NUM[numIdx] < n ? S16_NUM[numIdx] : n;
+        for (j = 0, bits = 0; j < num; j++)
         {
-            return nameof(S16);
+            @out[outOffset + j] = (int)((uint)@in[inOffset] >> bits) & (int)((uint)0xffffffff >> (32 - S16_BITS[numIdx][j]));
+            bits += S16_BITS[numIdx][j];
         }
+        return num;
+    }
+
+    /**
+     * Uncompressed data from an input array into an output array
+     *
+     * @param in    input array (in compressed form)
+     * @param tmpinpos  starting location in the compressed input array
+     * @param inlength  how much data we wish the read (in 32-bit words)
+     * @param out       output array (in decompressed form)
+     * @param currentPos    current position in the output array
+     * @param outlength     available data in the output array
+     */
+    public static void uncompress(int[] @in, int tmpinpos, int inlength, int[] @out, int currentPos, int outlength)
+    {
+        int pos = tmpinpos + inlength;
+        while (tmpinpos < pos)
+        {
+            int howmany = decompressblock(@out, currentPos,
+               @in, tmpinpos, outlength);
+            outlength -= howmany;
+            currentPos += howmany;
+            tmpinpos += 1;
+        }
+    }
+
+    private static int[][] shiftme(int[][] x)
+    {
+        int[][] answer = new int[x.Length][];
+        for (int k = 0; k < x.Length; ++k)
+        {
+            answer[k] = new int[x[k].Length];
+            for (int z = 0; z < answer[k].Length; ++z)
+                answer[k][z] = 1 << x[k][z];
+        }
+        return answer;
+    }
+
+    private const int S16_NUMSIZE = 16;
+    private const int S16_BITSSIZE = 28;
+    // the possible number of bits used to represent one integer
+    private static int[] S16_NUM = { 28, 21, 21, 21, 14, 9, 8, 7, 6, 6, 5, 5, 4, 3, 2, 1 };
+    // the corresponding number of elements for each value of the number of
+    // bits
+    private static int[][] S16_BITS = {
+        new[]{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
+        new[]{ 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
+        new[]{ 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1 },
+        new[]{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2 },
+        new[]{ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
+        new[]{ 4, 3, 3, 3, 3, 3, 3, 3, 3 }, new[] { 3, 4, 4, 4, 4, 3, 3, 3 },
+        new[]{ 4, 4, 4, 4, 4, 4, 4 }, new[]{ 5, 5, 5, 5, 4, 4 },
+        new[]{ 4, 4, 5, 5, 5, 5 }, new[]{ 6, 6, 6, 5, 5 }, new[]{ 5, 5, 6, 6, 6 },
+        new[]{ 7, 7, 7, 7 }, new[]{ 10, 9, 9, }, new[]{ 14, 14 }, new[]{ 28 } };
+    private static int[][] SHIFTED_S16_BITS = shiftme(S16_BITS);
+
+    public override string ToString()
+    {
+        return nameof(S16);
     }
 }

--- a/src/CSharpFastPFOR/S16.cs
+++ b/src/CSharpFastPFOR/S16.cs
@@ -205,10 +205,10 @@ public class S16
     private const int S16_NUMSIZE = 16;
     private const int S16_BITSSIZE = 28;
     // the possible number of bits used to represent one integer
-    private static int[] S16_NUM = { 28, 21, 21, 21, 14, 9, 8, 7, 6, 6, 5, 5, 4, 3, 2, 1 };
+    private static readonly int[] S16_NUM = { 28, 21, 21, 21, 14, 9, 8, 7, 6, 6, 5, 5, 4, 3, 2, 1 };
     // the corresponding number of elements for each value of the number of
     // bits
-    private static int[][] S16_BITS = {
+    private static readonly int[][] S16_BITS = {
         new[]{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
         new[]{ 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
         new[]{ 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1 },
@@ -218,7 +218,7 @@ public class S16
         new[]{ 4, 4, 4, 4, 4, 4, 4 }, new[]{ 5, 5, 5, 5, 4, 4 },
         new[]{ 4, 4, 5, 5, 5, 5 }, new[]{ 6, 6, 6, 5, 5 }, new[]{ 5, 5, 6, 6, 6 },
         new[]{ 7, 7, 7, 7 }, new[]{ 10, 9, 9, }, new[]{ 14, 14 }, new[]{ 28 } };
-    private static int[][] SHIFTED_S16_BITS = shiftme(S16_BITS);
+    private static readonly int[][] SHIFTED_S16_BITS = shiftme(S16_BITS);
 
     public override string ToString()
     {

--- a/src/CSharpFastPFOR/S9.cs
+++ b/src/CSharpFastPFOR/S9.cs
@@ -231,9 +231,9 @@ public class S9
         }
     }
 
-    private static int[] bitLength = { 1, 2, 3, 4, 5, 7, 9, 14, 28 };
+    private static readonly int[] bitLength = { 1, 2, 3, 4, 5, 7, 9, 14, 28 };
 
-    private static int[] codeNum = { 28, 14, 9, 7, 5, 4, 3, 2, 1 };
+    private static readonly int[] codeNum = { 28, 14, 9, 7, 5, 4, 3, 2, 1 };
 
     public override string ToString()
     {

--- a/src/CSharpFastPFOR/S9.cs
+++ b/src/CSharpFastPFOR/S9.cs
@@ -15,229 +15,228 @@
 
 using System;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class S9
 {
-    public class S9
+    /**
+     * Estimate size of the compressed output.
+     * 
+     * @param in
+     *                array to compress
+     * @param currentPos
+     *                where to start reading
+     * @param inlength
+     *                how many integers to read
+     * @return estimated size of the output (in 32-bit integers)
+     */
+    public static int estimatecompress(int[] @in, int currentPos, int inlength)
     {
-        /**
-         * Estimate size of the compressed output.
-         * 
-         * @param in
-         *                array to compress
-         * @param currentPos
-         *                where to start reading
-         * @param inlength
-         *                how many integers to read
-         * @return estimated size of the output (in 32-bit integers)
-         */
-        public static int estimatecompress(int[] @in, int currentPos, int inlength)
+        int tmpoutpos = 0;
+        int finalpos = currentPos + inlength;
+    outer:
+        while (currentPos < finalpos)
         {
-            int tmpoutpos = 0;
-            int finalpos = currentPos + inlength;
-        outer:
-            while (currentPos < finalpos)
+            int selector = 0;
+        mainloop:
+            for (; selector < 8;)
             {
-                int selector = 0;
-            mainloop:
-                for (; selector < 8;)
-                {
 
-                    int compressedNum = codeNum[selector];
-                    if (finalpos <= currentPos + compressedNum - 1)
-                        compressedNum = finalpos - currentPos;
-                    int b = bitLength[selector];
-                    int max = 1 << b;
-                    int i = 0;
-                    for (; i < compressedNum; i++)
-                        if (max <= @in[currentPos + i])
-                        {
-                            selector++;
-                            goto mainloop;
-                        }
-                    currentPos += compressedNum;
-                    ++tmpoutpos;
-                    goto outer;
-                }
-                const int selector2 = 8;
-                if (@in[currentPos] >= 1 << bitLength[selector2])
-                    throw new Exception("Too big a number");
-                tmpoutpos++;
-                currentPos++;
-
-            }
-            return tmpoutpos;
-        }
-
-        /**
-         * Compress an integer array using Simple9
-         *
-         * 
-         * @param in
-         *                array to compress
-         * @param currentPos
-         *                where to start reading
-         * @param inlength
-         *                how many integers to read
-         * @param out   output array
-         * @param tmpoutpos location in the output array
-         * @return the number of 32-bit words written (in compressed form)
-         */
-        public static int compress(int[] @in, int currentPos, int inlength, int[] @out, int tmpoutpos)
-        {
-            int origtmpoutpos = tmpoutpos;
-            int finalpos = currentPos + inlength;
-
-        outer:
-            while (currentPos < finalpos)
-            {
-                int selector = 0;
-            mainloop:
-                for (; selector < 8;)
-                {
-                    int res = 0;
-                    int compressedNum = codeNum[selector];
-                    if (finalpos <= currentPos + compressedNum - 1)
-                        compressedNum = finalpos - currentPos;
-                    int b = bitLength[selector];
-                    int max = 1 << b;
-                    int i = 0;
-                    for (; i < compressedNum; i++)
+                int compressedNum = codeNum[selector];
+                if (finalpos <= currentPos + compressedNum - 1)
+                    compressedNum = finalpos - currentPos;
+                int b = bitLength[selector];
+                int max = 1 << b;
+                int i = 0;
+                for (; i < compressedNum; i++)
+                    if (max <= @in[currentPos + i])
                     {
-                        if (max <= @in[currentPos + i])
-                        {
-                            selector++;
-                            goto mainloop;
-                        }
-                        res = (res << b) + @in[currentPos + i];
+                        selector++;
+                        goto mainloop;
                     }
-                    if (compressedNum != codeNum[selector])
-                        res <<= (codeNum[selector] - compressedNum)
-                                * b;
-                    res |= selector << 28;
-                    @out[tmpoutpos++] = res;
-                    currentPos += compressedNum;
-                    goto outer;
-                }
-                const int selector2 = 8;
-                if (@in[currentPos] >= 1 << bitLength[selector2])
-                    throw new Exception("Too big a number");
-                @out[tmpoutpos++] = @in[currentPos++] | (selector2 << 28);
+                currentPos += compressedNum;
+                ++tmpoutpos;
+                goto outer;
             }
-            return tmpoutpos - origtmpoutpos;
+            const int selector2 = 8;
+            if (@in[currentPos] >= 1 << bitLength[selector2])
+                throw new Exception("Too big a number");
+            tmpoutpos++;
+            currentPos++;
+
         }
+        return tmpoutpos;
+    }
 
-        /**
-         * Uncompressed data from an input array into an output array
-         * 
-         * @param in    input array (in compressed form)
-         * @param tmpinpos  starting location in the compressed input array
-         * @param inlength  how much data we wish the read (in 32-bit words)
-         * @param out       output array (in decompressed form)
-         * @param currentPos    current position in the output array
-         * @param outlength     available data in the output array
-         */
-        public static void uncompress(int[] @in, int tmpinpos, int inlength, int[] @out, int currentPos, int outlength)
+    /**
+     * Compress an integer array using Simple9
+     *
+     * 
+     * @param in
+     *                array to compress
+     * @param currentPos
+     *                where to start reading
+     * @param inlength
+     *                how many integers to read
+     * @param out   output array
+     * @param tmpoutpos location in the output array
+     * @return the number of 32-bit words written (in compressed form)
+     */
+    public static int compress(int[] @in, int currentPos, int inlength, int[] @out, int tmpoutpos)
+    {
+        int origtmpoutpos = tmpoutpos;
+        int finalpos = currentPos + inlength;
+
+    outer:
+        while (currentPos < finalpos)
         {
-            int length = currentPos + outlength;
-
-            while (currentPos < length)
+            int selector = 0;
+        mainloop:
+            for (; selector < 8;)
             {
-                int val = @in[tmpinpos++];
-                int header = (int)((uint)val >> 28);
-                switch (header)
+                int res = 0;
+                int compressedNum = codeNum[selector];
+                if (finalpos <= currentPos + compressedNum - 1)
+                    compressedNum = finalpos - currentPos;
+                int b = bitLength[selector];
+                int max = 1 << b;
+                int i = 0;
+                for (; i < compressedNum; i++)
                 {
-                    case 0:
-                        { // number : 28, bitwidth : 1
-                            int howmany = length - currentPos < 28 ? length - currentPos : 28;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (k + 4)) >> 31);
-                            }
-                            break;
-                        }
-                    case 1:
-                        { // number : 14, bitwidth : 2
-                            int howmany = length - currentPos < 14 ? length - currentPos : 14;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (2 * k + 4)) >> 30);
-                            }
-                            break;
-                        }
-                    case 2:
-                        { // number : 9, bitwidth : 3
-                            int howmany = length - currentPos < 9 ? length - currentPos : 9;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (3 * k + 5)) >> 29);
-                            }
-                            break;
-                        }
-                    case 3:
-                        { // number : 7, bitwidth : 4
-                            int howmany = length - currentPos < 7 ? length - currentPos : 7;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (4 * k + 4)) >> 28);
-                            }
-                            break;
-                        }
-                    case 4:
-                        { // number : 5, bitwidth : 5
-                            int howmany = length - currentPos < 5 ? length - currentPos : 5;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (5 * k + 7)) >> 27);
-                            }
-                            break;
-                        }
-                    case 5:
-                        { // number : 4, bitwidth : 7
-                            int howmany = length - currentPos < 4 ? length - currentPos : 4;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (7 * k + 4)) >> 25);
-                            }
-                            break;
-                        }
-                    case 6:
-                        { // number : 3, bitwidth : 9
-                            int howmany = length - currentPos < 3 ? length - currentPos : 3;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (9 * k + 5)) >> 23);
-                            }
-                            break;
-                        }
-                    case 7:
-                        { // number : 2, bitwidth : 14
-                            int howmany = length - currentPos < 2 ? length - currentPos : 2;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (14 * k + 4)) >> 18);
-                            }
-                            break;
-                        }
-                    case 8:
-                        { // number : 1, bitwidth : 28
-                            @out[currentPos++] = (int)((uint)(val << 4) >> 4);
-                            break;
-                        }
-                    default:
-                        {
-                            throw new Exception("shouldn't happen");
-                        }
+                    if (max <= @in[currentPos + i])
+                    {
+                        selector++;
+                        goto mainloop;
+                    }
+                    res = (res << b) + @in[currentPos + i];
                 }
+                if (compressedNum != codeNum[selector])
+                    res <<= (codeNum[selector] - compressedNum)
+                            * b;
+                res |= selector << 28;
+                @out[tmpoutpos++] = res;
+                currentPos += compressedNum;
+                goto outer;
+            }
+            const int selector2 = 8;
+            if (@in[currentPos] >= 1 << bitLength[selector2])
+                throw new Exception("Too big a number");
+            @out[tmpoutpos++] = @in[currentPos++] | (selector2 << 28);
+        }
+        return tmpoutpos - origtmpoutpos;
+    }
+
+    /**
+     * Uncompressed data from an input array into an output array
+     * 
+     * @param in    input array (in compressed form)
+     * @param tmpinpos  starting location in the compressed input array
+     * @param inlength  how much data we wish the read (in 32-bit words)
+     * @param out       output array (in decompressed form)
+     * @param currentPos    current position in the output array
+     * @param outlength     available data in the output array
+     */
+    public static void uncompress(int[] @in, int tmpinpos, int inlength, int[] @out, int currentPos, int outlength)
+    {
+        int length = currentPos + outlength;
+
+        while (currentPos < length)
+        {
+            int val = @in[tmpinpos++];
+            int header = (int)((uint)val >> 28);
+            switch (header)
+            {
+                case 0:
+                    { // number : 28, bitwidth : 1
+                        int howmany = length - currentPos < 28 ? length - currentPos : 28;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (k + 4)) >> 31);
+                        }
+                        break;
+                    }
+                case 1:
+                    { // number : 14, bitwidth : 2
+                        int howmany = length - currentPos < 14 ? length - currentPos : 14;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (2 * k + 4)) >> 30);
+                        }
+                        break;
+                    }
+                case 2:
+                    { // number : 9, bitwidth : 3
+                        int howmany = length - currentPos < 9 ? length - currentPos : 9;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (3 * k + 5)) >> 29);
+                        }
+                        break;
+                    }
+                case 3:
+                    { // number : 7, bitwidth : 4
+                        int howmany = length - currentPos < 7 ? length - currentPos : 7;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (4 * k + 4)) >> 28);
+                        }
+                        break;
+                    }
+                case 4:
+                    { // number : 5, bitwidth : 5
+                        int howmany = length - currentPos < 5 ? length - currentPos : 5;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (5 * k + 7)) >> 27);
+                        }
+                        break;
+                    }
+                case 5:
+                    { // number : 4, bitwidth : 7
+                        int howmany = length - currentPos < 4 ? length - currentPos : 4;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (7 * k + 4)) >> 25);
+                        }
+                        break;
+                    }
+                case 6:
+                    { // number : 3, bitwidth : 9
+                        int howmany = length - currentPos < 3 ? length - currentPos : 3;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (9 * k + 5)) >> 23);
+                        }
+                        break;
+                    }
+                case 7:
+                    { // number : 2, bitwidth : 14
+                        int howmany = length - currentPos < 2 ? length - currentPos : 2;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (14 * k + 4)) >> 18);
+                        }
+                        break;
+                    }
+                case 8:
+                    { // number : 1, bitwidth : 28
+                        @out[currentPos++] = (int)((uint)(val << 4) >> 4);
+                        break;
+                    }
+                default:
+                    {
+                        throw new Exception("shouldn't happen");
+                    }
             }
         }
+    }
 
-        private static int[] bitLength = { 1, 2, 3, 4, 5, 7, 9, 14, 28 };
+    private static int[] bitLength = { 1, 2, 3, 4, 5, 7, 9, 14, 28 };
 
-        private static int[] codeNum = { 28, 14, 9, 7, 5, 4, 3, 2, 1 };
+    private static int[] codeNum = { 28, 14, 9, 7, 5, 4, 3, 2, 1 };
 
-        public override string ToString()
-        {
-            return nameof(S9);
-        }
+    public override string ToString()
+    {
+        return nameof(S9);
     }
 }

--- a/src/CSharpFastPFOR/Simple16.cs
+++ b/src/CSharpFastPFOR/Simple16.cs
@@ -188,9 +188,9 @@ public class Simple16 : IntegerCODEC, SkippableIntegerCODEC
     private const int S16_NUMSIZE = 16;
     private const int S16_BITSSIZE = 28;
     // the possible number of bits used to represent one integer
-    private static int[] S16_NUM = { 28, 21, 21, 21, 14, 9, 8, 7, 6, 6, 5, 5, 4, 3, 2, 1 };
+    private static readonly int[] S16_NUM = { 28, 21, 21, 21, 14, 9, 8, 7, 6, 6, 5, 5, 4, 3, 2, 1 };
     // the corresponding number of elements for each value of the number of bits
-    private static int[][] S16_BITS = {
+    private static readonly int[][] S16_BITS = {
         new[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,1, 1, 1, 1, 1, 1 },
         new[]{ 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
         new[]{ 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1 },
@@ -200,7 +200,7 @@ public class Simple16 : IntegerCODEC, SkippableIntegerCODEC
         new[]{ 4, 4, 4, 4, 4, 4, 4 },  new[]{ 5, 5, 5, 5, 4, 4 },
         new[]{ 4, 4, 5, 5, 5, 5 }, new[] { 6, 6, 6, 5, 5 }, new[] { 5, 5, 6, 6, 6 },
         new[]{ 7, 7, 7, 7 }, new[] { 10, 9, 9, },  new[]{ 14, 14 },  new[]{ 28 } };
-    private static int[][] SHIFTED_S16_BITS = shiftme(S16_BITS);
+    private static readonly int[][] SHIFTED_S16_BITS = shiftme(S16_BITS);
 
     public override string ToString()
     {

--- a/src/CSharpFastPFOR/Simple16.cs
+++ b/src/CSharpFastPFOR/Simple16.cs
@@ -187,8 +187,10 @@ public class Simple16 : IntegerCODEC, SkippableIntegerCODEC
 
     private const int S16_NUMSIZE = 16;
     private const int S16_BITSSIZE = 28;
+
     // the possible number of bits used to represent one integer
     private static readonly int[] S16_NUM = { 28, 21, 21, 21, 14, 9, 8, 7, 6, 6, 5, 5, 4, 3, 2, 1 };
+
     // the corresponding number of elements for each value of the number of bits
     private static readonly int[][] S16_BITS = {
         new[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,1, 1, 1, 1, 1, 1 },
@@ -199,7 +201,8 @@ public class Simple16 : IntegerCODEC, SkippableIntegerCODEC
         new[]{ 4, 3, 3, 3, 3, 3, 3, 3, 3 }, new[] { 3, 4, 4, 4, 4, 3, 3, 3 },
         new[]{ 4, 4, 4, 4, 4, 4, 4 },  new[]{ 5, 5, 5, 5, 4, 4 },
         new[]{ 4, 4, 5, 5, 5, 5 }, new[] { 6, 6, 6, 5, 5 }, new[] { 5, 5, 6, 6, 6 },
-        new[]{ 7, 7, 7, 7 }, new[] { 10, 9, 9, },  new[]{ 14, 14 },  new[]{ 28 } };
+        new[]{ 7, 7, 7, 7 }, new[] { 10, 9, 9, },  new[]{ 14, 14 }, new[]{ 28 } };
+
     private static readonly int[][] SHIFTED_S16_BITS = shiftme(S16_BITS);
 
     public override string ToString()

--- a/src/CSharpFastPFOR/Simple16.cs
+++ b/src/CSharpFastPFOR/Simple16.cs
@@ -17,194 +17,193 @@
 
 using System;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class Simple16 : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class Simple16 : IntegerCODEC, SkippableIntegerCODEC
+
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
     {
-
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+        int i_inpos = inpos.get();
+        int i_outpos = outpos.get();
+        int finalin = i_inpos + inlength;
+        while (i_inpos < finalin)
         {
-            int i_inpos = inpos.get();
-            int i_outpos = outpos.get();
-            int finalin = i_inpos + inlength;
-            while (i_inpos < finalin)
-            {
-                int inoffset = compressblock(@out, i_outpos++, @in, i_inpos, inlength);
-                if (inoffset == -1)
-                    throw new Exception("Too big a number");
-                i_inpos += inoffset;
-                inlength -= inoffset;
-            }
-            inpos.set(i_inpos);
-            outpos.set(i_outpos);
+            int inoffset = compressblock(@out, i_outpos++, @in, i_inpos, inlength);
+            if (inoffset == -1)
+                throw new Exception("Too big a number");
+            i_inpos += inoffset;
+            inlength -= inoffset;
         }
+        inpos.set(i_inpos);
+        outpos.set(i_outpos);
+    }
 
-        /**
-         * Compress an integer array using Simple16
-         * 
-         * @param out
-         *            the compressed output
-         * @param outOffset
-         *            the offset of the output in the number of integers
-         * @param in
-         *            the integer input array
-         * @param inOffset
-         *            the offset of the input in the number of integers
-         * @param n
-         *            the number of elements to be compressed
-         * @return the number of compressed integers
-         */
-        public static int compressblock(int[] @out, int outOffset, int[] @in, int inOffset, int n)
+    /**
+     * Compress an integer array using Simple16
+     * 
+     * @param out
+     *            the compressed output
+     * @param outOffset
+     *            the offset of the output in the number of integers
+     * @param in
+     *            the integer input array
+     * @param inOffset
+     *            the offset of the input in the number of integers
+     * @param n
+     *            the number of elements to be compressed
+     * @return the number of compressed integers
+     */
+    public static int compressblock(int[] @out, int outOffset, int[] @in, int inOffset, int n)
+    {
+        int numIdx, j, num, bits;
+        for (numIdx = 0; numIdx < S16_NUMSIZE; numIdx++)
         {
-            int numIdx, j, num, bits;
-            for (numIdx = 0; numIdx < S16_NUMSIZE; numIdx++)
+            @out[outOffset] = numIdx << S16_BITSSIZE;
+            num = (S16_NUM[numIdx] < n) ? S16_NUM[numIdx] : n;
+
+            for (j = 0, bits = 0; (j < num)
+                                  && (@in[inOffset + j] < SHIFTED_S16_BITS[numIdx][j]);)
             {
-                @out[outOffset] = numIdx << S16_BITSSIZE;
-                num = (S16_NUM[numIdx] < n) ? S16_NUM[numIdx] : n;
-
-                for (j = 0, bits = 0; (j < num)
-                                      && (@in[inOffset + j] < SHIFTED_S16_BITS[numIdx][j]);)
-                {
-                    @out[outOffset] |= (@in[inOffset + j] << bits);
-                    bits += S16_BITS[numIdx][j];
-                    j++;
-                }
-
-                if (j == num)
-                {
-                    return num;
-                }
-            }
-
-            return -1;
-        }
-
-        /**
-         * Decompress an integer array using Simple16
-         * 
-         * @param out
-         *            the decompressed output
-         * @param outOffset
-         *            the offset of the output in the number of integers
-         * @param in
-         *            the compressed input array
-         * @param inOffset
-         *            the offset of the input in the number of integers
-         * @param n
-         *            the number of elements to be compressed
-         * @return the number of processed integers
-         */
-        public static int decompressblock(int[] @out, int outOffset, int[] @in, int inOffset, int n)
-        {
-            int numIdx, j = 0, bits = 0;
-            numIdx = (int)((uint)@in[inOffset] >> S16_BITSSIZE);
-            int num = S16_NUM[numIdx] < n ? S16_NUM[numIdx] : n;
-            for (j = 0, bits = 0; j < num; j++)
-            {
-                @out[outOffset + j] = (int)((uint)@in[inOffset] >> bits) & (int)((uint)0xffffffff >> (32 - S16_BITS[numIdx][j]));
+                @out[outOffset] |= (@in[inOffset + j] << bits);
                 bits += S16_BITS[numIdx][j];
+                j++;
             }
-            return num;
-        }
 
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num)
-        {
-            int i_inpos = inpos.get();
-            int i_outpos = outpos.get();
-            while (num > 0)
+            if (j == num)
             {
-                int howmany = decompressblock(@out, i_outpos, @in, i_inpos, num);
-                num -= howmany;
-                i_outpos += howmany;
-                i_inpos++;
-            }
-            inpos.set(i_inpos);
-            outpos.set(i_outpos);
-        }
-
-        /**
-         * Uncompress data from an array to another array.
-         * 
-         * Both inpos and outpos parameters are modified to indicate new positions
-         * after read/write.
-         * 
-         * @param in
-         *            array containing data in compressed form
-         * @param tmpinpos
-         *            where to start reading in the array
-         * @param inlength
-         *            length of the compressed data (ignored by some schemes)
-         * @param out
-         *            array where to write the compressed output
-         * @param currentPos
-         *            where to write the compressed output in out
-         * @param outlength
-         *            number of integers we want to decode
-         */
-        public static void uncompress(int[] @in, int tmpinpos, int inlength, int[] @out, int currentPos, int outlength)
-        {
-            int pos = tmpinpos + inlength;
-            while (tmpinpos < pos)
-            {
-                int howmany = decompressblock(@out, currentPos, @in, tmpinpos,
-                   outlength);
-                outlength -= howmany;
-                currentPos += howmany;
-                tmpinpos += 1;
+                return num;
             }
         }
 
-        private static int[][] shiftme(int[][] x)
+        return -1;
+    }
+
+    /**
+     * Decompress an integer array using Simple16
+     * 
+     * @param out
+     *            the decompressed output
+     * @param outOffset
+     *            the offset of the output in the number of integers
+     * @param in
+     *            the compressed input array
+     * @param inOffset
+     *            the offset of the input in the number of integers
+     * @param n
+     *            the number of elements to be compressed
+     * @return the number of processed integers
+     */
+    public static int decompressblock(int[] @out, int outOffset, int[] @in, int inOffset, int n)
+    {
+        int numIdx, j = 0, bits = 0;
+        numIdx = (int)((uint)@in[inOffset] >> S16_BITSSIZE);
+        int num = S16_NUM[numIdx] < n ? S16_NUM[numIdx] : n;
+        for (j = 0, bits = 0; j < num; j++)
         {
-            int[][] answer = new int[x.Length][];
-            for (int k = 0; k < x.Length; ++k)
-            {
-                answer[k] = new int[x[k].Length];
-                for (int z = 0; z < answer[k].Length; ++z)
-                    answer[k][z] = 1 << x[k][z];
-            }
-            return answer;
+            @out[outOffset + j] = (int)((uint)@in[inOffset] >> bits) & (int)((uint)0xffffffff >> (32 - S16_BITS[numIdx][j]));
+            bits += S16_BITS[numIdx][j];
         }
+        return num;
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num)
+    {
+        int i_inpos = inpos.get();
+        int i_outpos = outpos.get();
+        while (num > 0)
         {
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos);
+            int howmany = decompressblock(@out, i_outpos, @in, i_inpos, num);
+            num -= howmany;
+            i_outpos += howmany;
+            i_inpos++;
         }
+        inpos.set(i_inpos);
+        outpos.set(i_outpos);
+    }
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    /**
+     * Uncompress data from an array to another array.
+     * 
+     * Both inpos and outpos parameters are modified to indicate new positions
+     * after read/write.
+     * 
+     * @param in
+     *            array containing data in compressed form
+     * @param tmpinpos
+     *            where to start reading in the array
+     * @param inlength
+     *            length of the compressed data (ignored by some schemes)
+     * @param out
+     *            array where to write the compressed output
+     * @param currentPos
+     *            where to write the compressed output in out
+     * @param outlength
+     *            number of integers we want to decode
+     */
+    public static void uncompress(int[] @in, int tmpinpos, int inlength, int[] @out, int currentPos, int outlength)
+    {
+        int pos = tmpinpos + inlength;
+        while (tmpinpos < pos)
         {
-            if (inlength == 0)
-                return;
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
-
+            int howmany = decompressblock(@out, currentPos, @in, tmpinpos,
+               outlength);
+            outlength -= howmany;
+            currentPos += howmany;
+            tmpinpos += 1;
         }
+    }
 
-        private const int S16_NUMSIZE = 16;
-        private const int S16_BITSSIZE = 28;
-        // the possible number of bits used to represent one integer
-        private static int[] S16_NUM = { 28, 21, 21, 21, 14, 9, 8, 7, 6, 6, 5, 5, 4, 3, 2, 1 };
-        // the corresponding number of elements for each value of the number of bits
-        private static int[][] S16_BITS = {
-            new[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,1, 1, 1, 1, 1, 1 },
-            new[]{ 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
-            new[]{ 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1 },
-            new[]{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2 },
-            new[]{ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
-            new[]{ 4, 3, 3, 3, 3, 3, 3, 3, 3 }, new[] { 3, 4, 4, 4, 4, 3, 3, 3 },
-            new[]{ 4, 4, 4, 4, 4, 4, 4 },  new[]{ 5, 5, 5, 5, 4, 4 },
-            new[]{ 4, 4, 5, 5, 5, 5 }, new[] { 6, 6, 6, 5, 5 }, new[] { 5, 5, 6, 6, 6 },
-            new[]{ 7, 7, 7, 7 }, new[] { 10, 9, 9, },  new[]{ 14, 14 },  new[]{ 28 } };
-        private static int[][] SHIFTED_S16_BITS = shiftme(S16_BITS);
-
-        public override string ToString()
+    private static int[][] shiftme(int[][] x)
+    {
+        int[][] answer = new int[x.Length][];
+        for (int k = 0; k < x.Length; ++k)
         {
-            return nameof(Simple16);
+            answer[k] = new int[x[k].Length];
+            for (int z = 0; z < answer[k].Length; ++z)
+                answer[k][z] = 1 << x[k][z];
         }
+        return answer;
+    }
+
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
+
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
+
+    }
+
+    private const int S16_NUMSIZE = 16;
+    private const int S16_BITSSIZE = 28;
+    // the possible number of bits used to represent one integer
+    private static int[] S16_NUM = { 28, 21, 21, 21, 14, 9, 8, 7, 6, 6, 5, 5, 4, 3, 2, 1 };
+    // the corresponding number of elements for each value of the number of bits
+    private static int[][] S16_BITS = {
+        new[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,1, 1, 1, 1, 1, 1 },
+        new[]{ 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
+        new[]{ 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1 },
+        new[]{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2 },
+        new[]{ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
+        new[]{ 4, 3, 3, 3, 3, 3, 3, 3, 3 }, new[] { 3, 4, 4, 4, 4, 3, 3, 3 },
+        new[]{ 4, 4, 4, 4, 4, 4, 4 },  new[]{ 5, 5, 5, 5, 4, 4 },
+        new[]{ 4, 4, 5, 5, 5, 5 }, new[] { 6, 6, 6, 5, 5 }, new[] { 5, 5, 6, 6, 6 },
+        new[]{ 7, 7, 7, 7 }, new[] { 10, 9, 9, },  new[]{ 14, 14 },  new[]{ 28 } };
+    private static int[][] SHIFTED_S16_BITS = shiftme(S16_BITS);
+
+    public override string ToString()
+    {
+        return nameof(Simple16);
     }
 }

--- a/src/CSharpFastPFOR/Simple9.cs
+++ b/src/CSharpFastPFOR/Simple9.cs
@@ -18,335 +18,334 @@
 
 using System;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class Simple9 : IntegerCODEC, SkippableIntegerCODEC
 {
-    public class Simple9 : IntegerCODEC, SkippableIntegerCODEC
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
     {
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            int tmpoutpos = outpos.get();
-            int currentPos = inpos.get();
-            int finalin = currentPos + inlength;
+        int tmpoutpos = outpos.get();
+        int currentPos = inpos.get();
+        int finalin = currentPos + inlength;
 
-        outer:
-            while (currentPos < finalin - 28)
+    outer:
+        while (currentPos < finalin - 28)
+        {
+            int selector = 0;
+        mainloop:
+            for (; selector < 8;)
             {
-                int selector = 0;
-            mainloop:
-                for (; selector < 8;)
+                int res = 0;
+                int compressedNum = codeNum[selector];
+                int b = bitLength[selector];
+                int max = 1 << b;
+                int i = 0;
+                for (; i < compressedNum; i++)
                 {
-                    int res = 0;
-                    int compressedNum = codeNum[selector];
-                    int b = bitLength[selector];
-                    int max = 1 << b;
-                    int i = 0;
-                    for (; i < compressedNum; i++)
+                    if (max <= @in[currentPos + i])
                     {
-                        if (max <= @in[currentPos + i])
-                        {
-                            selector++;
-                            goto mainloop;
-                        }
-                        res = (res << b) + @in[currentPos + i];
+                        selector++;
+                        goto mainloop;
                     }
-                    res |= selector << 28;
-                    @out[tmpoutpos++] = res;
-                    currentPos += compressedNum;
-                    goto outer;
+                    res = (res << b) + @in[currentPos + i];
                 }
-
-                const int selector2 = 8;
-                if (@in[currentPos] >= 1 << bitLength[selector2])
-                    throw new Exception("Too big a number");
-                @out[tmpoutpos++] = @in[currentPos++] | (selector2 << 28);
+                res |= selector << 28;
+                @out[tmpoutpos++] = res;
+                currentPos += compressedNum;
+                goto outer;
             }
 
-        outer2:
-            while (currentPos < finalin)
+            const int selector2 = 8;
+            if (@in[currentPos] >= 1 << bitLength[selector2])
+                throw new Exception("Too big a number");
+            @out[tmpoutpos++] = @in[currentPos++] | (selector2 << 28);
+        }
+
+    outer2:
+        while (currentPos < finalin)
+        {
+            int selector3 = 0;
+        mainloop:
+            for (; selector3 < 8;)
             {
-                int selector3 = 0;
-            mainloop:
-                for (; selector3 < 8;)
+                int res = 0;
+                int compressedNum = codeNum[selector3];
+                if (finalin <= currentPos + compressedNum - 1)
+                    compressedNum = finalin - currentPos;
+                int b = bitLength[selector3];
+                int max = 1 << b;
+                int i = 0;
+                for (; i < compressedNum; i++)
                 {
-                    int res = 0;
-                    int compressedNum = codeNum[selector3];
-                    if (finalin <= currentPos + compressedNum - 1)
-                        compressedNum = finalin - currentPos;
-                    int b = bitLength[selector3];
-                    int max = 1 << b;
-                    int i = 0;
-                    for (; i < compressedNum; i++)
+                    if (max <= @in[currentPos + i])
                     {
-                        if (max <= @in[currentPos + i])
-                        {
-                            selector3++;
-                            goto mainloop;
-                        }
-                        res = (res << b) + @in[currentPos + i];
+                        selector3++;
+                        goto mainloop;
                     }
-
-                    if (compressedNum != codeNum[selector3])
-                        res <<= (codeNum[selector3] - compressedNum)
-                                * b;
-                    res |= selector3 << 28;
-                    @out[tmpoutpos++] = res;
-                    currentPos += compressedNum;
-                    goto outer2;
+                    res = (res << b) + @in[currentPos + i];
                 }
 
-                const int selector4 = 8;
-                if (@in[currentPos] >= 1 << bitLength[selector4])
-                    throw new Exception("Too big a number");
-                @out[tmpoutpos++] = @in[currentPos++] | (selector4 << 28);
+                if (compressedNum != codeNum[selector3])
+                    res <<= (codeNum[selector3] - compressedNum)
+                            * b;
+                res |= selector3 << 28;
+                @out[tmpoutpos++] = res;
+                currentPos += compressedNum;
+                goto outer2;
             }
-            inpos.set(currentPos);
-            outpos.set(tmpoutpos);
-        }
 
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int outlength)
+            const int selector4 = 8;
+            if (@in[currentPos] >= 1 << bitLength[selector4])
+                throw new Exception("Too big a number");
+            @out[tmpoutpos++] = @in[currentPos++] | (selector4 << 28);
+        }
+        inpos.set(currentPos);
+        outpos.set(tmpoutpos);
+    }
+
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int outlength)
+    {
+        int currentPos = outpos.get();
+        int tmpinpos = inpos.get();
+        int finalout = currentPos + outlength;
+        while (currentPos < finalout - 28)
         {
-            int currentPos = outpos.get();
-            int tmpinpos = inpos.get();
-            int finalout = currentPos + outlength;
-            while (currentPos < finalout - 28)
+            int val = @in[tmpinpos++];
+            int header = (int)((uint)val >> 28);
+            switch (header)
             {
-                int val = @in[tmpinpos++];
-                int header = (int)((uint)val >> 28);
-                switch (header)
-                {
-                    case 0:
-                        { // number : 28, bitwidth : 1
-                            @out[currentPos++] = (int)((uint)(val << 4) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 5) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 6) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 7) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 8) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 9) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 10) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 11) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 12) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 13) >> 31); // 10
-                            @out[currentPos++] = (int)((uint)(val << 14) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 15) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 16) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 17) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 18) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 19) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 20) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 21) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 22) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 23) >> 31); // 20
-                            @out[currentPos++] = (int)((uint)(val << 24) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 25) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 26) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 27) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 28) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 29) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 30) >> 31);
-                            @out[currentPos++] = (int)((uint)(val << 31) >> 31);
-                            break;
-                        }
-                    case 1:
-                        { // number : 14, bitwidth : 2
-                            @out[currentPos++] = (int)((uint)(val << 4) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 6) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 8) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 10) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 12) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 14) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 16) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 18) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 20) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 22) >> 30); // 10
-                            @out[currentPos++] = (int)((uint)(val << 24) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 26) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 28) >> 30);
-                            @out[currentPos++] = (int)((uint)(val << 30) >> 30);
-                            break;
-                        }
-                    case 2:
-                        { // number : 9, bitwidth : 3
-                            @out[currentPos++] = (int)((uint)(val << 5) >> 29);
-                            @out[currentPos++] = (int)((uint)(val << 8) >> 29);
-                            @out[currentPos++] = (int)((uint)(val << 11) >> 29);
-                            @out[currentPos++] = (int)((uint)(val << 14) >> 29);
-                            @out[currentPos++] = (int)((uint)(val << 17) >> 29);
-                            @out[currentPos++] = (int)((uint)(val << 20) >> 29);
-                            @out[currentPos++] = (int)((uint)(val << 23) >> 29);
-                            @out[currentPos++] = (int)((uint)(val << 26) >> 29);
-                            @out[currentPos++] = (int)((uint)(val << 29) >> 29);
-                            break;
-                        }
-                    case 3:
-                        { // number : 7, bitwidth : 4
-                            @out[currentPos++] = (int)((uint)(val << 4) >> 28);
-                            @out[currentPos++] = (int)((uint)(val << 8) >> 28);
-                            @out[currentPos++] = (int)((uint)(val << 12) >> 28);
-                            @out[currentPos++] = (int)((uint)(val << 16) >> 28);
-                            @out[currentPos++] = (int)((uint)(val << 20) >> 28);
-                            @out[currentPos++] = (int)((uint)(val << 24) >> 28);
-                            @out[currentPos++] = (int)((uint)(val << 28) >> 28);
-                            break;
-                        }
-                    case 4:
-                        { // number : 5, bitwidth : 5
-                            @out[currentPos++] = (int)((uint)(val << 7) >> 27);
-                            @out[currentPos++] = (int)((uint)(val << 12) >> 27);
-                            @out[currentPos++] = (int)((uint)(val << 17) >> 27);
-                            @out[currentPos++] = (int)((uint)(val << 22) >> 27);
-                            @out[currentPos++] = (int)((uint)(val << 27) >> 27);
-                            break;
-                        }
-                    case 5:
-                        { // number : 4, bitwidth : 7
-                            @out[currentPos++] = (int)((uint)(val << 4) >> 25);
-                            @out[currentPos++] = (int)((uint)(val << 11) >> 25);
-                            @out[currentPos++] = (int)((uint)(val << 18) >> 25);
-                            @out[currentPos++] = (int)((uint)(val << 25) >> 25);
-                            break;
-                        }
-                    case 6:
-                        { // number : 3, bitwidth : 9
-                            @out[currentPos++] = (int)((uint)(val << 5) >> 23);
-                            @out[currentPos++] = (int)((uint)(val << 14) >> 23);
-                            @out[currentPos++] = (int)((uint)(val << 23) >> 23);
-                            break;
-                        }
-                    case 7:
-                        { // number : 2, bitwidth : 14
-                            @out[currentPos++] = (int)((uint)(val << 4) >> 18);
-                            @out[currentPos++] = (int)((uint)(val << 18) >> 18);
-                            break;
-                        }
-                    case 8:
-                        { // number : 1, bitwidth : 28
-                            @out[currentPos++] = (int)((uint)(val << 4) >> 4);
-                            break;
-                        }
-                    default:
-                        {
-                            throw new Exception("shouldn't happen: limited to 28-bit integers");
-                        }
-                }
+                case 0:
+                    { // number : 28, bitwidth : 1
+                        @out[currentPos++] = (int)((uint)(val << 4) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 5) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 6) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 7) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 8) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 9) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 10) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 11) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 12) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 13) >> 31); // 10
+                        @out[currentPos++] = (int)((uint)(val << 14) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 15) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 16) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 17) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 18) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 19) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 20) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 21) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 22) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 23) >> 31); // 20
+                        @out[currentPos++] = (int)((uint)(val << 24) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 25) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 26) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 27) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 28) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 29) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 30) >> 31);
+                        @out[currentPos++] = (int)((uint)(val << 31) >> 31);
+                        break;
+                    }
+                case 1:
+                    { // number : 14, bitwidth : 2
+                        @out[currentPos++] = (int)((uint)(val << 4) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 6) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 8) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 10) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 12) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 14) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 16) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 18) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 20) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 22) >> 30); // 10
+                        @out[currentPos++] = (int)((uint)(val << 24) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 26) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 28) >> 30);
+                        @out[currentPos++] = (int)((uint)(val << 30) >> 30);
+                        break;
+                    }
+                case 2:
+                    { // number : 9, bitwidth : 3
+                        @out[currentPos++] = (int)((uint)(val << 5) >> 29);
+                        @out[currentPos++] = (int)((uint)(val << 8) >> 29);
+                        @out[currentPos++] = (int)((uint)(val << 11) >> 29);
+                        @out[currentPos++] = (int)((uint)(val << 14) >> 29);
+                        @out[currentPos++] = (int)((uint)(val << 17) >> 29);
+                        @out[currentPos++] = (int)((uint)(val << 20) >> 29);
+                        @out[currentPos++] = (int)((uint)(val << 23) >> 29);
+                        @out[currentPos++] = (int)((uint)(val << 26) >> 29);
+                        @out[currentPos++] = (int)((uint)(val << 29) >> 29);
+                        break;
+                    }
+                case 3:
+                    { // number : 7, bitwidth : 4
+                        @out[currentPos++] = (int)((uint)(val << 4) >> 28);
+                        @out[currentPos++] = (int)((uint)(val << 8) >> 28);
+                        @out[currentPos++] = (int)((uint)(val << 12) >> 28);
+                        @out[currentPos++] = (int)((uint)(val << 16) >> 28);
+                        @out[currentPos++] = (int)((uint)(val << 20) >> 28);
+                        @out[currentPos++] = (int)((uint)(val << 24) >> 28);
+                        @out[currentPos++] = (int)((uint)(val << 28) >> 28);
+                        break;
+                    }
+                case 4:
+                    { // number : 5, bitwidth : 5
+                        @out[currentPos++] = (int)((uint)(val << 7) >> 27);
+                        @out[currentPos++] = (int)((uint)(val << 12) >> 27);
+                        @out[currentPos++] = (int)((uint)(val << 17) >> 27);
+                        @out[currentPos++] = (int)((uint)(val << 22) >> 27);
+                        @out[currentPos++] = (int)((uint)(val << 27) >> 27);
+                        break;
+                    }
+                case 5:
+                    { // number : 4, bitwidth : 7
+                        @out[currentPos++] = (int)((uint)(val << 4) >> 25);
+                        @out[currentPos++] = (int)((uint)(val << 11) >> 25);
+                        @out[currentPos++] = (int)((uint)(val << 18) >> 25);
+                        @out[currentPos++] = (int)((uint)(val << 25) >> 25);
+                        break;
+                    }
+                case 6:
+                    { // number : 3, bitwidth : 9
+                        @out[currentPos++] = (int)((uint)(val << 5) >> 23);
+                        @out[currentPos++] = (int)((uint)(val << 14) >> 23);
+                        @out[currentPos++] = (int)((uint)(val << 23) >> 23);
+                        break;
+                    }
+                case 7:
+                    { // number : 2, bitwidth : 14
+                        @out[currentPos++] = (int)((uint)(val << 4) >> 18);
+                        @out[currentPos++] = (int)((uint)(val << 18) >> 18);
+                        break;
+                    }
+                case 8:
+                    { // number : 1, bitwidth : 28
+                        @out[currentPos++] = (int)((uint)(val << 4) >> 4);
+                        break;
+                    }
+                default:
+                    {
+                        throw new Exception("shouldn't happen: limited to 28-bit integers");
+                    }
             }
-            while (currentPos < finalout)
+        }
+        while (currentPos < finalout)
+        {
+            int val = @in[tmpinpos++];
+            int header = (int)((uint)val >> 28);
+            switch (header)
             {
-                int val = @in[tmpinpos++];
-                int header = (int)((uint)val >> 28);
-                switch (header)
-                {
-                    case 0:
-                        { // number : 28, bitwidth : 1
-                            int howmany = finalout - currentPos;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (k + 4)) >> 31);
-                            }
-                            break;
-                        }
-                    case 1:
-                        { // number : 14, bitwidth : 2
-                            int howmany = finalout - currentPos < 14 ? finalout - currentPos : 14;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (2 * k + 4)) >> 30);
-                            }
-                            break;
-                        }
-                    case 2:
-                        { // number : 9, bitwidth : 3
-                            int howmany = finalout - currentPos < 9 ? finalout - currentPos : 9;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (3 * k + 5)) >> 29);
-                            }
-                            break;
-                        }
-                    case 3:
-                        { // number : 7, bitwidth : 4
-                            int howmany = finalout - currentPos < 7 ? finalout - currentPos : 7;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (4 * k + 4)) >> 28);
-                            }
-                            break;
-                        }
-                    case 4:
-                        { // number : 5, bitwidth : 5
-                            int howmany = finalout - currentPos < 5 ? finalout - currentPos : 5;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (5 * k + 7)) >> 27);
-                            }
-                            break;
-                        }
-                    case 5:
-                        { // number : 4, bitwidth : 7
-                            int howmany = finalout - currentPos < 4 ? finalout - currentPos : 4;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (7 * k + 4)) >> 25);
-                            }
-                            break;
-                        }
-                    case 6:
-                        { // number : 3, bitwidth : 9
-                            int howmany = finalout - currentPos < 3 ? finalout - currentPos : 3;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (9 * k + 5)) >> 23);
-                            }
-                            break;
-                        }
-                    case 7:
-                        { // number : 2, bitwidth : 14
-                            int howmany = finalout - currentPos < 2 ? finalout - currentPos : 2;
-                            for (int k = 0; k < howmany; ++k)
-                            {
-                                @out[currentPos++] = (int)((uint)(val << (14 * k + 4)) >> 18);
-                            }
-                            break;
-                        }
-                    case 8:
-                        { // number : 1, bitwidth : 28
-                            @out[currentPos++] = (int)((uint)(val << 4) >> 4);
-                            break;
-                        }
-                    default:
+                case 0:
+                    { // number : 28, bitwidth : 1
+                        int howmany = finalout - currentPos;
+                        for (int k = 0; k < howmany; ++k)
                         {
-                            throw new Exception("shouldn't happen");
+                            @out[currentPos++] = (int)((uint)(val << (k + 4)) >> 31);
                         }
-                }
+                        break;
+                    }
+                case 1:
+                    { // number : 14, bitwidth : 2
+                        int howmany = finalout - currentPos < 14 ? finalout - currentPos : 14;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (2 * k + 4)) >> 30);
+                        }
+                        break;
+                    }
+                case 2:
+                    { // number : 9, bitwidth : 3
+                        int howmany = finalout - currentPos < 9 ? finalout - currentPos : 9;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (3 * k + 5)) >> 29);
+                        }
+                        break;
+                    }
+                case 3:
+                    { // number : 7, bitwidth : 4
+                        int howmany = finalout - currentPos < 7 ? finalout - currentPos : 7;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (4 * k + 4)) >> 28);
+                        }
+                        break;
+                    }
+                case 4:
+                    { // number : 5, bitwidth : 5
+                        int howmany = finalout - currentPos < 5 ? finalout - currentPos : 5;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (5 * k + 7)) >> 27);
+                        }
+                        break;
+                    }
+                case 5:
+                    { // number : 4, bitwidth : 7
+                        int howmany = finalout - currentPos < 4 ? finalout - currentPos : 4;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (7 * k + 4)) >> 25);
+                        }
+                        break;
+                    }
+                case 6:
+                    { // number : 3, bitwidth : 9
+                        int howmany = finalout - currentPos < 3 ? finalout - currentPos : 3;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (9 * k + 5)) >> 23);
+                        }
+                        break;
+                    }
+                case 7:
+                    { // number : 2, bitwidth : 14
+                        int howmany = finalout - currentPos < 2 ? finalout - currentPos : 2;
+                        for (int k = 0; k < howmany; ++k)
+                        {
+                            @out[currentPos++] = (int)((uint)(val << (14 * k + 4)) >> 18);
+                        }
+                        break;
+                    }
+                case 8:
+                    { // number : 1, bitwidth : 28
+                        @out[currentPos++] = (int)((uint)(val << 4) >> 4);
+                        break;
+                    }
+                default:
+                    {
+                        throw new Exception("shouldn't happen");
+                    }
             }
-            outpos.set(currentPos);
-            inpos.set(tmpinpos);
         }
+        outpos.set(currentPos);
+        inpos.set(tmpinpos);
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            @out[outpos.get()] = inlength;
-            outpos.increment();
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        @out[outpos.get()] = inlength;
+        outpos.increment();
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            int outlength = @in[inpos.get()];
-            inpos.increment();
-            headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int outlength = @in[inpos.get()];
+        inpos.increment();
+        headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
 
-        }
-        private static int[] bitLength = { 1, 2, 3, 4, 5, 7, 9, 14, 28 };
+    }
+    private static int[] bitLength = { 1, 2, 3, 4, 5, 7, 9, 14, 28 };
 
-        private static int[] codeNum = { 28, 14, 9, 7, 5, 4, 3, 2, 1 };
+    private static int[] codeNum = { 28, 14, 9, 7, 5, 4, 3, 2, 1 };
 
-        public override string ToString()
-        {
-            return nameof(Simple9);
-        }
+    public override string ToString()
+    {
+        return nameof(Simple9);
     }
 }

--- a/src/CSharpFastPFOR/Simple9.cs
+++ b/src/CSharpFastPFOR/Simple9.cs
@@ -340,9 +340,9 @@ public class Simple9 : IntegerCODEC, SkippableIntegerCODEC
         headlessUncompress(@in, inpos, inlength, @out, outpos, outlength);
 
     }
-    private static int[] bitLength = { 1, 2, 3, 4, 5, 7, 9, 14, 28 };
+    private static readonly int[] bitLength = { 1, 2, 3, 4, 5, 7, 9, 14, 28 };
 
-    private static int[] codeNum = { 28, 14, 9, 7, 5, 4, 3, 2, 1 };
+    private static readonly int[] codeNum = { 28, 14, 9, 7, 5, 4, 3, 2, 1 };
 
     public override string ToString()
     {

--- a/src/CSharpFastPFOR/SkippableComposition.cs
+++ b/src/CSharpFastPFOR/SkippableComposition.cs
@@ -15,8 +15,8 @@ namespace Genbox.CSharpFastPFOR;
 
 public class SkippableComposition : SkippableIntegerCODEC
 {
-    private SkippableIntegerCODEC F1;
-    private SkippableIntegerCODEC F2;
+    private readonly SkippableIntegerCODEC F1;
+    private readonly SkippableIntegerCODEC F2;
 
     /**
      * Compose a scheme from a first one (f1) and a second one (f2). The first

--- a/src/CSharpFastPFOR/SkippableComposition.cs
+++ b/src/CSharpFastPFOR/SkippableComposition.cs
@@ -11,52 +11,51 @@
  * @author Daniel Lemire
  */
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class SkippableComposition : SkippableIntegerCODEC
 {
-    public class SkippableComposition : SkippableIntegerCODEC
+    private SkippableIntegerCODEC F1;
+    private SkippableIntegerCODEC F2;
+
+    /**
+     * Compose a scheme from a first one (f1) and a second one (f2). The first
+     * one is called first and then the second one tries to compress whatever
+     * remains from the first run.
+     * 
+     * By convention, the first scheme should be such that if, during decoding,
+     * a 32-bit zero is first encountered, then there is no output.
+     * 
+     * @param f1
+     *            first codec
+     * @param f2
+     *            second codec
+     */
+    public SkippableComposition(SkippableIntegerCODEC f1, SkippableIntegerCODEC f2)
     {
-        private SkippableIntegerCODEC F1;
-        private SkippableIntegerCODEC F2;
+        F1 = f1;
+        F2 = f2;
+    }
 
-        /**
-         * Compose a scheme from a first one (f1) and a second one (f2). The first
-         * one is called first and then the second one tries to compress whatever
-         * remains from the first run.
-         * 
-         * By convention, the first scheme should be such that if, during decoding,
-         * a 32-bit zero is first encountered, then there is no output.
-         * 
-         * @param f1
-         *            first codec
-         * @param f2
-         *            second codec
-         */
-        public SkippableComposition(SkippableIntegerCODEC f1, SkippableIntegerCODEC f2)
-        {
-            F1 = f1;
-            F2 = f2;
-        }
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        int init = inpos.get();
+        F1.headlessCompress(@in, inpos, inlength, @out, outpos);
+        inlength -= inpos.get() - init;
+        F2.headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            int init = inpos.get();
-            F1.headlessCompress(@in, inpos, inlength, @out, outpos);
-            inlength -= inpos.get() - init;
-            F2.headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num)
+    {
+        int init = inpos.get();
+        F1.headlessUncompress(@in, inpos, inlength, @out, outpos, num);
+        inlength -= inpos.get() - init;
+        num -= outpos.get();
+        F2.headlessUncompress(@in, inpos, inlength, @out, outpos, num);
+    }
 
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num)
-        {
-            int init = inpos.get();
-            F1.headlessUncompress(@in, inpos, inlength, @out, outpos, num);
-            inlength -= inpos.get() - init;
-            num -= outpos.get();
-            F2.headlessUncompress(@in, inpos, inlength, @out, outpos, num);
-        }
-
-        public override string ToString()
-        {
-            return F1 + "+" + F2;
-        }
+    public override string ToString()
+    {
+        return F1 + "+" + F2;
     }
 }

--- a/src/CSharpFastPFOR/SkippableIntegerCODEC.cs
+++ b/src/CSharpFastPFOR/SkippableIntegerCODEC.cs
@@ -17,50 +17,49 @@
  * @author Daniel Lemire
  * 
  */
-namespace Genbox.CSharpFastPFOR
-{
-    public interface SkippableIntegerCODEC
-    {
-        /**
-         * Compress data from an array to another array.
-         * 
-         * Both inpos and outpos are modified to represent how much data was read
-         * and written to if 12 ints (inlength = 12) are compressed to 3 ints, then
-         * inpos will be incremented by 12 while outpos will be incremented by 3 we
-         * use IntWrapper to pass the values by reference.
-         * 
-         * @param in
-         *            input array
-         * @param inpos
-         *            location in the input array
-         * @param inlength
-         *            how many integers to compress
-         * @param out
-         *            output array
-         * @param outpos
-         *            where to write in the output array
-         */
-        void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos);
+namespace Genbox.CSharpFastPFOR;
 
-        /**
-         * Uncompress data from an array to another array.
-         * 
-         * Both inpos and outpos parameters are modified to indicate new positions
-         * after read/write.
-         * 
-         * @param in
-         *            array containing data in compressed form
-         * @param inpos
-         *            where to start reading in the array
-         * @param inlength
-         *            length of the compressed data (ignored by some schemes)
-         * @param out
-         *            array where to write the compressed output
-         * @param outpos
-         *            where to write the compressed output in out
-         * @param num
-         *            number of integers we want to decode, the actual number of integers decoded can be less
-         */
-        void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num);
-    }
+public interface SkippableIntegerCODEC
+{
+    /**
+     * Compress data from an array to another array.
+     * 
+     * Both inpos and outpos are modified to represent how much data was read
+     * and written to if 12 ints (inlength = 12) are compressed to 3 ints, then
+     * inpos will be incremented by 12 while outpos will be incremented by 3 we
+     * use IntWrapper to pass the values by reference.
+     * 
+     * @param in
+     *            input array
+     * @param inpos
+     *            location in the input array
+     * @param inlength
+     *            how many integers to compress
+     * @param out
+     *            output array
+     * @param outpos
+     *            where to write in the output array
+     */
+    void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos);
+
+    /**
+     * Uncompress data from an array to another array.
+     * 
+     * Both inpos and outpos parameters are modified to indicate new positions
+     * after read/write.
+     * 
+     * @param in
+     *            array containing data in compressed form
+     * @param inpos
+     *            where to start reading in the array
+     * @param inlength
+     *            length of the compressed data (ignored by some schemes)
+     * @param out
+     *            array where to write the compressed output
+     * @param outpos
+     *            where to write the compressed output in out
+     * @param num
+     *            number of integers we want to decode, the actual number of integers decoded can be less
+     */
+    void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num);
 }

--- a/src/CSharpFastPFOR/Synth/ClusteredDataGenerator.cs
+++ b/src/CSharpFastPFOR/Synth/ClusteredDataGenerator.cs
@@ -19,7 +19,7 @@ namespace Genbox.CSharpFastPFOR.Synth;
 
 public class ClusteredDataGenerator
 {
-    private readonly UniformDataGenerator unidg = new UniformDataGenerator();
+    private readonly UniformDataGenerator unidg = new();
 
     /**
      * Creating random array generator.

--- a/src/CSharpFastPFOR/Synth/ClusteredDataGenerator.cs
+++ b/src/CSharpFastPFOR/Synth/ClusteredDataGenerator.cs
@@ -15,67 +15,66 @@
  * @author Daniel Lemire
  */
 
-namespace Genbox.CSharpFastPFOR.Synth
+namespace Genbox.CSharpFastPFOR.Synth;
+
+public class ClusteredDataGenerator
 {
-    public class ClusteredDataGenerator
+    private readonly UniformDataGenerator unidg = new UniformDataGenerator();
+
+    /**
+     * Creating random array generator.
+     */
+    public ClusteredDataGenerator()
     {
-        private readonly UniformDataGenerator unidg = new UniformDataGenerator();
+    }
 
-        /**
-         * Creating random array generator.
-         */
-        public ClusteredDataGenerator()
-        {
-        }
+    private void fillUniform(int[] array, int offset, int length, int Min, int Max)
+    {
+        int[] v = this.unidg.generateUniform(length, Max - Min);
+        for (int k = 0; k < v.Length; ++k)
+            array[k + offset] = Min + v[k];
+    }
 
-        private void fillUniform(int[] array, int offset, int length, int Min, int Max)
+    private void fillClustered(int[] array, int offset, int length, int Min, int Max)
+    {
+        int range = Max - Min;
+        if ((range == length) || (length <= 10))
         {
-            int[] v = this.unidg.generateUniform(length, Max - Min);
-            for (int k = 0; k < v.Length; ++k)
-                array[k + offset] = Min + v[k];
+            fillUniform(array, offset, length, Min, Max);
+            return;
         }
+        int cut = length / 2 + ((range - length - 1 > 0) ? this.unidg.rand.Next(range - length - 1) : 0);
+        double p = this.unidg.rand.NextDouble();
+        if (p < 0.25)
+        {
+            fillUniform(array, offset, length / 2, Min, Min + cut);
+            fillClustered(array, offset + length / 2, length - length / 2, Min + cut, Max);
+        }
+        else if (p < 0.5)
+        {
+            fillClustered(array, offset, length / 2, Min, Min + cut);
+            fillUniform(array, offset + length / 2, length - length / 2, Min + cut, Max);
+        }
+        else
+        {
+            fillClustered(array, offset, length / 2, Min, Min + cut);
+            fillClustered(array, offset + length / 2, length - length / 2, Min + cut, Max);
+        }
+    }
 
-        private void fillClustered(int[] array, int offset, int length, int Min, int Max)
-        {
-            int range = Max - Min;
-            if ((range == length) || (length <= 10))
-            {
-                fillUniform(array, offset, length, Min, Max);
-                return;
-            }
-            int cut = length / 2 + ((range - length - 1 > 0) ? this.unidg.rand.Next(range - length - 1) : 0);
-            double p = this.unidg.rand.NextDouble();
-            if (p < 0.25)
-            {
-                fillUniform(array, offset, length / 2, Min, Min + cut);
-                fillClustered(array, offset + length / 2, length - length / 2, Min + cut, Max);
-            }
-            else if (p < 0.5)
-            {
-                fillClustered(array, offset, length / 2, Min, Min + cut);
-                fillUniform(array, offset + length / 2, length - length / 2, Min + cut, Max);
-            }
-            else
-            {
-                fillClustered(array, offset, length / 2, Min, Min + cut);
-                fillClustered(array, offset + length / 2, length - length / 2, Min + cut, Max);
-            }
-        }
-
-        /**
-         * generates randomly N distinct integers from 0 to Max.
-         * 
-         * @param N
-         *                number of integers to generate
-         * @param Max
-         *                maximal value of the integers
-         * @return array containing the integers
-         */
-        public int[] generateClustered(int N, int Max)
-        {
-            int[] array = new int[N];
-            fillClustered(array, 0, N, 0, Max);
-            return array;
-        }
+    /**
+     * generates randomly N distinct integers from 0 to Max.
+     * 
+     * @param N
+     *                number of integers to generate
+     * @param Max
+     *                maximal value of the integers
+     * @return array containing the integers
+     */
+    public int[] generateClustered(int N, int Max)
+    {
+        int[] array = new int[N];
+        fillClustered(array, 0, N, 0, Max);
+        return array;
     }
 }

--- a/src/CSharpFastPFOR/Synth/UniformDataGenerator.cs
+++ b/src/CSharpFastPFOR/Synth/UniformDataGenerator.cs
@@ -15,121 +15,120 @@ using System;
 using System.Collections.Generic;
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR.Synth
+namespace Genbox.CSharpFastPFOR.Synth;
+
+public class UniformDataGenerator
 {
-    public class UniformDataGenerator
+    /**
+     * construct generator of random arrays.
+     */
+    public UniformDataGenerator()
     {
-        /**
-         * construct generator of random arrays.
-         */
-        public UniformDataGenerator()
-        {
-            this.rand = new Random();
-        }
-
-        /**
-         * @param seed
-         *                random seed
-         */
-        public UniformDataGenerator(int seed)
-        {
-            this.rand = new Random(seed);
-        }
-
-        /**
-         * generates randomly N distinct integers from 0 to Max.
-         */
-
-        private int[] generateUniformHash(int N, int Max)
-        {
-            if (N > Max)
-                throw new Exception("not possible");
-
-            int[] ans = new int[N];
-            HashSet<int> s = new HashSet<int>();
-            while (s.Count < N)
-                s.Add(rand.Next(Max));
-
-            //Iterator<Integer> i = s.iterator();
-            HashSet<int>.Enumerator i = s.GetEnumerator();
-
-            for (int k = 0; k < N; ++k)
-            {
-                ans[k] = i.Current;
-                i.MoveNext();
-            }
-
-            Arrays.sort(ans);
-            return ans;
-        }
-
-        /**
-         * output all integers from the range [0,Max) that are not in the array
-         */
-        private static int[] negate(int[] x, int Max)
-        {
-            int[] ans = new int[Max - x.Length];
-            int i = 0;
-            int c = 0;
-            for (int j = 0; j < x.Length; ++j)
-            {
-                int v = x[j];
-                for (; i < v; ++i)
-                    ans[c++] = i;
-                ++i;
-            }
-            while (c < ans.Length)
-                ans[c++] = i++;
-            return ans;
-        }
-
-        /**
-         * generates randomly N distinct integers from 0 to Max.
-         * 
-         * @param N
-         *                number of integers to generate
-         * @param Max
-         *                bound on the value of integers
-         * @return an array containing randomly selected integers
-         */
-        public int[] generateUniform(int N, int Max)
-        {
-            if (N * 2 > Max)
-            {
-                return negate(generateUniform(Max - N, Max), Max);
-            }
-            if (2048 * N > Max)
-                return generateUniformBitmap(N, Max);
-            return generateUniformHash(N, Max);
-        }
-
-        /**
-         * generates randomly N distinct integers from 0 to Max.
-         */
-        private int[] generateUniformBitmap(int N, int Max)
-        {
-            if (N > Max)
-                throw new Exception("not possible");
-            int[] ans = new int[N];
-            BitSet bs = new BitSet(Max);
-            int cardinality = 0;
-            while (cardinality < N)
-            {
-                int v = rand.Next(Max);
-                if (!bs.get(v))
-                {
-                    bs.set(v);
-                    cardinality++;
-                }
-            }
-            int pos = 0;
-            for (int i = bs.nextSetBit(0); i >= 0; i = bs.nextSetBit(i + 1))
-            {
-                ans[pos++] = i;
-            }
-            return ans;
-        }
-
-        public readonly Random rand = new Random();
+        this.rand = new Random();
     }
+
+    /**
+     * @param seed
+     *                random seed
+     */
+    public UniformDataGenerator(int seed)
+    {
+        this.rand = new Random(seed);
+    }
+
+    /**
+     * generates randomly N distinct integers from 0 to Max.
+     */
+
+    private int[] generateUniformHash(int N, int Max)
+    {
+        if (N > Max)
+            throw new Exception("not possible");
+
+        int[] ans = new int[N];
+        HashSet<int> s = new HashSet<int>();
+        while (s.Count < N)
+            s.Add(rand.Next(Max));
+
+        //Iterator<Integer> i = s.iterator();
+        HashSet<int>.Enumerator i = s.GetEnumerator();
+
+        for (int k = 0; k < N; ++k)
+        {
+            ans[k] = i.Current;
+            i.MoveNext();
+        }
+
+        Arrays.sort(ans);
+        return ans;
+    }
+
+    /**
+     * output all integers from the range [0,Max) that are not in the array
+     */
+    private static int[] negate(int[] x, int Max)
+    {
+        int[] ans = new int[Max - x.Length];
+        int i = 0;
+        int c = 0;
+        for (int j = 0; j < x.Length; ++j)
+        {
+            int v = x[j];
+            for (; i < v; ++i)
+                ans[c++] = i;
+            ++i;
+        }
+        while (c < ans.Length)
+            ans[c++] = i++;
+        return ans;
+    }
+
+    /**
+     * generates randomly N distinct integers from 0 to Max.
+     * 
+     * @param N
+     *                number of integers to generate
+     * @param Max
+     *                bound on the value of integers
+     * @return an array containing randomly selected integers
+     */
+    public int[] generateUniform(int N, int Max)
+    {
+        if (N * 2 > Max)
+        {
+            return negate(generateUniform(Max - N, Max), Max);
+        }
+        if (2048 * N > Max)
+            return generateUniformBitmap(N, Max);
+        return generateUniformHash(N, Max);
+    }
+
+    /**
+     * generates randomly N distinct integers from 0 to Max.
+     */
+    private int[] generateUniformBitmap(int N, int Max)
+    {
+        if (N > Max)
+            throw new Exception("not possible");
+        int[] ans = new int[N];
+        BitSet bs = new BitSet(Max);
+        int cardinality = 0;
+        while (cardinality < N)
+        {
+            int v = rand.Next(Max);
+            if (!bs.get(v))
+            {
+                bs.set(v);
+                cardinality++;
+            }
+        }
+        int pos = 0;
+        for (int i = bs.nextSetBit(0); i >= 0; i = bs.nextSetBit(i + 1))
+        {
+            ans[pos++] = i;
+        }
+        return ans;
+    }
+
+    public readonly Random rand = new Random();
 }

--- a/src/CSharpFastPFOR/Synth/UniformDataGenerator.cs
+++ b/src/CSharpFastPFOR/Synth/UniformDataGenerator.cs
@@ -45,8 +45,8 @@ public class UniformDataGenerator
         if (N > Max)
             throw new Exception("not possible");
 
-        int[] ans = new int[N];
-        HashSet<int> s = new HashSet<int>();
+        var ans = new int[N];
+        var s = new HashSet<int>();
         while (s.Count < N)
             s.Add(rand.Next(Max));
 
@@ -111,7 +111,7 @@ public class UniformDataGenerator
         if (N > Max)
             throw new Exception("not possible");
         int[] ans = new int[N];
-        BitSet bs = new BitSet(Max);
+        var bs = new BitSet(Max);
         int cardinality = 0;
         while (cardinality < N)
         {
@@ -130,5 +130,5 @@ public class UniformDataGenerator
         return ans;
     }
 
-    public readonly Random rand = new Random();
+    public readonly Random rand = new();
 }

--- a/src/CSharpFastPFOR/Util.cs
+++ b/src/CSharpFastPFOR/Util.cs
@@ -16,211 +16,210 @@
 using System;
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class Util
 {
-    public class Util
+    /**
+     * Compute the maximum of the integer logarithms (ceil(log(x+1)) of a range
+     * of value
+     * 
+     * @param i
+     *            source array
+     * @param pos
+     *            starting position
+     * @param length
+     *            number of integers to consider
+     * @return integer logarithm
+     */
+    public static int maxbits(int[] i, int pos, int length)
     {
-        /**
-         * Compute the maximum of the integer logarithms (ceil(log(x+1)) of a range
-         * of value
-         * 
-         * @param i
-         *            source array
-         * @param pos
-         *            starting position
-         * @param length
-         *            number of integers to consider
-         * @return integer logarithm
-         */
-        public static int maxbits(int[] i, int pos, int length)
-        {
-            int mask = 0;
-            for (int k = pos; k < pos + length; ++k)
-                mask |= i[k];
-            return bits(mask);
-        }
+        int mask = 0;
+        for (int k = pos; k < pos + length; ++k)
+            mask |= i[k];
+        return bits(mask);
+    }
 
-        public static int maxbits32(int[] i, int pos)
-        {
-            int mask = i[pos];
-            mask |= i[pos + 1];
-            mask |= i[pos + 2];
-            mask |= i[pos + 3];
-            mask |= i[pos + 4];
-            mask |= i[pos + 5];
-            mask |= i[pos + 6];
-            mask |= i[pos + 7];
-            mask |= i[pos + 8];
-            mask |= i[pos + 9];
-            mask |= i[pos + 10];
-            mask |= i[pos + 11];
-            mask |= i[pos + 12];
-            mask |= i[pos + 13];
-            mask |= i[pos + 14];
-            mask |= i[pos + 15];
-            mask |= i[pos + 16];
-            mask |= i[pos + 17];
-            mask |= i[pos + 18];
-            mask |= i[pos + 19];
-            mask |= i[pos + 20];
-            mask |= i[pos + 21];
-            mask |= i[pos + 22];
-            mask |= i[pos + 23];
-            mask |= i[pos + 24];
-            mask |= i[pos + 25];
-            mask |= i[pos + 26];
-            mask |= i[pos + 27];
-            mask |= i[pos + 28];
-            mask |= i[pos + 29];
-            mask |= i[pos + 30];
-            mask |= i[pos + 31];
-            return bits(mask);
-        }
+    public static int maxbits32(int[] i, int pos)
+    {
+        int mask = i[pos];
+        mask |= i[pos + 1];
+        mask |= i[pos + 2];
+        mask |= i[pos + 3];
+        mask |= i[pos + 4];
+        mask |= i[pos + 5];
+        mask |= i[pos + 6];
+        mask |= i[pos + 7];
+        mask |= i[pos + 8];
+        mask |= i[pos + 9];
+        mask |= i[pos + 10];
+        mask |= i[pos + 11];
+        mask |= i[pos + 12];
+        mask |= i[pos + 13];
+        mask |= i[pos + 14];
+        mask |= i[pos + 15];
+        mask |= i[pos + 16];
+        mask |= i[pos + 17];
+        mask |= i[pos + 18];
+        mask |= i[pos + 19];
+        mask |= i[pos + 20];
+        mask |= i[pos + 21];
+        mask |= i[pos + 22];
+        mask |= i[pos + 23];
+        mask |= i[pos + 24];
+        mask |= i[pos + 25];
+        mask |= i[pos + 26];
+        mask |= i[pos + 27];
+        mask |= i[pos + 28];
+        mask |= i[pos + 29];
+        mask |= i[pos + 30];
+        mask |= i[pos + 31];
+        return bits(mask);
+    }
 
-        /**
-         * Compute the maximum of the integer logarithms (ceil(log(x+1)) of a the
-         * successive differences (deltas) of a range of value
-         * 
-         * @param initoffset
-         *            initial vallue for the computation of the deltas
-         * @param i
-         *            source array
-         * @param pos
-         *            starting position
-         * @param length
-         *            number of integers to consider
-         * @return integer logarithm
-         */
-        public static int maxdiffbits(int initoffset, int[] i, int pos, int length)
+    /**
+     * Compute the maximum of the integer logarithms (ceil(log(x+1)) of a the
+     * successive differences (deltas) of a range of value
+     * 
+     * @param initoffset
+     *            initial vallue for the computation of the deltas
+     * @param i
+     *            source array
+     * @param pos
+     *            starting position
+     * @param length
+     *            number of integers to consider
+     * @return integer logarithm
+     */
+    public static int maxdiffbits(int initoffset, int[] i, int pos, int length)
+    {
+        int mask = 0;
+        mask |= (i[pos] - initoffset);
+        for (int k = pos + 1; k < pos + length; ++k)
         {
-            int mask = 0;
-            mask |= (i[pos] - initoffset);
-            for (int k = pos + 1; k < pos + length; ++k)
-            {
-                mask |= i[k] - i[k - 1];
-            }
-            return bits(mask);
+            mask |= i[k] - i[k - 1];
         }
+        return bits(mask);
+    }
 
-        /**
-         * Compute the integer logarithms (ceil(log(x+1)) of a value
-         * 
-         * @param i
-         *            source value
-         * @return integer logarithm
-         */
-        public static int bits(int i)
-        {
-            return 32 - Integer.numberOfLeadingZeros(i);
-        }
+    /**
+     * Compute the integer logarithms (ceil(log(x+1)) of a value
+     * 
+     * @param i
+     *            source value
+     * @return integer logarithm
+     */
+    public static int bits(int i)
+    {
+        return 32 - Integer.numberOfLeadingZeros(i);
+    }
 
-        public static int packsize(int num, int b)
-        {
-            if (b > 16)
-                return num;
-            int howmanyfit = 32 / b;
-            return (num + howmanyfit - 1) / howmanyfit;
-        }
-
-        public static int pack(int[] outputarray, int arraypos, int[] data, int datapos, int num, int b)
-        {
-            if (num == 0)
-                return arraypos;
-            if (b > 16)
-            {
-                Array.Copy(data, datapos, outputarray, arraypos, num);
-                return num + arraypos;
-            }
-            for (int k = 0; k < packsize(num, b); ++k)
-                outputarray[k + arraypos] = 0;
-            int inwordpointer = 0;
-            for (int k = 0; k < num; ++k)
-            {
-                outputarray[arraypos] |= (data[k + datapos] << inwordpointer);
-                inwordpointer += b;
-                int increment = ((inwordpointer + b - 1) >> 5);
-                arraypos += increment;
-                inwordpointer &= ~(-increment);
-            }
-            return arraypos + (inwordpointer > 0 ? 1 : 0);
-        }
-
-        public static int unpack(int[] sourcearray, int arraypos, int[] data, int datapos, int num, int b)
-        {
-            if (b > 16)
-            {
-                Array.Copy(sourcearray, arraypos, data, 0, num);
-                return num + arraypos;
-            }
-            int mask = (1 << b) - 1;
-            int inwordpointer = 0;
-            for (int k = 0; k < num; ++k)
-            {
-                data[k + datapos] = (int)(((uint)sourcearray[arraypos] >> inwordpointer) & mask);
-                inwordpointer += b;
-                int increment = ((inwordpointer + b - 1) >> 5);
-                arraypos += increment;
-                inwordpointer &= ~(-increment);
-            }
-            return arraypos + (inwordpointer > 0 ? 1 : 0);
-        }
-
-        public static int packsizew(int num, int b)
-        {
-            int howmanyfit = 32 / b;
-            if (num <= howmanyfit)
-                return 1;
+    public static int packsize(int num, int b)
+    {
+        if (b > 16)
             return num;
-        }
+        int howmanyfit = 32 / b;
+        return (num + howmanyfit - 1) / howmanyfit;
+    }
 
-        public static int packw(int[] outputarray, int arraypos, int[] data, int num, int b)
+    public static int pack(int[] outputarray, int arraypos, int[] data, int datapos, int num, int b)
+    {
+        if (num == 0)
+            return arraypos;
+        if (b > 16)
         {
-            int howmanyfit = 32 / b;
-            if (num > howmanyfit)
-            {
-                Array.Copy(data, 0, outputarray, arraypos, num);
-                return num + arraypos;
-            }
-            outputarray[arraypos] = 0;
-            int inwordpointer = 0;
-            for (int k = 0; k < num; ++k)
-            {
-                outputarray[arraypos] |= (data[k] << inwordpointer);
-                inwordpointer += b;
-            }
-            return arraypos + 1;
+            Array.Copy(data, datapos, outputarray, arraypos, num);
+            return num + arraypos;
         }
+        for (int k = 0; k < packsize(num, b); ++k)
+            outputarray[k + arraypos] = 0;
+        int inwordpointer = 0;
+        for (int k = 0; k < num; ++k)
+        {
+            outputarray[arraypos] |= (data[k + datapos] << inwordpointer);
+            inwordpointer += b;
+            int increment = ((inwordpointer + b - 1) >> 5);
+            arraypos += increment;
+            inwordpointer &= ~(-increment);
+        }
+        return arraypos + (inwordpointer > 0 ? 1 : 0);
+    }
 
-        public static int unpackw(int[] sourcearray, int arraypos, int[] data, int num, int b)
+    public static int unpack(int[] sourcearray, int arraypos, int[] data, int datapos, int num, int b)
+    {
+        if (b > 16)
         {
-            int howmanyfit = 32 / b;
-            if (num > howmanyfit)
-            {
-                Array.Copy(sourcearray, arraypos, data, 0, num);
-                return num + arraypos;
-            }
-            int mask = (1 << b) - 1;
-            int val = sourcearray[arraypos];
-            for (int k = 0; k < num; ++k)
-            {
-                data[k] = (val & mask);
-                val >>= b;
-            }
-            return arraypos + 1;
+            Array.Copy(sourcearray, arraypos, data, 0, num);
+            return num + arraypos;
         }
+        int mask = (1 << b) - 1;
+        int inwordpointer = 0;
+        for (int k = 0; k < num; ++k)
+        {
+            data[k + datapos] = (int)(((uint)sourcearray[arraypos] >> inwordpointer) & mask);
+            inwordpointer += b;
+            int increment = ((inwordpointer + b - 1) >> 5);
+            arraypos += increment;
+            inwordpointer &= ~(-increment);
+        }
+        return arraypos + (inwordpointer > 0 ? 1 : 0);
+    }
 
-        /**
-         * return floor(value / factor) * factor
-         * 
-         * @param value
-         *            numerator
-         * @param factor
-         *            denominator
-         * @return greatest multiple of factor no larger than value
-         */
-        public static int greatestMultiple(int value, int factor)
+    public static int packsizew(int num, int b)
+    {
+        int howmanyfit = 32 / b;
+        if (num <= howmanyfit)
+            return 1;
+        return num;
+    }
+
+    public static int packw(int[] outputarray, int arraypos, int[] data, int num, int b)
+    {
+        int howmanyfit = 32 / b;
+        if (num > howmanyfit)
         {
-            return value - value % factor;
+            Array.Copy(data, 0, outputarray, arraypos, num);
+            return num + arraypos;
         }
+        outputarray[arraypos] = 0;
+        int inwordpointer = 0;
+        for (int k = 0; k < num; ++k)
+        {
+            outputarray[arraypos] |= (data[k] << inwordpointer);
+            inwordpointer += b;
+        }
+        return arraypos + 1;
+    }
+
+    public static int unpackw(int[] sourcearray, int arraypos, int[] data, int num, int b)
+    {
+        int howmanyfit = 32 / b;
+        if (num > howmanyfit)
+        {
+            Array.Copy(sourcearray, arraypos, data, 0, num);
+            return num + arraypos;
+        }
+        int mask = (1 << b) - 1;
+        int val = sourcearray[arraypos];
+        for (int k = 0; k < num; ++k)
+        {
+            data[k] = (val & mask);
+            val >>= b;
+        }
+        return arraypos + 1;
+    }
+
+    /**
+     * return floor(value / factor) * factor
+     * 
+     * @param value
+     *            numerator
+     * @param factor
+     *            denominator
+     * @return greatest multiple of factor no larger than value
+     */
+    public static int greatestMultiple(int value, int factor)
+    {
+        return value - value % factor;
     }
 }

--- a/src/CSharpFastPFOR/VariableByte.cs
+++ b/src/CSharpFastPFOR/VariableByte.cs
@@ -19,7 +19,7 @@ using Genbox.CSharpFastPFOR.Port;
 
 namespace Genbox.CSharpFastPFOR;
 
-public class VariableByte : IntegerCODEC, ByteIntegerCODEC, SkippableIntegerCODEC
+public sealed class VariableByte : IntegerCODEC, ByteIntegerCODEC, SkippableIntegerCODEC
 {
     private static sbyte extract7bits(int i, long val)
     {

--- a/src/CSharpFastPFOR/VariableByte.cs
+++ b/src/CSharpFastPFOR/VariableByte.cs
@@ -17,217 +17,216 @@
 
 using Genbox.CSharpFastPFOR.Port;
 
-namespace Genbox.CSharpFastPFOR
+namespace Genbox.CSharpFastPFOR;
+
+public class VariableByte : IntegerCODEC, ByteIntegerCODEC, SkippableIntegerCODEC
 {
-    public class VariableByte : IntegerCODEC, ByteIntegerCODEC, SkippableIntegerCODEC
+    private static sbyte extract7bits(int i, long val)
     {
-        private static sbyte extract7bits(int i, long val)
-        {
-            return (sbyte)((val >> (7 * i)) & ((1 << 7) - 1));
-        }
+        return (sbyte)((val >> (7 * i)) & ((1 << 7) - 1));
+    }
 
-        private static sbyte extract7bitsmaskless(int i, long val)
-        {
-            return (sbyte)((val >> (7 * i)));
-        }
+    private static sbyte extract7bitsmaskless(int i, long val)
+    {
+        return (sbyte)((val >> (7 * i)));
+    }
 
-        public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            headlessCompress(@in, inpos, inlength, @out, outpos);
-        }
+    public void compress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        headlessCompress(@in, inpos, inlength, @out, outpos);
+    }
 
-        public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    public void headlessCompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        ByteBuffer buf = ByteBuffer.allocateDirect(inlength * 8);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+        for (int k = inpos.get(); k < inpos.get() + inlength; ++k)
         {
-            if (inlength == 0)
-                return;
-            ByteBuffer buf = ByteBuffer.allocateDirect(inlength * 8);
-            buf.order(ByteOrder.LITTLE_ENDIAN);
-            for (int k = inpos.get(); k < inpos.get() + inlength; ++k)
+            long val = @in[k] & 0xFFFFFFFFL; // To be consistent with
+            // unsigned integers in C/C++
+            if (val < (1 << 7))
             {
-                long val = @in[k] & 0xFFFFFFFFL; // To be consistent with
-                // unsigned integers in C/C++
-                if (val < (1 << 7))
-                {
-                    buf.put((sbyte)(val | (1 << 7)));
-                }
-                else if (val < (1 << 14))
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)(extract7bitsmaskless(1, (val)) | (1 << 7)));
-                }
-                else if (val < (1 << 21))
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)extract7bits(1, val));
-                    buf.put((sbyte)(extract7bitsmaskless(2, (val)) | (1 << 7)));
-                }
-                else if (val < (1 << 28))
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)extract7bits(1, val));
-                    buf.put((sbyte)extract7bits(2, val));
-                    buf.put((sbyte)(extract7bitsmaskless(3, (val)) | (1 << 7)));
-                }
-                else
-                {
-                    buf.put((sbyte)extract7bits(0, val));
-                    buf.put((sbyte)extract7bits(1, val));
-                    buf.put((sbyte)extract7bits(2, val));
-                    buf.put((sbyte)extract7bits(3, val));
-                    buf.put((sbyte)(extract7bitsmaskless(4, (val)) | (1 << 7)));
-                }
+                buf.put((sbyte)(val | (1 << 7)));
             }
-            while (buf.position() % 4 != 0)
-                buf.put((sbyte)0);
-            int length = buf.position();
-            buf.flip();
-            IntBuffer ibuf = buf.asIntBuffer();
-            ibuf.get(@out, outpos.get(), length / 4);
-            outpos.add(length / 4);
-            inpos.add(inlength);
-        }
-
-        public void compress(int[] @in, IntWrapper inpos, int inlength, sbyte[] @out, IntWrapper outpos)
-        {
-            if (inlength == 0)
-                return;
-            int outpostmp = outpos.get();
-            for (int k = inpos.get(); k < inpos.get() + inlength; ++k)
+            else if (val < (1 << 14))
             {
-                long val = @in[k] & 0xFFFFFFFFL; // To be consistent with
-                // unsigned integers in C/C++
-                if (val < (1 << 7))
-                {
-                    @out[outpostmp++] = (sbyte)(val | (1 << 7));
-                }
-                else if (val < (1 << 14))
-                {
-                    @out[outpostmp++] = (sbyte)extract7bits(0, val);
-                    @out[outpostmp++] = (sbyte)(extract7bitsmaskless(1, (val)) | (1 << 7));
-                }
-                else if (val < (1 << 21))
-                {
-                    @out[outpostmp++] = (sbyte)extract7bits(0, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(1, val);
-                    @out[outpostmp++] = (sbyte)(extract7bitsmaskless(2, (val)) | (1 << 7));
-                }
-                else if (val < (1 << 28))
-                {
-                    @out[outpostmp++] = (sbyte)extract7bits(0, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(1, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(2, val);
-                    @out[outpostmp++] = (sbyte)(extract7bitsmaskless(3, (val)) | (1 << 7));
-                }
-                else
-                {
-                    @out[outpostmp++] = (sbyte)extract7bits(0, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(1, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(2, val);
-                    @out[outpostmp++] = (sbyte)extract7bits(3, val);
-                    @out[outpostmp++] = (sbyte)(extract7bitsmaskless(4, (val)) | (1 << 7));
-                }
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)(extract7bitsmaskless(1, (val)) | (1 << 7)));
             }
-            outpos.set(outpostmp);
-            inpos.add(inlength);
-        }
-
-        public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            int s = 0;
-            int val = 0;
-            int p = inpos.get();
-            int finalp = inpos.get() + inlength;
-            int tmpoutpos = outpos.get();
-            for (int v = 0, shift = 0; p < finalp;)
+            else if (val < (1 << 21))
             {
-                val = @in[p];
-                int c = (sbyte)(int)((uint)val >> s);
-                s += 8;
-                p += s >> 5;
-                s = s & 31;
-                v += ((c & 127) << shift);
-                if ((c & 128) == 128)
-                {
-                    @out[tmpoutpos++] = v;
-                    v = 0;
-                    shift = 0;
-                }
-                else
-                    shift += 7;
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)extract7bits(1, val));
+                buf.put((sbyte)(extract7bitsmaskless(2, (val)) | (1 << 7)));
             }
-            outpos.set(tmpoutpos);
-            inpos.add(inlength);
-        }
-
-        public void uncompress(sbyte[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
-        {
-            int p = inpos.get();
-            int finalp = inpos.get() + inlength;
-            int tmpoutpos = outpos.get();
-            for (int v = 0; p < finalp; @out[tmpoutpos++] = v)
+            else if (val < (1 << 28))
             {
-                v = @in[p] & 0x7F;
-                if (@in[p] < 0)
-                {
-                    p += 1;
-                    continue;
-                }
-                v = ((@in[p + 1] & 0x7F) << 7) | v;
-                if (@in[p + 1] < 0)
-                {
-                    p += 2;
-                    continue;
-                }
-                v = ((@in[p + 2] & 0x7F) << 14) | v;
-                if (@in[p + 2] < 0)
-                {
-                    p += 3;
-                    continue;
-                }
-                v = ((@in[p + 3] & 0x7F) << 21) | v;
-                if (@in[p + 3] < 0)
-                {
-                    p += 4;
-                    continue;
-                }
-                v = ((@in[p + 4] & 0x7F) << 28) | v;
-                p += 5;
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)extract7bits(1, val));
+                buf.put((sbyte)extract7bits(2, val));
+                buf.put((sbyte)(extract7bitsmaskless(3, (val)) | (1 << 7)));
             }
-            outpos.set(tmpoutpos);
-            inpos.add(p);
-        }
-
-        public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num)
-        {
-            int s = 0;
-            int val = 0;
-            int p = inpos.get();
-            int tmpoutpos = outpos.get();
-            int finaloutpos = num + tmpoutpos;
-            for (int v = 0, shift = 0; tmpoutpos < finaloutpos;)
+            else
             {
-                val = @in[p];
-                int c = (int)((uint)val >> s);
-                s += 8;
-                p += s >> 5;
-                s = s & 31;
-                v += ((c & 127) << shift);
-                if ((c & 128) == 128)
-                {
-                    @out[tmpoutpos++] = v;
-                    v = 0;
-                    shift = 0;
-                }
-                else
-                    shift += 7;
+                buf.put((sbyte)extract7bits(0, val));
+                buf.put((sbyte)extract7bits(1, val));
+                buf.put((sbyte)extract7bits(2, val));
+                buf.put((sbyte)extract7bits(3, val));
+                buf.put((sbyte)(extract7bitsmaskless(4, (val)) | (1 << 7)));
             }
-            outpos.set(tmpoutpos);
-            inpos.set(p + (s != 0 ? 1 : 0));
         }
+        while (buf.position() % 4 != 0)
+            buf.put((sbyte)0);
+        int length = buf.position();
+        buf.flip();
+        IntBuffer ibuf = buf.asIntBuffer();
+        ibuf.get(@out, outpos.get(), length / 4);
+        outpos.add(length / 4);
+        inpos.add(inlength);
+    }
 
-        public override string ToString()
+    public void compress(int[] @in, IntWrapper inpos, int inlength, sbyte[] @out, IntWrapper outpos)
+    {
+        if (inlength == 0)
+            return;
+        int outpostmp = outpos.get();
+        for (int k = inpos.get(); k < inpos.get() + inlength; ++k)
         {
-            return nameof(VariableByte);
+            long val = @in[k] & 0xFFFFFFFFL; // To be consistent with
+            // unsigned integers in C/C++
+            if (val < (1 << 7))
+            {
+                @out[outpostmp++] = (sbyte)(val | (1 << 7));
+            }
+            else if (val < (1 << 14))
+            {
+                @out[outpostmp++] = (sbyte)extract7bits(0, val);
+                @out[outpostmp++] = (sbyte)(extract7bitsmaskless(1, (val)) | (1 << 7));
+            }
+            else if (val < (1 << 21))
+            {
+                @out[outpostmp++] = (sbyte)extract7bits(0, val);
+                @out[outpostmp++] = (sbyte)extract7bits(1, val);
+                @out[outpostmp++] = (sbyte)(extract7bitsmaskless(2, (val)) | (1 << 7));
+            }
+            else if (val < (1 << 28))
+            {
+                @out[outpostmp++] = (sbyte)extract7bits(0, val);
+                @out[outpostmp++] = (sbyte)extract7bits(1, val);
+                @out[outpostmp++] = (sbyte)extract7bits(2, val);
+                @out[outpostmp++] = (sbyte)(extract7bitsmaskless(3, (val)) | (1 << 7));
+            }
+            else
+            {
+                @out[outpostmp++] = (sbyte)extract7bits(0, val);
+                @out[outpostmp++] = (sbyte)extract7bits(1, val);
+                @out[outpostmp++] = (sbyte)extract7bits(2, val);
+                @out[outpostmp++] = (sbyte)extract7bits(3, val);
+                @out[outpostmp++] = (sbyte)(extract7bitsmaskless(4, (val)) | (1 << 7));
+            }
         }
+        outpos.set(outpostmp);
+        inpos.add(inlength);
+    }
+
+    public void uncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        int s = 0;
+        int val = 0;
+        int p = inpos.get();
+        int finalp = inpos.get() + inlength;
+        int tmpoutpos = outpos.get();
+        for (int v = 0, shift = 0; p < finalp;)
+        {
+            val = @in[p];
+            int c = (sbyte)(int)((uint)val >> s);
+            s += 8;
+            p += s >> 5;
+            s = s & 31;
+            v += ((c & 127) << shift);
+            if ((c & 128) == 128)
+            {
+                @out[tmpoutpos++] = v;
+                v = 0;
+                shift = 0;
+            }
+            else
+                shift += 7;
+        }
+        outpos.set(tmpoutpos);
+        inpos.add(inlength);
+    }
+
+    public void uncompress(sbyte[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos)
+    {
+        int p = inpos.get();
+        int finalp = inpos.get() + inlength;
+        int tmpoutpos = outpos.get();
+        for (int v = 0; p < finalp; @out[tmpoutpos++] = v)
+        {
+            v = @in[p] & 0x7F;
+            if (@in[p] < 0)
+            {
+                p += 1;
+                continue;
+            }
+            v = ((@in[p + 1] & 0x7F) << 7) | v;
+            if (@in[p + 1] < 0)
+            {
+                p += 2;
+                continue;
+            }
+            v = ((@in[p + 2] & 0x7F) << 14) | v;
+            if (@in[p + 2] < 0)
+            {
+                p += 3;
+                continue;
+            }
+            v = ((@in[p + 3] & 0x7F) << 21) | v;
+            if (@in[p + 3] < 0)
+            {
+                p += 4;
+                continue;
+            }
+            v = ((@in[p + 4] & 0x7F) << 28) | v;
+            p += 5;
+        }
+        outpos.set(tmpoutpos);
+        inpos.add(p);
+    }
+
+    public void headlessUncompress(int[] @in, IntWrapper inpos, int inlength, int[] @out, IntWrapper outpos, int num)
+    {
+        int s = 0;
+        int val = 0;
+        int p = inpos.get();
+        int tmpoutpos = outpos.get();
+        int finaloutpos = num + tmpoutpos;
+        for (int v = 0, shift = 0; tmpoutpos < finaloutpos;)
+        {
+            val = @in[p];
+            int c = (int)((uint)val >> s);
+            s += 8;
+            p += s >> 5;
+            s = s & 31;
+            v += ((c & 127) << shift);
+            if ((c & 128) == 128)
+            {
+                @out[tmpoutpos++] = v;
+                v = 0;
+                shift = 0;
+            }
+            else
+                shift += 7;
+        }
+        outpos.set(tmpoutpos);
+        inpos.set(p + (s != 0 ? 1 : 0));
+    }
+
+    public override string ToString()
+    {
+        return nameof(VariableByte);
     }
 }


### PR DESCRIPTION
This PR:

- uses file-scoped namespaces
- adds readonly to readonly fields
- seals classes that implement and interface
- uses var when the other side is the type name
- changes Interger to a struct

Excluding Integer -> struct change and sealing (preventing the user from subclassing to improve the ability for the JIT to devirtualize calls), all changes are focused on code readability. 
